### PR TITLE
docs: promote [Unreleased] to v2.6.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+---
+
+## 2.6.0 (2026-06-10)
+
 ### Added
 - **Core Nexus Samsung TV** (`Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv.json`) — Device-specific Nightly template for Samsung smart TVs and other hardware without Dolby Vision support. Derived from Core Nexus Stream with the DV-Only Kill ESE enabled by default. DV-only streams are excluded; HDR10, HDR10+, HLG, and SDR content passes through normally.
 - **DV-Only Kill ESE** — New optional ESE added to all 30 active templates (`enabled: false` by default). When toggled on, excludes streams where Dolby Vision is the only format tag with no HDR10/HDR10+/HLG/SDR fallback layer — the DV streams that cause black screens on non-DV devices. DV+HDR10 streams (dual-layer) are unaffected. `enabled: true` is pre-set in the Samsung TV Nightly template.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,21 +8,21 @@ This is a living list of planned work, active development, and recently complete
 
 | Version | Item |
 |---|---|
-| Unreleased | Core Nexus Samsung TV Nightly template — DV-only kill enabled, device-specific |
-| Unreleased | DV-Only Kill ESE — optional, disabled by default, all 30 templates |
-| Unreleased | Subtitle language flags — `uSubtitleEmojis` replaces generic 📝 SUB badge |
-| Unreleased | Flash `daysSinceRelease` guard — uncached allowed for ≤ 3-day-old content |
-| Unreleased | Balanced preload selector — `perGroup(resolution, 2)` across 28 templates |
-| Unreleased | Episode sort fix — global sort updated to canonical 14-key in 7 templates |
-| Unreleased | Core Nexus Stream (Fire Stick) + Lite variants |
-| Unreleased | Anime Non-Anime Query Guard — `and not isAnime` ISE guard |
-| Unreleased | Flash template `addonName` mismatch fix |
-| Unreleased | Regional Content Guide (`Guides/REGIONAL_CONTENT_GUIDE.md`) |
-| Unreleased | GitHub Actions version pins corrected (checkout @v4, github-script @v7) |
-| Unreleased | Link checker exit code string comparison fix |
-| Unreleased | Auto-responder keywords refined; Flash/Nightly labels + labeler added |
-| Unreleased | IMPORT_GUIDE, WHICH_TEMPLATE, DEVICE_PROFILES full rewrites |
-| Unreleased | FAQ and TROUBLESHOOTING stale content fixes |
+| v2.6.0 | Core Nexus Samsung TV Nightly template — DV-only kill enabled, device-specific |
+| v2.6.0 | DV-Only Kill ESE — optional, disabled by default, all 30 templates |
+| v2.6.0 | Subtitle language flags — `uSubtitleEmojis` replaces generic 📝 SUB badge |
+| v2.6.0 | Flash `daysSinceRelease` guard — uncached allowed for ≤ 3-day-old content |
+| v2.6.0 | Balanced preload selector — `perGroup(resolution, 2)` across 28 templates |
+| v2.6.0 | Episode sort fix — global sort updated to canonical 14-key in 7 templates |
+| v2.6.0 | Core Nexus Stream (Fire Stick) + Lite variants |
+| v2.6.0 | Anime Non-Anime Query Guard — `and not isAnime` ISE guard |
+| v2.6.0 | Flash template `addonName` mismatch fix |
+| v2.6.0 | Regional Content Guide (`Guides/REGIONAL_CONTENT_GUIDE.md`) |
+| v2.6.0 | GitHub Actions version pins corrected (checkout @v4, github-script @v7) |
+| v2.6.0 | Link checker exit code string comparison fix |
+| v2.6.0 | Auto-responder keywords refined; Flash/Nightly labels + labeler added |
+| v2.6.0 | IMPORT_GUIDE, WHICH_TEMPLATE, DEVICE_PROFILES full rewrites |
+| v2.6.0 | FAQ and TROUBLESHOOTING stale content fixes |
 | v2.5.1 | Local test environment — `requirements.txt` + CONTRIBUTING.md setup guide |
 | v2.5.1 | Midnight's Meteor V2 Beta documented across STATUS.md and Guides |
 | v2.5.1 | README banner and badges fixed |


### PR DESCRIPTION
Moves all shipped items from `[Unreleased]` to `## 2.6.0 (2026-06-10)` in CHANGELOG.md. Updates all `Unreleased` labels in the ROADMAP Recently Completed table to `v2.6.0`. Leaves an empty `[Unreleased]` placeholder for future work.

Merge this before pushing the `v2.6.0` release tag so the tag's release notes reflect the finalised CHANGELOG.

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_