### PR TITLE
feat: updated branding — new icon and square README banner

### DIFF
--- a/Assets/banner_square.svg
+++ b/Assets/banner_square.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" width="600" height="600">
+  <defs>
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
+    </linearGradient>
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
+    </linearGradient>
+    <linearGradient id="orangeGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#ff9472"/>
+      <stop offset="100%" stop-color="#e8401a"/>
+    </linearGradient>
+    <filter id="hexGlow"><feGaussianBlur stdDeviation="10" result="blur"/><feComposite in="SourceGraphic" in2="blur" operator="over"/></filter>
+    <filter id="diamGlow"><feGaussianBlur stdDeviation="12" result="blur"/><feComposite in="SourceGraphic" in2="blur" operator="over"/></filter>
+    <filter id="softGlow"><feGaussianBlur stdDeviation="20"/></filter>
+  </defs>
+
+  <rect width="600" height="600" fill="#0d1117" rx="24"/>
+
+  <!-- Ambient glow -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="#00e5ff" opacity="0.04" filter="url(#softGlow)"/>
+  <polygon points="300,212 356,268 300,324 244,268" fill="#c060c0" opacity="0.08" filter="url(#softGlow)"/>
+
+  <!-- Hex glow -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="none" stroke="#00e5ff" stroke-width="28" stroke-linejoin="round" opacity="0.3" filter="url(#hexGlow)"/>
+
+  <!-- Hex outline -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="none" stroke="url(#hexGrad)" stroke-width="20" stroke-linejoin="round"/>
+
+  <!-- Diamond glow -->
+  <polygon points="300,212 356,268 300,324 244,268" fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+
+  <!-- Diamond -->
+  <polygon points="300,212 356,268 300,324 244,268" fill="url(#diamGrad)" opacity="0.95"/>
+
+  <!-- CORE BUILDS — cyan, semi-bold -->
+  <text x="300" y="450"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="26" font-weight="600" letter-spacing="5"
+    fill="#00e5ff" text-anchor="middle">CORE BUILDS</text>
+
+  <!-- BY BREVITY — orange, light -->
+  <text x="300" y="476"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="19" font-weight="300" letter-spacing="5"
+    fill="url(#orangeGrad)" text-anchor="middle" opacity="0.65">BY BREVITY</text>
+</svg>

--- a/Assets/core_icon.svg
+++ b/Assets/core_icon.svg
@@ -1,26 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="100%" height="100%">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
   <defs>
-    <linearGradient id="coreGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#00f2fe" />
-      <stop offset="100%" stop-color="#4facfe" />
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
     </linearGradient>
-    
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ff7e5f" />
-      <stop offset="100%" stop-color="#ff4b2b" />
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
     </linearGradient>
-
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur stdDeviation="12" result="blur" />
-      <feComposite in="SourceGraphic" in2="blur" operator="over" />
+    <filter id="hexGlow">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="diamGlow">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="20"/>
     </filter>
   </defs>
 
-  <circle cx="256" cy="256" r="240" fill="#0d1117" stroke="#161b22" stroke-width="16"/>
-  
-  <polygon points="256,110 382,183 382,329 256,402 130,329 130,183" fill="none" stroke="url(#coreGrad)" stroke-width="28" filter="url(#glow)"/>
-  
-  <polygon points="256,170 342,256 256,342 170,256" fill="url(#accentGrad)" opacity="0.95" filter="url(#glow)"/>
-  
-  <circle cx="256" cy="256" r="24" fill="#ffffff" />
+  <circle cx="256" cy="256" r="248" fill="#0d1117"/>
+
+  <!-- Ambient glow -->
+  <polygon points="256,130 358,188 358,304 256,362 154,304 154,188"
+    fill="#00e5ff" opacity="0.04" filter="url(#softGlow)"/>
+  <polygon points="256,194 312,250 256,306 200,250"
+    fill="#c060c0" opacity="0.08" filter="url(#softGlow)"/>
+
+  <!-- Hex glow layer -->
+  <polygon points="256,130 358,188 358,304 256,362 154,304 154,188"
+    fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round"
+    opacity="0.3" filter="url(#hexGlow)"/>
+
+  <!-- Hex outline -->
+  <polygon points="256,130 358,188 358,304 256,362 154,304 154,188"
+    fill="none" stroke="url(#hexGrad)" stroke-width="22" stroke-linejoin="round"/>
+
+  <!-- Diamond glow -->
+  <polygon points="256,194 312,250 256,306 200,250"
+    fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+
+  <!-- Diamond -->
+  <polygon points="256,194 312,250 256,306 200,250"
+    fill="url(#diamGrad)" opacity="0.95"/>
 </svg>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/banner.svg" alt="Core Builds Banner" width="100%"/>
+    <img src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/banner_square.svg" alt="Core Builds Banner" width="400"/>
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

- **New `core_icon.svg`** — glowing gradient diamond (cyan → purple → orange) replaces the flat orange fill. Hex outline retains cyan gradient with soft ambient glow behind it. All templates pick this up automatically on merge via the existing `addonLogo` URL.
- **New `banner_square.svg`** — 600×600 square brand mark with centred logo, cyan CORE BUILDS wordmark, orange BY BREVITY tagline.
- **README updated** — hero image switched from the wide banner to the new square mark.

## Test plan

- [ ] Confirm icon renders correctly in AIOStreams after merge
- [ ] Confirm README hero image displays correctly on GitHub

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj