### PR TITLE
feat(flash): promote 720p to proper S/A/B quality tier

### DIFF
--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -1415,11 +1415,15 @@
         "enabled": true
       },
       {
-        "expression": "/* CB 720p Fallback | WEB-DL */ resolution(quality(streams, 'WEB-DL', 'WEBRip'), '720p')",
+        "expression": "/* CB S-Tier 720p | WEB-DL */ resolution(quality(streams, 'WEB-DL'), '720p')",
         "enabled": true
       },
       {
-        "expression": "/* CB 720p Fallback | Any */ resolution(streams, '720p')",
+        "expression": "/* CB A-Tier 720p | WEBRip or BluRay */ resolution(quality(streams, 'WEBRip', 'BluRay'), '720p')",
+        "enabled": true
+      },
+      {
+        "expression": "/* CB B-Tier 720p | Any 720p */ resolution(streams, '720p')",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -1363,11 +1363,15 @@
         "enabled": true
       },
       {
-        "expression": "/* CB 720p Fallback | WEB-DL */ resolution(quality(streams, 'WEB-DL', 'WEBRip'), '720p')",
+        "expression": "/* CB S-Tier 720p | WEB-DL */ resolution(quality(streams, 'WEB-DL'), '720p')",
         "enabled": true
       },
       {
-        "expression": "/* CB 720p Fallback | Any */ resolution(streams, '720p')",
+        "expression": "/* CB A-Tier 720p | WEBRip or BluRay */ resolution(quality(streams, 'WEBRip', 'BluRay'), '720p')",
+        "enabled": true
+      },
+      {
+        "expression": "/* CB B-Tier 720p | Any 720p */ resolution(streams, '720p')",
         "enabled": true
       }
     ],


### PR DESCRIPTION
## Summary

- Promotes 720p from two unlabelled "Fallback" PSE entries to a full three-tier structure in both Flash templates
- Matches the S/A/B/C tier layout already used for 4K and 1080p

## Before

```
/* CB 720p Fallback | WEB-DL */  resolution(quality(streams, 'WEB-DL', 'WEBRip'), '720p')
/* CB 720p Fallback | Any */     resolution(streams, '720p')
```

## After

```
/* CB S-Tier 720p | WEB-DL */         resolution(quality(streams, 'WEB-DL'), '720p')
/* CB A-Tier 720p | WEBRip or BluRay */ resolution(quality(streams, 'WEBRip', 'BluRay'), '720p')
/* CB B-Tier 720p | Any 720p */        resolution(streams, '720p')
```

## Files Changed

- `Templates/Torbox/Flash/core-nexus-flash.json`
- `Templates/Torbox/Flash/core-nexus-flash-4k.json`

## Test plan

- [x] `python3 validate_templates.py` — 0 errors, 0 warnings on both files
- [ ] Import Flash template and confirm 720p cached streams surface and sort correctly below 1080p results

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_