### PR TITLE
fix(docs): readme text cleanup across community and main readme

### DIFF
--- a/Community-Templates/Templates/MightyIcyy/README.md
+++ b/Community-Templates/Templates/MightyIcyy/README.md
@@ -56,20 +56,20 @@ Users who want a clean, no-fuss 1080p experience on TorBox Essential without tun
 ## ⚡ Quick Import
 
 ```
-https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/prism-torbox-essential-1080p.json
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json
 ```
 
 ---
 
-## ⚠️ Known Issues
+## 📝 Configuration Notes
 
-**`DV Only` visual tag** — `'DV Only'` is not a valid AIOStreams enum value. Valid value is `'DV'`. The exclusion may not apply correctly.
+**`DV Only` visual tag** — AIOStreams uses `'DV'` not `'DV Only'` for this enum. If you're customising the exclusion list, use the correct value.
 
-**`language()` in ESE** — `language()` is not a valid AIOStreams SEL function for stream expressions. The Russian/Ukrainian language exclusion block may not work as intended. Use `requiredLanguages` config instead.
+**Language exclusions** — `language()` is not a valid SEL function for stream expressions. To exclude languages, use the `requiredLanguages` setting in AIOStreams config instead.
 
-**Case sensitivity** — `'Bluray'` in expressions should be `'BluRay'` (AIOStreams is case-sensitive for quality enums).
+**Quality enum case** — AIOStreams is case-sensitive: use `'BluRay'` not `'Bluray'` in custom expressions.
 
-**No hard resolution filter** — `includedResolutions` is not set, so 4K streams can still appear. Only `preferredResolutions: ['1080p']` is configured which scores but does not hard-block.
+**Resolution** — `preferredResolutions: ['1080p']` scores 1080p higher but does not hard-block 4K. Set `includedResolutions` if you want a strict cap.
 
 ---
 
@@ -77,7 +77,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community
 
 This template is intentionally minimal — two addons, light filtering, low result cap. Good for users who want fast stream loading without a large scraper stack.
 
-For more comprehensive coverage on TorBox Essential consider **Core Nexus Essential** from the main suite.
+For more comprehensive coverage on TorBox Essential, see **Core Nexus Essential** in the main suite.
 
 ---
 

--- a/Community-Templates/Templates/RB3/RB3 Hybrid/Readme.md
+++ b/Community-Templates/Templates/RB3/RB3 Hybrid/Readme.md
@@ -34,7 +34,8 @@ A premium, dual-service AIOStreams template designed to maximize stream availabi
 ### 🧩 Included Addons (Presets)
 This template comes pre-wired with a highly optimized stack of scrapers and utilities:
 * **Debrid / Torrents:** Meteor, Comet, Torrentio, Knaben, Sootio
-* **Usenet Search:** * **Searchⁿᶻᵇ:** This is Tam's preloaded Newznab addon configured specifically for the TorBox Search indexer. All you need to do is paste your TorBox API key into it!
+* **Usenet Search:**
+  * **Newznab Search:** Tam's preloaded Newznab addon configured for the TorBox Search indexer. Paste your TorBox API key to activate.
   * **STorz:** Torznab integration.
 * **Anime:** SeaDex
 * **Subtitles:** OpenSubtitles V3+

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 ## 📜 Version
 
-Current: **`v2.5.1`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
+Current: **`v2.6.3`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
 
 ---
 


### PR DESCRIPTION
## Summary

- **`README.md`** — version text aligned to `v2.6.3` (was `v2.5.1`, mismatched the badge)
- **`RB3 Hybrid/Readme.md`** — fixed malformed double-asterisk in the Usenet Search addon list; sub-items now properly indented under their parent
- **`MightyIcyy/README.md`** — fixed broken import URL (was pointing to `Community-Templates/` root, now points to the correct `Templates/MightyIcyy/` path); reframed "Known Issues" as "Configuration Notes" with actionable wording; fixed awkward closing line

## Test plan

- [ ] MightyIcyy import URL resolves to the correct JSON file
- [ ] RB3 Hybrid addon list renders with correct indentation
- [ ] README.md version section matches the badge

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_