### PR TITLE
docs: add Anime Dub templates to README and Torbox README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ EasyNews only (no TorBox)? → Speed EasyNews
 
 Watching anime?
 ├── Want 4K HDR? → Anime 4K
-└── Standard 1080p? → Anime
+├── Standard 1080p? → Anime
+└── Prefer English dubs? → Anime Dub
 
 Getting too few results / low-overhead host? → use the Lite variant of any template above
 ```
@@ -126,8 +127,9 @@ Getting too few results / low-overhead host? → use the Lite variant of any tem
 |---|---|---|
 | **Core Nexus Anime** | 1080p + 4K | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json` |
 | **Core Nexus Anime 4K** | 4K + 1080p fallback | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json` |
+| **Core Nexus Anime Dub** | 1080p · Dubbed-first | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub.json` |
 
-SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japanese + English + Dual Audio
+SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japanese + English + Dual Audio · Anime Dub prioritises English dubs and Dual Audio
 
 ---
 
@@ -149,6 +151,7 @@ SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japa
 | **Speed Lite** | Speed | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json` |
 | **Anime Lite** | Anime | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-lite.json` |
 | **Anime 4K Lite** | Anime 4K | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json` |
+| **Anime Dub Lite** | Anime Dub | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json` |
 
 ---
 

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -30,7 +30,8 @@ EasyNews only (no TorBox)? → Speed EasyNews
 
 Anime?
 ├── Want 4K HDR? → Anime 4K
-└── Standard 1080p? → Anime
+├── Standard 1080p? → Anime
+└── Prefer English dubs? → Anime Dub
 
 Getting too few results / low-overhead host? → use the Lite variant of any template above
 ```
@@ -174,13 +175,14 @@ Full 4K for Essential plan. No Usenet.
 
 SeaDex best-release enforcement · AnimeTosho (Nyaa.si mirror) · FLAC/AAC first · Japanese + English + Dual Audio.
 
-| | Anime | Anime 4K |
-|---|---|---|
-| **File** | `core-nexus-anime.json` | `core-nexus-anime-4k.json` |
-| **Resolution** | 1080p primary · 720p fallback | 2160p primary · 1080p fallback |
-| **Visual priority** | SDR-first | DV → HDR10+ → HDR |
-| **Audio priority** | FLAC → AAC | Atmos → TrueHD → FLAC |
-| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json` | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json` |
+| | Anime | Anime 4K | Anime Dub |
+|---|---|---|---|
+| **File** | `core-nexus-anime.json` | `core-nexus-anime-4k.json` | `core-nexus-anime-dub.json` |
+| **Resolution** | 1080p primary · 720p fallback | 2160p primary · 1080p fallback | 1080p primary · 720p fallback |
+| **Language priority** | Japanese → Dual Audio → English | Japanese → Dual Audio → English | Dubbed → Dual Audio → English → Japanese |
+| **Visual priority** | SDR-first | DV → HDR10+ → HDR | SDR-first |
+| **Audio priority** | FLAC → AAC | Atmos → TrueHD → FLAC | FLAC → AAC |
+| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json` | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json` | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub.json` |
 
 ---
 
@@ -223,6 +225,7 @@ Every standard template has a `-lite` variant. Lite removes 12 quality-gate ESEs
 | **Speed Lite** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json` |
 | **Anime Lite** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-lite.json` |
 | **Anime 4K Lite** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json` |
+| **Anime Dub Lite** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json` |
 
 ---
 


### PR DESCRIPTION
## Summary

README updates following the Anime Dub template additions in PR #20.

## Changes

**`README.md`**
- Decision tree: added `└── Prefer English dubs? → Anime Dub` branch under Watching anime?
- Anime section: added Core Nexus Anime Dub row with import URL
- Lite table: added Anime Dub Lite row with import URL

**`Templates/Torbox/README.md`**
- Decision tree: added Anime Dub branch
- Anime comparison table: expanded to 3 columns (Anime / Anime 4K / Anime Dub) with Language priority row added
- Lite table: added Anime Dub Lite row

## Test plan

- [x] All import URLs point to correct raw.githubusercontent.com paths
- [x] No broken links or table formatting issues

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_