### PR TITLE
docs: add banner, quick reference, guide links and disclaimer to template readme

### DIFF
--- a/Assets/templates_banner.svg
+++ b/Assets/templates_banner.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" width="1200" height="280">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a080f"/>
+      <stop offset="50%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#0a080f"/>
+    </linearGradient>
+    <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#a371f7" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#a371f7" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#a371f7" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#a371f7" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#a371f7" stroke-width="1" stroke-opacity="0.15"/>
+
+  <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
+
+  <text x="600" y="105"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="72" font-weight="800" letter-spacing="-1"
+    fill="#ffffff" text-anchor="middle">TEMPLATE DIRECTORY</text>
+
+  <text x="600" y="148"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="18" font-weight="400" letter-spacing="12"
+    fill="#a371f7" text-anchor="middle" opacity="0.9">BY BREVITY</text>
+
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#a371f7" opacity="0.4"/>
+
+  <text x="600" y="208"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="18" font-weight="300" letter-spacing="4"
+    fill="#c8a9fa" text-anchor="middle" opacity="0.7">TORBOX  ·  AIOSTREAMS  ·  V2.6.3</text>
+
+  <text x="600" y="244"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="14" font-weight="300" letter-spacing="3"
+    fill="#888fa0" text-anchor="middle" opacity="0.6">CORE BUILDS TEMPLATE LIBRARY</text>
+
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
+</svg>

--- a/Guides/README.md
+++ b/Guides/README.md
@@ -50,6 +50,8 @@ It's not installing new software. It loads a pre-configured settings file into y
 
 That's it. You're watching in under 5 minutes.
 
+> 📋 **Ready to import?** Jump straight to the [Template Directory](https://github.com/brevityA/Core-Builds/blob/main/Templates/Torbox/README.md) for all import URLs and a quick reference table.
+
 ---
 
 **Quick reference — what each section covers:**

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -1,8 +1,49 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/templates_banner.svg" alt="Core Builds Template Directory Banner" width="100%"/>
+</p>
+
 # Core Builds — Template Directory
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
 > **Current version: v2.6.3** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+
+> 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
+
+---
+
+## ⚡ Quick Reference
+
+| Template | Plan | Resolution | Best for |
+|---|---|---|---|
+| [4K Pro](#-core-nexus-4k-pro) | Pro | 4K + 1080p | Flagship — DV/HDR REMUX + Usenet |
+| [Stream](#-core-nexus-stream) | Pro | 1080p | WEB-DL only, budget hardware |
+| [Stream (Fire Stick)](#-core-nexus-stream-fire-stick) | Pro | 1080p SDR | Fire Stick + low-RAM devices |
+| [Samsung TV](#-core-nexus-samsung-tv-nightly) 🌙 | Pro | 1080p | Samsung / no Dolby Vision |
+| [Samsung TV 4K](#-core-nexus-samsung-tv-4k-nightly) 🌙 | Pro | 4K + 1080p | Samsung 4K / HDR10+ |
+| [Hybrid](#-core-nexus-hybrid) | Pro + NZBGeek | 1080p | Dual-source: TorBox + Usenet |
+| [4K Essential](#-core-nexus-4k-essential) | Essential | 4K + 1080p | Full 4K on Essential plan |
+| [Essential](#-core-nexus-essential) | Essential | 1080p | Standard Essential build |
+| [Speed 4K+](#easynews-speed-templates) | Essential + EasyNews | 4K | Instant cached 4K |
+| [Speed+](#easynews-speed-templates) | Essential + EasyNews | 1080p | Instant cached 1080p |
+| [Speed EasyNews](#easynews-speed-templates) | EasyNews only | 1080p | EasyNews — no TorBox needed |
+| [Speed 4K](#torbox-only-speed-templates) | Essential | 4K | Fast cached 4K |
+| [Speed](#torbox-only-speed-templates) | Essential | 1080p | Fast cached 1080p |
+| [Anime](#-anime) 🎌 | Essential | 1080p | SeaDex best-release anime |
+| [Anime 4K](#-anime) 🎌 | Essential | 4K + 1080p | HDR anime |
+| [Anime Dub](#-anime) 🎌 | Essential | 1080p | English dubbed anime |
+| [Flash](#️-flash-tier) ⚡⚡ | Essential | 1080p | Instant play, cached only |
+| [Flash 4K](#️-flash-tier) ⚡⚡ | Essential | 4K + 1080p | Instant play 4K, cached only |
+
+> 🪶 Every template above also has a **Lite variant** (`-lite` suffix in the filename). Import URLs are in the [All Templates](#-all-templates) table below.
+
+### 🌍 Community
+
+| Template | Author | Plan | Resolution | Best for |
+|---|---|---|---|---|
+| [Auburn Tiger Edition](#-community-templates) | RB3 | Pro + RD | 4K + 1080p | TorBox Pro + Real-Debrid, warm orange/navy UI |
+| [RB3 TorBox Pro + RD Hybrid](#-community-templates) | RB3 | Pro + RD | 1080p | Dual-source hybrid with Usenet |
+| [Prism TorBox Essential 1080p](#-community-templates) | MightyIcyy | Essential | 1080p | Simple, low-friction Essential build |
 
 ---
 
@@ -309,4 +350,10 @@ Every standard template has a `-lite` variant. Lite removes 12 quality-gate ESEs
 
 ---
 
-*Part of [Core Builds by Brevity](https://github.com/brevityA/Core-Builds) · [Main README](https://github.com/brevityA/Core-Builds/blob/main/README.md) · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)*
+## ⚠️ Disclaimer
+
+Core Builds is an independent community project and is not affiliated with, endorsed by, or supported by TorBox, AIOStreams, or any service provider referenced in these templates. Templates configure how the AIOStreams addon filters and displays streams — they do not host, proxy, or distribute any content. Use is entirely at your own risk.
+
+---
+
+*Part of [Core Builds by Brevity](https://github.com/brevityA/Core-Builds) · [Complete Setup Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)*


### PR DESCRIPTION
## Summary

- **Banner** — new `Assets/templates_banner.svg` with purple `#a371f7` accent, matching the design system used across guide, formatters, and community banners
- **Quick reference table** — 18 main templates + 3 community templates, each with plan, resolution, and one-line best-for description; sits above the full template detail sections
- **Guide link** — callout below the intro pointing new users to `Guides/README.md`
- **Footer** — updated to include Complete Setup Guide link alongside the changelog
- **Disclaimer** — independent community project notice before the footer
- **Guide cross-link** — "Ready to import?" callout added to `Guides/README.md` pointing back to the Template Directory

## Test plan

- [ ] Banner renders correctly on GitHub (purple accent, dark gradient, corner decorations)
- [ ] Quick reference anchor links resolve to the correct sections
- [ ] Guide ↔ Template Directory cross-links both work

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_