### PR TITLE
fix: labeler workflow + triage catch-all

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -52,3 +52,7 @@ infrastructure:
   - changed-files:
     - any-glob-to-any-file: '.github/**'
 
+triage:
+  - changed-files:
+    - any-glob-to-any-file: '**'
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Label Pull Requests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -11,6 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **Workflow** (`labeler.yml`): switched trigger from `pull_request_target` to `pull_request` and added `actions/checkout@v4` step — gives the labeler local access to the config file, fixes API auth errors
- **Config** (`.github/labeler.yml`): added `triage` catch-all rule (`**`) — any PR that doesn't match an existing glob still gets a label so nothing slips through unlabelled

## Audit

`welcome.yml` intentionally stays on `pull_request_target` — it needs write access to post comments on fork PRs, which `pull_request` does not provide.

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_