### PR TITLE
fix: resolve low-priority audit issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ on:
       - 'tests/**'
       - 'Templates/**/*.json'
       - 'Formatters/**/*.json'
+      - '**/*.md'
+      - 'Assets/**'
 
 jobs:
   test:

--- a/Formatters/README.md
+++ b/Formatters/README.md
@@ -8,6 +8,29 @@ Custom stream display layouts for AIOStreams. Formatters control how every strea
 
 ---
 
+## ⚡ Quick Comparison
+
+| Formatter | Style | Name lines | Desc lines | Key feature |
+|---|---|---|---|---|
+| **Core Nexus Apex v2** ⭐ | Emoji circles | 1 | 4 | Score number, bitrate-first, per-language subtitle flags |
+| **Core Nexus Apex** | Emoji circles | 1 | 4 | Audio codec in name, two-tier score badge |
+| **Core Nexus Elite** | Emoji circles | 1 | 4 | 🟣/🔵/🟢/⚫ resolution circles · INSTANT/UNCACHED · PREMIER |
+| **Core Nexus Sigma** | `「 」` brackets | 1 | 4 | Title-first name line, smallcaps, premium editorial feel |
+| **Core Nexus Minimal** | ⚡/⏳ indicator | 1 | 3 | 3-line description, first audio codec only, TV/AppleTV |
+| **Core Nexus TV** | UPPER CASE | 1 | 4 | 10-foot UI, 🔴/🔵/🟢 circles, projector & smart TV |
+| **Core Nexus Uniform** | Emoji circles | 1 | 4 | Legacy — replaced by Elite |
+| **Core Syntax** | `「 」` brackets | 1 | 4 | Original formatter, ✦/✧ cache indicator, ◈ ELITE badge |
+| **Core Syntax V3** | `「 」` brackets | 1 | 4 | JBL Spatial, ★ Premium badge, IMAX/Hybrid/edition flags |
+| **Omni Diamond v2.2.0** | Dense emoji | 2 | 4 | Two-line name, maximum metadata density |
+| **Core Zenith Diamond** | 🔹/🔸 dots | 1 | 4 | Dot separators, encode + audio + PREMIER in name |
+| **Core Zenith Auburn Tiger** | 🔸 orange dots | 1 | 4 | Warm orange/navy, 🐅 release prefix, Auburn Tiger pairs |
+| **Midnight Slate** | ASCII `◼⬤▶◆` | 1 | 4 | No emoji — for clients that render emoji poorly |
+| **Nexus Prime** | Emoji | 1 | 4 | SeaDex/BEST detection, 📅 age format, subtitle listing |
+| **RB3 Clean v4** | Bold unicode | 3 | 6 | Three-line name with bold resolution + italic quality source |
+| **RB3 Formatter** | 🔸/🔹 smallcaps | 1 | 4 | Auburn Tiger paired, JBL Spatial, PREMIER tagging |
+
+---
+
 ## 📋 Active Formatters
 
 ### ⭐ Core Nexus Apex v2

--- a/tests/test_doc_consistency.py
+++ b/tests/test_doc_consistency.py
@@ -1,0 +1,53 @@
+"""
+Checks that all raw.githubusercontent.com URLs referencing this repo
+in markdown files point to files that actually exist in the local checkout.
+Catches broken template import links, missing assets, and stale doc references.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+RAW_URL_PATTERN = re.compile(
+    r"https://raw\.githubusercontent\.com/brevityA/Core-Builds/refs/heads/main/([^\s\)\"'>]+)"
+)
+
+
+def _collect_broken_urls():
+    broken = []
+    for md in REPO_ROOT.rglob("*.md"):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for match in RAW_URL_PATTERN.finditer(text):
+            rel_path = match.group(1)
+            if not (REPO_ROOT / rel_path).exists():
+                broken.append((str(md.relative_to(REPO_ROOT)), rel_path))
+    return broken
+
+
+def test_all_raw_github_urls_exist():
+    """Every raw.githubusercontent.com URL in a markdown file must resolve to a real file."""
+    broken = _collect_broken_urls()
+    if broken:
+        lines = [f"  {src}: {path}" for src, path in broken]
+        pytest.fail("Broken raw GitHub URLs:\n" + "\n".join(lines))
+
+
+def test_template_directory_lists_all_templates():
+    """Every .json file in Templates/Torbox/ (non-deprecated) should appear in the master README."""
+    readme = (REPO_ROOT / "Templates" / "Torbox" / "README.md").read_text(encoding="utf-8")
+    missing = []
+    for json_file in (REPO_ROOT / "Templates" / "Torbox").rglob("*.json"):
+        # Skip deprecated templates
+        if "Deprecated" in json_file.parts or "Nightly" in json_file.parts:
+            continue
+        if json_file.name not in readme:
+            missing.append(str(json_file.relative_to(REPO_ROOT)))
+    if missing:
+        pytest.fail(
+            "Templates not listed in Templates/Torbox/README.md:\n"
+            + "\n".join(f"  {p}" for p in sorted(missing))
+        )


### PR DESCRIPTION
## Summary

Resolves the tractable low-priority issues from the full repo audit.

### Doc consistency test (`tests/test_doc_consistency.py`)
New pytest file with two checks:
- `test_all_raw_github_urls_exist` — scans every markdown file for `raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/` URLs and asserts the referenced file exists locally. Catches broken template import links, missing assets, and stale doc references without any network requests.
- `test_template_directory_lists_all_templates` — verifies every non-deprecated, non-nightly template JSON is named in `Templates/Torbox/README.md`.

### Test workflow trigger (`.github/workflows/tests.yml`)
Added `**/*.md` and `Assets/**` to the `pull_request` path triggers so the doc consistency tests run automatically on doc-only and asset PRs.

### Formatter quick comparison (`Formatters/README.md`)
Added a `⚡ Quick Comparison` table at the top of the formatters README covering all 16 formatters — style, name lines, description lines, and one-line key feature. Lets users pick at a glance without reading every entry.

### Orphaned PNGs (not in this PR)
`Assets/auburn_tiger_preview.png` and `Assets/zenith_diamond_preview.png` are still referenced in `GALLERY.md` on `main`. PR #62 rewrites `GALLERY.md` to use SVGs — merge #62 first, then the PNGs can be deleted safely in a follow-up.

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_