### PR TITLE
fix: correct action version pins, auto-responder keywords, and release packaging

### DIFF
--- a/.github/workflows/auto-responder.yml
+++ b/.github/workflows/auto-responder.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Respond to deprecated / known-issue reports
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issueBody = context.payload.issue.body
@@ -20,11 +20,13 @@ jobs:
             const issueTitle = context.payload.issue.title.toLowerCase();
             const text = issueTitle + ' ' + issueBody;
 
-            // ── Deprecated Dual Core / Real-Debrid ──────────────────────────
+            // ── Deprecated Dual Core templates (specific names only) ─────────
+            // Note: generic 'real-debrid' terms are intentionally excluded here —
+            // the Hybrid templates are active TorBox+RD builds, not deprecated.
             const deprecatedKeywords = [
-              'dual core', 'dual-core', 'real-debrid', 'realdebrid',
-              'rd hybrid', 'invalid character', 'proxy error',
-              'core-nexus-rd', 'torbox + rd', 'torbox+rd'
+              'dual core', 'dual-core',
+              'core-nexus-rd', 'torbox + rd', 'torbox+rd',
+              'invalid character', 'proxy error'
             ];
             if (deprecatedKeywords.some(k => text.includes(k))) {
               await github.rest.issues.createComment({
@@ -34,15 +36,15 @@ jobs:
                 body: [
                   '👋 Hey there!',
                   '',
-                  'It looks like you\'re asking about the **Dual Core** (TorBox + Real-Debrid) templates or hitting the "Invalid character" proxy error.',
+                  'It looks like you\'re asking about the old **Dual Core** (TorBox + Real-Debrid) templates or hitting the "Invalid character" proxy error.',
                   '',
-                  '⚠️ **These templates have been deprecated.** Due to Real-Debrid API changes they will fail to import and cause playback issues.',
+                  '⚠️ **The old Dual Core templates have been deprecated.** Due to Real-Debrid API changes they will fail to import and cause playback issues.',
                   '',
-                  '**Fix your setup:**',
-                  '1. Remove the failed template from your AIOStreams dashboard.',
-                  '2. Import a supported TorBox-exclusive build:',
-                  '   - [Core Nexus 4K Pro](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-pro.json)',
-                  '   - [Core Nexus Stream (1080p)](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json)',
+                  '**Your options:**',
+                  '- **TorBox only** — import a Core Nexus build:',
+                  '  - [Core Nexus 4K Pro](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-pro.json)',
+                  '  - [Core Nexus Stream (1080p)](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json)',
+                  '- **TorBox + Real-Debrid** — use the [Hybrid template](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json) instead',
                   '',
                   '*This issue has been auto-closed. If you\'re still stuck, open a new issue with your current template version and host details.*'
                 ].join('\n')

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,7 +9,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Prepare release archive
         run: |
           mkdir -p release_assets
-          find Templates/ -name "*.json" ! -path "*/Deprecated/*" ! -path "*/Personal/*" -exec cp {} release_assets/ \;
+          find Templates/ -name "*.json" ! -path "*/Deprecated/*" ! -path "*/Personal/*" ! -path "*/Nightly/*" -exec cp {} release_assets/ \;
           find Formatters/ -name "*.json" -exec cp {} release_assets/ \;
           cp README.md CHANGELOG.md release_assets/
           cd release_assets

--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -24,7 +24,7 @@ jobs:
           git checkout FETCH_HEAD
 
       - name: Sync labels via GitHub API
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Fetch and format upstream JSON
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install pytest
         run: pip install pytest --quiet


### PR DESCRIPTION
## Summary

- **Action version pins** — `actions/checkout@v6` (doesn't exist) → `@v4` across five workflows; `actions/github-script@v9` → `@v7` in auto-responder and sync-labels
- **Auto-responder keyword fix** — removed `'real-debrid'` and `'realdebrid'` from the deprecated keyword list; these were incorrectly auto-closing issues about the Hybrid templates (which are active TorBox+RD builds, not deprecated). Updated auto-reply body to surface the Hybrid template as the current RD option
- **Release packaging** — excluded `Nightly/` from the stable release archive; nightly builds shouldn't ship alongside stable releases

## Files changed

| File | Change |
|---|---|
| `auto-responder.yml` | `github-script@v9` → `@v7`; narrowed deprecated keywords; updated reply body |
| `link-checker.yml` | `checkout@v6` → `@v4` |
| `release.yml` | `checkout@v6` → `@v4`; exclude Nightly from archive |
| `status-check.yml` | `checkout@v6` → `@v4` |
| `sync-labels.yml` | `github-script@v9` → `@v7` |
| `sync-upstream.yml` | `checkout@v6` → `@v4` |
| `tests.yml` | `checkout@v6` → `@v4` |

## Test plan

- [ ] Confirm CI passes on this branch
- [ ] Verify `actions/checkout@v4` resolves correctly in a test workflow run
- [ ] Open a test issue containing "dual core" — auto-responder should fire with updated body including Hybrid link
- [ ] Open a test issue containing "real-debrid" — auto-responder should NOT fire

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_