### PR TITLE
fix: correct community template paths and contribution instructions

### DIFF
--- a/Community-Templates/Readme.md
+++ b/Community-Templates/Readme.md
@@ -12,6 +12,6 @@ These templates are provided "as-is." While they offer awesome alternative aesth
 ### 🛠️ How to Contribute
 Got a killer layout you want to share with the WuPlay ecosystem?
 1. **Fork** this repository.
-2. Add your `.json` file to this folder (`/Community-Builds`).
+2. Add your `.json` file to this folder (`/Community-Templates`).
 3. Open a **Pull Request**! Please include a screenshot of what your formatter looks like on-screen in the PR description so users can see your design before downloading.
 4. 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japa
 
 | Template | Author | Plan | Import |
 |---|---|---|---|
-| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/prism-torbox-essential-1080p.json) | MightyIcyy | Essential | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/prism-torbox-essential-1080p.json) |
+| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) | MightyIcyy | Essential | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) |
 | [RB3 TorBox Pro + RD Hybrid](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) | RB3 | TorBox Pro + RD | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) · [README](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/RB3/RB3%20Hybrid/Readme.md) |
 
 > Want your template listed? Open a PR to `Community-Templates/` with your JSON and a README.


### PR DESCRIPTION
- README: MightyIcyy link pointed to `Community-Templates/` root instead of `Community-Templates/Templates/MightyIcyy/`
- Community-Templates/Readme.md: contribution path said `/Community-Builds`, corrected to `/Community-Templates`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_