### PR TITLE
fix: release changelog categories and discussion template links

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-and-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.yml
@@ -5,7 +5,7 @@ body:
     attributes:
       value: |
         Ask anything about Core Builds templates, formatters, filtering, or AIOStreams setup.
-        Check the [Guides](https://github.com/Branding-Brevity/Core-Builds-By-Brevity/blob/main/Guides/README.md) and [FAQ](https://github.com/Branding-Brevity/Core-Builds-By-Brevity/blob/main/Guides/README.md#9--faq) first — common questions are answered there.
+        Check the [Guides](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) and [FAQ](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#9--faq) first — common questions are answered there.
 
   - type: input
     id: template

--- a/.github/DISCUSSION_TEMPLATE/template-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/template-request.yml
@@ -5,7 +5,7 @@ body:
     attributes:
       value: |
         Suggest a new template, formatter variant, or filtering configuration.
-        Check the [Roadmap](https://github.com/Branding-Brevity/Core-Builds-By-Brevity/blob/main/ROADMAP.md) first — it may already be planned.
+        Check the [Roadmap](https://github.com/brevityA/Core-Builds/blob/main/ROADMAP.md) first — it may already be planned.
 
   - type: dropdown
     id: type

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,8 +11,12 @@ changelog:
         - template-hybrid
         - template-anime
         - template-speed
+        - template-flash
         - formatter
         - new-template
+    - title: "🌙 Nightly / Pre-release"
+      labels:
+        - nightly
     - title: "🐛 Bug Fixes"
       labels:
         - bug


### PR DESCRIPTION
## Summary

Three small config fixes found during the GitHub audit.

## Changes

| File | Fix |
|---|---|
| `.github/release.yml` | Add `template-flash` to the New Templates changelog category; add a new `🌙 Nightly / Pre-release` category for the `nightly` label — both labels were added in PR #28 but were missing here, so Flash and Nightly PRs would have been uncategorised in auto-generated release notes |
| `.github/DISCUSSION_TEMPLATE/q-and-a.yml` | Guides and FAQ links pointed to `Branding-Brevity/Core-Builds-By-Brevity` — now point to `brevityA/Core-Builds` |
| `.github/DISCUSSION_TEMPLATE/template-request.yml` | ROADMAP link pointed to `Branding-Brevity/Core-Builds-By-Brevity` — now points to `brevityA/Core-Builds` |

## Test plan

- [ ] Create a test release and confirm Flash-labelled PRs appear under "New Templates & Formatters"
- [ ] Confirm Nightly-labelled PRs appear under "Nightly / Pre-release"
- [ ] Open the Q&A discussion template and confirm guide links resolve correctly
- [ ] Open the Template Request discussion template and confirm the ROADMAP link resolves correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_