### PR TITLE
fix: README badge layout + static RELEASE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,20 @@
     <img src="https://img.shields.io/github/actions/workflow/status/brevityA/Core-Builds/validate.yml?style=for-the-badge&label=BUILD&logo=github&logoColor=white&labelColor=1a1f27" alt="Build Status"/>
   </a>
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://img.shields.io/github/v/release/brevityA/Core-Builds?style=for-the-badge&label=RELEASE&labelColor=1a1f27&color=00d4ff" alt="Latest Release"/>
+    <img src="https://img.shields.io/badge/RELEASE-v2.6.3-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
   </a>
+</p>
+
+<p align="center">
   <a href="https://github.com/brevityA/Core-Builds/stargazers">
     <img src="https://img.shields.io/github/stars/brevityA/Core-Builds?style=for-the-badge&label=STARS&logo=github&logoColor=white&labelColor=1a1f27&color=00d4ff&cacheSeconds=86400" alt="Stars"/>
   </a>
   <a href="https://ko-fi.com/branding_brevity">
     <img src="https://img.shields.io/badge/DONATE-Ko--fi-ff5f5f?style=for-the-badge&logo=ko-fi&logoColor=white&labelColor=1a1f27" alt="Donate"/>
   </a>
+</p>
+
+<p align="center">
   <a href="https://github.com/brevityA/Core-Builds/discussions">
     <img src="https://img.shields.io/badge/DISCUSSIONS-Community-7c3aed?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1f27" alt="Discussions"/>
   </a>


### PR DESCRIPTION
## Summary

- Replaced broken dynamic RELEASE badge (`img.shields.io/github/v/release/`) with a static badge (`v2.6.3`) — the dynamic one was hitting GitHub's API token pool limit and showing an error
- Grouped badges into paired rows (BUILD+RELEASE, STARS+DONATE, DISCUSSIONS+ROADMAP) so they display in a clean 2-column layout instead of stacking individually
- TorBox referral badge remains on its own row as before

## Test plan

- [ ] Verify RELEASE badge shows `v2.6.3` without error
- [ ] Verify badges render in 2-per-row groupings on the README

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_