### PR TITLE
docs: fix stale deprecated-template references in guides and Torbox README

### DIFF
--- a/Guides/FAQ.md
+++ b/Guides/FAQ.md
@@ -66,10 +66,10 @@ TorBox Essential is the entry-level plan — it gives you torrent caching but no
 Speed tier trades source coverage for load time. It uses 4 addons instead of 8-9, so it finds fewer total results but delivers them in 2-3 seconds. If TorBox has your content cached, Speed is excellent. If you regularly watch niche or older content that isn't well-cached, a standard template covers more ground.
 
 **Can I use Real-Debrid with Core Builds?**
-Yes — the Advanced (Dual Core) templates pair TorBox with RD. Due to RD's May 2026 filter enforcement, these work best on WuPlay. Stremio users may see reduced RD results for some content. See the [Advanced templates](https://github.com/brevityA/Core-Builds/tree/refs/heads/main/Templates/Torbox/Deprecated/Dual).
+Yes — use the [Core Nexus Hybrid](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json) template (TorBox Pro + NZBGeek). It does not pair TorBox with RD directly, but the Hybrid template gives you the broadest source coverage. For a pure TorBox + RD setup, community template [RB3 Hybrid](https://github.com/brevityA/Core-Builds/tree/main/Community-Templates/Templates/RB3) is available. Note: RD's May 2026 server-side keyword filter reduces RD results for some WEB-DL content on Stremio.
 
 **What happened to the Dual Core templates?**
-They were briefly deprecated due to RD's May 2026 server-side filter causing issues, then reclassified as **Advanced** after community reports of them working well on WuPlay. They're still available and maintained — just moved to `Templates/Torbox/Deprecated/Dual/` for now.
+The old Dual Core templates (TorBox + Real-Debrid) are deprecated due to RD API changes causing import failures and playback issues. They remain in `Templates/Torbox/Deprecated/Dual/` for reference only. Use the [Core Nexus Hybrid](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json) or the community RB3 Hybrid template instead.
 
 ---
 

--- a/Guides/TROUBLESHOOTING.md
+++ b/Guides/TROUBLESHOOTING.md
@@ -47,10 +47,10 @@ If it fails repeatedly:
 
 **Fix:** Double-check the URL matches the exact path in the repo. Raw URLs follow this pattern:
 ```
-https://raw.githubusercontent.com/brevityA/Core-Builds/main/Templates/Torbox/Dual/core-nexus-4k-dual-core.json
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-pro.json
 ```
 
-Note: `Torbox` has a lowercase `b`. `Dual`, `Single`, and `Hybrid` are capitalised. Filenames are all lowercase with hyphens.
+Note: `Torbox` has a lowercase `b`. `Single`, `Hybrid`, `Flash`, `Speed`, `Essential`, and `Anime` are capitalised. Filenames are all lowercase with hyphens.
 
 ---
 
@@ -87,7 +87,7 @@ keyword(streams, 'all', 'WEB-DL', 'WEBRip', 'AMZN')
 
 **What it means:** The streams are loading but the files have been flagged by your debrid service. This is most commonly the Real-Debrid "infringing file" issue where RD has blocked certain WEB-DL and streaming platform rips.
 
-**Fix:** The Core Builds dual-service templates include an RD Infringing File Scrub that filters these results before they reach Stremio. If you are seeing red errors, confirm you are on v2.1.2 or later and that the MediaFusion and Real-Debrid presets are correctly configured.
+**Fix:** This is an RD-side policy issue — RD blocks certain WEB-DL and streaming platform filenames server-side. TorBox does not apply this filter, so switching to a TorBox-primary template (Core Nexus Stream, Essential, Speed, or Hybrid) eliminates these errors. If you specifically need RD coverage, the community [RB3 Hybrid](https://github.com/brevityA/Core-Builds/tree/main/Community-Templates/Templates/RB3) template is the current TorBox + RD option.
 
 ---
 

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -44,6 +44,7 @@ Getting too few results / low-overhead host? → use the Lite variant of any tem
 |---|---|---|---|
 | **Core Nexus 4K Pro** | TorBox Pro | 4K+1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-pro.json` |
 | **Core Nexus Stream** | TorBox Pro | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json` |
+| **Core Nexus Stream (Fire Stick)** | TorBox Pro | 1080p SDR | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick.json` |
 | **Core Nexus Hybrid** | Pro + NZBGeek | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
 | **Core Nexus 4K Essential** | Essential | 4K+1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
 | **Core Nexus Essential** | Essential | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential.json` |


### PR DESCRIPTION
## Summary

Three files still had references to deprecated Dual Core templates or old file paths after the template rename.

## Changes

| File | Fix |
|---|---|
| `Templates/Torbox/README.md` | Added Core Nexus Stream (Fire Stick) to the All Templates table — was missing after PR #22 |
| `Guides/FAQ.md` | "Can I use Real-Debrid?" — replaced broken Dual Core link with Hybrid template + RB3 community template as current options. "What happened to Dual Core?" — clarified deprecated status and pointed to replacements |
| `Guides/TROUBLESHOOTING.md` | URL example used old `Templates/Torbox/Dual/` path → updated to current `Single/` example with corrected folder-name note. RD wall-of-red section referenced deprecated dual-service templates + MediaFusion RD Scrub → replaced with accurate RD server-side policy explanation and current TorBox-primary alternatives |

## Test plan
- [ ] Confirm Stream Fire Stick appears in Torbox/README.md template table
- [ ] Open FAQ.md — verify RD links resolve to valid templates
- [ ] Open TROUBLESHOOTING.md — verify URL example resolves correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_