### PR TITLE
fix: replace sortCriteria "order" with "direction" across all 26 templates

### DIFF
--- a/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
@@ -724,7 +724,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Anime/core-nexus-anime-4k.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k.json
@@ -773,7 +773,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Anime/core-nexus-anime-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-lite.json
@@ -706,7 +706,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Anime/core-nexus-anime.json
+++ b/Templates/Torbox/Anime/core-nexus-anime.json
@@ -755,7 +755,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -1157,7 +1157,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -1205,7 +1205,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -1057,7 +1057,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -1105,7 +1105,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -336,7 +336,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -288,44 +288,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -1067,7 +1067,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -1115,7 +1115,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Single/core-nexus-4k-pro-lite.json
+++ b/Templates/Torbox/Single/core-nexus-4k-pro-lite.json
@@ -1161,7 +1161,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Single/core-nexus-4k-pro.json
+++ b/Templates/Torbox/Single/core-nexus-4k-pro.json
@@ -1209,7 +1209,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -1064,7 +1064,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -1112,7 +1112,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus-lite.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus-lite.json
@@ -335,7 +335,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
@@ -335,7 +335,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews-lite.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews-lite.json
@@ -287,44 +287,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
@@ -287,44 +287,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-plus-lite.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-plus-lite.json
@@ -287,44 +287,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-plus.json
@@ -287,44 +287,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -336,7 +336,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -336,7 +336,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -288,44 +288,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -288,44 +288,43 @@
       "global": [
         {
           "key": "resolution",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "language",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "visualTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
           "key": "audioChannel",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "audioTag",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "streamExpressionScore",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "bitrate",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "quality",
-          "order": "desc"
+          "direction": "desc"
         },
         {
           "key": "regexScore",
-          "order": "desc"
+          "direction": "desc"
         }
       ],
       "movies": [


### PR DESCRIPTION
## Summary

- Replaced all `"order"` fields with `"direction"` in `sortCriteria.global` across every active template
- Flash and Speed templates used `"order"`-only entries throughout (9–10 entries each)
- All other templates (Single, Essential, Anime, Hybrid) had a redundant `"order"` alongside `"direction"` on the `encode` sort key specifically
- AIOStreams validator requires `"direction"` — `"order"` is rejected on import

**26 files changed** across: Single, Essential, Flash, Hybrid, Anime, Speed/TorBox, Speed/EasyNews

## Test plan

- [ ] Verify templates import cleanly into AIOStreams (no validator rejection)
- [ ] Confirm sort order behaviour is unchanged (all values remain `"desc"`)
- [ ] Run `validate_templates.py` — no sortCriteria errors expected

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_