### PR TITLE
fix: correct addonName in Flash and Flash 4K templates

### DIFF
--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -1098,7 +1098,7 @@
     "checkOwned": false,
     "trusted": false,
     "showChanges": true,
-    "addonName": "Core Nexus Speed 4K",
+    "addonName": "Core Nexus Flash 4K",
     "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/main/Assets/core_icon.svg",
     "addonDescription": "Speed 4K — TorBox Essential. Shows CACHED streams only for instant play. Zero results = content not yet in TorBox cache. Try a popular title first.",
     "appliedTemplates": [

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -1070,7 +1070,7 @@
     "checkOwned": false,
     "trusted": false,
     "showChanges": true,
-    "addonName": "Core Nexus Speed",
+    "addonName": "Core Nexus Flash",
     "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/main/Assets/core_icon.svg",
     "addonDescription": "Speed 1080p — TorBox Essential. Shows CACHED streams only for instant play. Zero results = content not yet in TorBox cache. Try a popular title first.",
     "appliedTemplates": [


### PR DESCRIPTION
Both Flash templates inherited addonName from their Speed parent when they were derived — Flash showed "Core Nexus Speed" and Flash 4K showed "Core Nexus Speed 4K". Updated to "Core Nexus Flash" and "Core Nexus Flash 4K" respectively so the in-app label matches the template identity.

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

## Description
<!-- What does this PR change and why? -->

## Type of Change
- [ ] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [ ] Documentation update
- [ ] Workflow / infrastructure

## Template Checklist
<!-- If this PR modifies or adds a template JSON, complete this -->
- [ ] JSON is valid (passes `validate.yml`)
- [ ] `instanceId` present on all presets
- [ ] `timeout` set in all preset `options`
- [ ] `formatter.id` is `"tamtaro"` (or `"custom"` for community formatters)
- [ ] No `not()` — use `negate()` instead
- [ ] No `or()` / `keyword()` / `language()` in stream expressions
- [ ] `preferredResolutions` matches `includedResolutions` exactly
- [ ] Usenet settings (`cacheAndPlay`, `nzbFailover`) correct for plan tier
- [ ] `addonName` and `meta.id` are unique and correct
- [ ] Version bumped in `metadata.version`

## Testing
<!-- How did you test this? Which instance/plan was used? -->
- AIOStreams instance: 
- TorBox plan: 
- Content tested on: 

## Related Issues
<!-- Closes # -->
