### PR TITLE
fix: switch labeler trigger to pull_request + add checkout step

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Label Pull Requests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -11,6 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Changed trigger from `pull_request_target` to `pull_request`
- Added `actions/checkout@v4` step before the labeler

`pull_request_target` runs in the base branch context and doesn't need a checkout, but it can lose visibility of changed files in the PR head for glob matching. `pull_request` with an explicit checkout gives the labeler accurate file paths.

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_