### PR TITLE
fix: correct broken formatter and community template file paths

### DIFF
--- a/Community-Templates/Readme.md
+++ b/Community-Templates/Readme.md
@@ -12,6 +12,6 @@ These templates are provided "as-is." While they offer awesome alternative aesth
 ### 🛠️ How to Contribute
 Got a killer layout you want to share with the WuPlay ecosystem?
 1. **Fork** this repository.
-2. Add your `.json` file to this folder (`/Community-Builds`).
+2. Add your `.json` file to this folder (`/Community-Templates`).
 3. Open a **Pull Request**! Please include a screenshot of what your formatter looks like on-screen in the PR description so users can see your design before downloading.
 4. 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 | **Core Nexus Elite** | All 14 Core Nexus templates | [↓ Download](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/Core%20Nexus%20Elite%20Formatter.json) |
 | **Core Nexus TV** | Stand-alone · all templates | [↓ Download](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/Core%20Nexus%20TV%20Formatter.json) |
 | **Core Syntax V3** | Core Cipher personal build | [↓ Download](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/Core_Syntax_V3.json) |
-| **Core Nexus Uniform** | Legacy — replaced by Core Nexus Elite | [↓ Download](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/Core_Nexus_Uniform_Formatter.json) |
+| **Core Nexus Uniform** | Legacy — replaced by Core Nexus Elite | [↓ Download](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/Core%20Nexus%20Uniform%20Formatter.json) |
 
 > 📁 [**Browse all formatters →**](https://github.com/brevityA/Core-Builds/tree/main/Formatters)
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japa
 
 | Template | Author | Plan | Import |
 |---|---|---|---|
-| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/prism-torbox-essential-1080p.json) | MightyIcyy | Essential | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/prism-torbox-essential-1080p.json) |
+| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) | MightyIcyy | Essential | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) |
 | [RB3 TorBox Pro + RD Hybrid](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) | RB3 | TorBox Pro + RD | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) · [README](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/RB3/RB3%20Hybrid/Readme.md) |
 
 > Want your template listed? Open a PR to `Community-Templates/` with your JSON and a README.

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -248,7 +248,7 @@ Every standard template has a `-lite` variant. Lite removes 12 quality-gate ESEs
 
 | Template | Author | Import |
 |---|---|---|
-| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/prism-torbox-essential-1080p.json) | MightyIcyy | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/prism-torbox-essential-1080p.json) |
+| [Prism TorBox Essential 1080p](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) | MightyIcyy | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json) |
 | [RB3 TorBox Pro + RD Hybrid](https://github.com/brevityA/Core-Builds/blob/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) | RB3 | [↓ JSON](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/RB3/RB3%20Hybrid/RB3%20TorBox%20Pro%20%2B%20RD%20Hybrid.json) |
 
 > Want your template listed? Open a PR to `Community-Templates/` with your JSON and a README.


### PR DESCRIPTION
File debug found two broken links:

- `README.md`: `Core_Nexus_Uniform_Formatter.json` → URL-encoded `Core%20Nexus%20Uniform%20Formatter.json` (file uses spaces not underscores)
- `Templates/Torbox/README.md`: MightyIcyy path was still pointing to `Community-Templates/` root — corrected to `Community-Templates/Templates/MightyIcyy/`

All referenced file paths now verified clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_