### PR TITLE
fix(community): update RB3 preview to Stremio UI style + modernise banner

### DIFF
--- a/Assets/Formatters/rb3-clean-v4-preview.svg
+++ b/Assets/Formatters/rb3-clean-v4-preview.svg
@@ -1,62 +1,68 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" width="800" height="420">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 400" width="520" height="400">
   <defs>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
-      .bg   { fill: #0d1117; }
-      .card { fill: #161b22; stroke: #30363d; stroke-width: 1; }
-      .lbl  { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; fill: #58a6ff; letter-spacing: 0.08em; text-transform: uppercase; }
-      .sub  { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500; fill: #3fb950; letter-spacing: 0.04em; }
-      .name { font-family: 'Inter', sans-serif; font-size: 13.5px; font-weight: 700; fill: #e6edf3; }
-      .d1   { font-family: 'Inter', sans-serif; font-size: 12px; font-weight: 400; fill: #c9d1d9; }
-      .d2   { font-family: 'Inter', sans-serif; font-size: 12px; font-weight: 400; fill: #8b949e; }
-      .sep  { stroke: #30363d; stroke-width: 1; }
+      .bg      { fill: #181b24; }
+      .hdr-bg  { fill: #1e2333; }
+      .tab-bg  { fill: #252c3e; }
+      .tab-txt { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; fill: #e8eaf0; }
+      .ttl     { font-family: 'Inter', sans-serif; font-size: 15px; font-weight: 700; fill: #e8eaf0; }
+      .n1      { font-family: 'Inter', sans-serif; font-size: 12px; font-weight: 500; fill: #c5c9d6; }
+      .n2      { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 700; fill: #e8eaf0; }
+      .n3      { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 400; fill: #c5c9d6; font-style: italic; }
+      .recent  { font-family: 'Inter', sans-serif; font-size: 12px; font-weight: 600; fill: #e8882a; }
+      .d1      { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 400; fill: #9aa0b0; }
+      .d2      { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 400; fill: #6e7485; }
+      .div     { stroke: #2c3040; stroke-width: 1; }
     </style>
   </defs>
 
-  <rect class="bg" width="800" height="420"/>
+  <!-- Background -->
+  <rect class="bg" width="520" height="400"/>
 
-  <!-- Header -->
-  <text x="20" y="17" class="lbl">RB3 Clean v4 — Stream Preview</text>
-  <text x="20" y="28" class="sub">Service · ⚡/⏳ cache  ·  bold unicode resolution  ·  italic unicode source  ·  clean ⁞ metadata rows</text>
+  <!-- Header bar -->
+  <rect class="hdr-bg" x="0" y="0" width="520" height="36"/>
+  <text x="16" y="23" class="ttl">Streams</text>
 
-  <!-- Card 1: 4K REMUX, Cached -->
-  <rect class="card" x="16" y="36" width="768" height="178" rx="6"/>
+  <!-- Tab bar -->
+  <rect class="hdr-bg" x="0" y="36" width="520" height="30"/>
+  <rect class="tab-bg" x="8" y="40" width="160" height="22" rx="4"/>
+  <text x="88" y="55" class="tab-txt" text-anchor="middle">RB3Streams · TorBox Pro</text>
+  <text x="220" y="55" class="tab-txt" fill="#6e7485">Debridio · TorBox Pro</text>
 
-  <!-- Name block -->
-  <text x="32" y="61" class="name">TB ⚡</text>
-  <text x="32" y="79" class="name">𝟰𝗞 𝗨𝗛𝗗</text>
-  <text x="32" y="97" class="name">𝘉𝘭𝘶-𝘳𝘢𝘺 𝘙𝘦𝘮𝘶𝘹</text>
+  <!-- Divider under tabs -->
+  <line x1="0" y1="66" x2="520" y2="66" class="div"/>
 
-  <!-- Separator -->
-  <line x1="32" y1="108" x2="752" y2="108" class="sep"/>
+  <!-- ─── Stream 1: 4K UHD cached ─── -->
+  <text x="16" y="88"  class="n1">TB ⚡</text>
+  <text x="16" y="110" class="n2">𝟰𝗞 𝗨𝗛𝗗</text>
+  <text x="16" y="128" class="n3">𝘉𝘭𝘶-𝘳𝘢𝘺 𝘙𝘦𝘮𝘶𝘹</text>
+  <text x="16" y="145" class="recent">▶️ Recent</text>
 
-  <!-- Description block -->
-  <text x="32" y="124" class="d1">📁 Oppenheimer (2023)</text>
-  <text x="32" y="141" class="d2">  ⁞  🎬 DV｜HDR10+   💿 x265</text>
-  <text x="32" y="158" class="d2">  ⁞  🔊 7.1   🎧 TrueHD Atmos</text>
-  <text x="32" y="175" class="d2">  ⁞  🌐 en｜fr｜de</text>
-  <text x="32" y="192" class="d2">  ⁞  📦 58.4 GB   〽️ 45.2 Mbps</text>
-  <text x="32" y="207" class="d2">🧩 TorBox</text>
+  <!-- Description 1 -->
+  <text x="16" y="162" class="d1">📁 Oppenheimer (2023)</text>
+  <text x="16" y="177" class="d2">  ⁞  🎬 DV｜HDR10+   💿 x265</text>
+  <text x="16" y="192" class="d2">  ⁞  🔊 7.1   🎧 TrueHD Atmos</text>
+  <text x="16" y="207" class="d2">  ⁞  📦 58.4 GB   〽️ 45.2 Mbps   🧩 TorBox</text>
 
-  <!-- Card 2: 1080p WEB-DL, Uncached -->
-  <rect class="card" x="16" y="224" width="768" height="178" rx="6"/>
+  <!-- Divider -->
+  <line x1="0" y1="220" x2="520" y2="220" class="div"/>
 
-  <!-- Name block -->
-  <text x="32" y="249" class="name">TB      ⏳</text>
-  <text x="32" y="267" class="name">𝟭𝟬𝟴𝟬𝗽</text>
-  <text x="32" y="285" class="name">𝘞𝘌𝘉-𝘋𝘓</text>
+  <!-- ─── Stream 2: 1080p uncached ─── -->
+  <text x="16" y="242" class="n1">TB      ⏳</text>
+  <text x="16" y="264" class="n2">𝟭𝟬𝟴𝟬𝗽</text>
+  <text x="16" y="282" class="n3">𝘞𝘌𝘉-𝘋𝘓</text>
 
-  <!-- Separator -->
-  <line x1="32" y1="296" x2="752" y2="296" class="sep"/>
+  <!-- Description 2 -->
+  <text x="16" y="306" class="d1">📁 The Dark Knight (2008)</text>
+  <text x="16" y="321" class="d2">  ⁞  🎬 HDR10   💿 x264</text>
+  <text x="16" y="336" class="d2">  ⁞  🔊 5.1   🎧 DD+</text>
+  <text x="16" y="351" class="d2">  ⁞  📦 8.2 GB   〽️ 12.4 Mbps   🌱 89   🧩 TorBox</text>
 
-  <!-- Description block -->
-  <text x="32" y="312" class="d1">📁 The Dark Knight (2008)</text>
-  <text x="32" y="329" class="d2">  ⁞  🎬 HDR10   💿 x264</text>
-  <text x="32" y="346" class="d2">  ⁞  🔊 5.1   🎧 DD+</text>
-  <text x="32" y="363" class="d2">  ⁞  🌐 en</text>
-  <text x="32" y="380" class="d2">  ⁞  📦 8.2 GB   〽️ 12.4 Mbps</text>
-  <text x="32" y="395" class="d2">🌱 89   🧩 TorBox</text>
+  <!-- Divider -->
+  <line x1="0" y1="364" x2="520" y2="364" class="div"/>
 
-  <!-- footer -->
-  <text x="400" y="413" class="lbl" text-anchor="middle" fill="#484f58">Core Builds by Brevity · github.com/brevityA/Core-Builds</text>
+  <!-- Footer -->
+  <rect class="hdr-bg" x="0" y="364" width="520" height="36"/>
+  <text x="260" y="386" font-family="Inter, sans-serif" font-size="10" font-weight="500" fill="#3d4456" text-anchor="middle" letter-spacing="0.06em">CORE BUILDS BY BREVITY · github.com/brevityA/Core-Builds</text>
 </svg>

--- a/Assets/auburn_tiger_banner.svg
+++ b/Assets/auburn_tiger_banner.svg
@@ -1,21 +1,56 @@
-<svg width="1280" height="400" viewBox="0 0 1280 400" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1280" height="400" fill="#050B14"/>
-  
-  <g stroke="#0F1C36" stroke-width="2">
-    <path d="M0 100H1280M0 200H1280M0 300H1280"/>
-    <path d="M100 0V400M200 0V400M300 0V400M1100 0V400M1200 0V400"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" width="1200" height="280">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d0a06"/>
+      <stop offset="50%" stop-color="#110e08"/>
+      <stop offset="100%" stop-color="#0d0a06"/>
+    </linearGradient>
+    <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FF5E00" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#FF5E00" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#FF5E00" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#FF5E00" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
 
-  <text x="100" y="205" font-family="Montserrat, 'Segoe UI', Helvetica, sans-serif" font-weight="900" font-size="85" font-style="italic" fill="#FF5E00" letter-spacing="2">AUBURN TIGER</text>
-  <text x="105" y="255" font-family="Inter, 'Segoe UI', Helvetica, sans-serif" font-weight="700" font-size="24" fill="#E2E8F0" letter-spacing="12">AIOSTREAMS COMMUNITY BUILD</text>
+  <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#FF5E00" stroke-width="1" stroke-opacity="0.15"/>
 
-  <rect x="100" y="285" width="700" height="4" fill="#FF5E00"/>
+  <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
 
-  <g transform="translate(1080, 150)">
-    <path d="M40 0L75 60H5L40 0Z" fill="#FF5E00"/>
-    
-    <rect x="25" y="75" width="30" height="30" fill="#1E3A8A"/>
-    
-    <path d="M40 165L5 105H75L40 165Z" fill="#FF5E00"/>
-  </g>
+  <!-- Main title -->
+  <text x="600" y="105"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="72" font-weight="800" letter-spacing="-1"
+    fill="#ffffff" text-anchor="middle">AUBURN TIGER</text>
+
+  <!-- By line -->
+  <text x="600" y="148"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="18" font-weight="400" letter-spacing="12"
+    fill="#FF5E00" text-anchor="middle" opacity="0.9">BY RB3</text>
+
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#FF5E00" opacity="0.4"/>
+
+  <!-- Subtitle -->
+  <text x="600" y="208"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="18" font-weight="300" letter-spacing="4"
+    fill="#ffb380" text-anchor="middle" opacity="0.7">COMMUNITY TEMPLATE  ·  CLEAN v4 FORMATTER</text>
+
+  <!-- Tag line -->
+  <text x="600" y="244"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="14" font-weight="300" letter-spacing="3"
+    fill="#888672" text-anchor="middle" opacity="0.6">TORBOX PRO  ·  REAL-DEBRID  ·  AIOSTREAMS</text>
+
+  <!-- Corner decorations -->
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#FF5E00" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#FF5E00" opacity="0.4"/>
 </svg>


### PR DESCRIPTION
## Summary

Follow-up to #52 — two commits that were pushed after the merge:

- **Stremio-style preview** — rebuilds `rb3-clean-v4-preview.svg` to mimic the actual Stremio stream list UI (dark panel, tab bar, stream rows with dividers) instead of the generic card mockup
- **Modernised banner** — updates `auburn_tiger_banner.svg` to match the Core Builds gradient style (dark background, orange accent line, corner decorations); subtitle updated to include "CLEAN v4 FORMATTER"

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_