### PR TITLE
docs: update all READMEs, CHANGELOG, and ROADMAP to v2.7.2

### DIFF
--- a/Expressions/apex-iqr-pses.md
+++ b/Expressions/apex-iqr-pses.md
@@ -1,4 +1,4 @@
-# Core Nexus 4K Apex — IQR PSE Expressions (v0.3.0)
+# Core Nexus 4K Apex — IQR PSE Expressions (v0.3.2)
 
 Tukey IQR outlier detection applied to every ranked-pool tier.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/brevityA/Core-Builds/validate.yml?style=for-the-badge&label=BUILD&logo=github&logoColor=white&labelColor=1a1f27" alt="Build Status"/>
   </a>
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://img.shields.io/badge/RELEASE-v2.6.3-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
+    <img src="https://img.shields.io/badge/RELEASE-v2.7.2-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
   </a>
 </p>
 
@@ -276,7 +276,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 ## 📜 Version
 
-Current: **`v2.6.3`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
+Current: **`v2.7.2`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,8 @@ This is a living list of planned work, active development, and recently complete
 
 | Version | Item |
 |---|---|
-| v2.7.1 | Addon stack cleanup — Knaben moved to last P2P slot, `torbox-search` disabled (deprecated in AIOStreams v2.30.2), AnimeTosho + NekoBT enabled across all 6 anime templates; applied to all 33 active templates |
+| v2.7.2 | `size()` floor guards on BluRay REMUX PSEs — 15 GB floor for 4K Remux, 8 GB floor for 1080p Remux; applied to 4K Apex, 4K Pro, 4K Essential, 4K Hybrid, and 1080p Hybrid |
+| v2.7.1 | Addon stack cleanup — Knaben moved to last P2P slot, `torbox-search` renamed-addon fix, AnimeTosho + NekoBT enabled across all 6 anime templates; applied to all 33 active templates |
 | v2.7.0 | Core Nexus 4K Hybrid — new TorBox + NZBGeek Usenet template; full 4K, full HDR, full lossless audio |
 | v2.7.0 | IQR Tukey fence PSEs rolled out to 4K Pro, 4K Essential, and Hybrid (1080p tiers) |
 | v0.3.0 | Core Nexus 4K Apex — IQR Tukey fence PSEs (Q1−1.5×IQR / Q3+1.5×IQR); three-tier adaptive gate with thin-pool and new-release fallbacks; replaces min/max approach |
@@ -47,7 +48,7 @@ This is a living list of planned work, active development, and recently complete
 
 | Item | Notes |
 |---|---|
-| `size()` guards on Remux PSEs | Add file-size floor to Remux tiers in Apex/Pro/Essential — filters mislabeled fakes before they corrupt the IQR pool |
+| `hasSeaDex` + `seMatched()` anime gating | Adaptive anime quality gate: if SeaDex data exists → require SeaDex-matched stream in top tier; else fall through to standard sort |
 | `hasSeaDex` + `seMatched()` anime gating | Adaptive anime quality gate: if SeaDex data exists → require SeaDex-matched stream in top tier; else fall through to standard sort |
 | AllDebrid template suite | Flash + Speed + Essential variants; natively supported in AIOStreams; biggest unserved community segment |
 | Samsung TV Nightly → stable | Gather community feedback; promote out of Nightly once validated on hardware |

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -6,7 +6,7 @@
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v2.6.3** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v2.7.2** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
 > 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 
@@ -132,7 +132,7 @@ Flagship 4K build. Full addon stack. Targets DV/HDR, TrueHD/Atmos, BluRay REMUX.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-4k-pro.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-pro.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ✅ cacheAndPlay + nzbFailover |
@@ -141,12 +141,12 @@ Flagship 4K build. Full addon stack. Targets DV/HDR, TrueHD/Atmos, BluRay REMUX.
 
 ### 🎯 Core Nexus 4K Apex
 
-Adaptive flagship. Identical addon and ESE stack to 4K Pro — the difference is in the PSEs. Instead of fixed quality tiers, each tier sets its bitrate floor dynamically at 85% of the lowest ranked stream's bitrate in that tier. If ranked streams exist, only streams meeting the floor are preferred. If no ranked streams exist yet (new release, < 60 days), a median-cluster fallback shows streams within ±25% of the median bitrate. HDR and SDR WEB-DL are evaluated separately so HDR streams don't inflate the SDR floor.
+Adaptive flagship. Identical addon and ESE stack to 4K Pro — the difference is in the PSEs. Uses IQR Tukey fence filtering (Q1−1.5×IQR / Q3+1.5×IQR) to set bitrate floors per tier, with a min/max fallback for thin pools and a median cluster for new releases under 60 days. BluRay REMUX tiers also enforce file size floors (15 GB for 4K, 8 GB for 1080p) to filter mislabeled fakes. HDR and SDR WEB-DL are evaluated separately so HDR streams don't inflate the SDR floor.
 
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-4k-apex.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.3.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-apex.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ✅ cacheAndPlay + nzbFailover |
@@ -160,7 +160,7 @@ Adaptive flagship. Identical addon and ESE stack to 4K Pro — the difference is
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ via Newznab (opt-in) |
@@ -174,7 +174,7 @@ Adaptive flagship. Identical addon and ESE stack to 4K Pro — the difference is
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream-firestick.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick.json` |
 | **Resolution** | 1080p · SDR |
 | **Usenet** | ❌ |
@@ -220,7 +220,7 @@ TorBox Pro + NZBGeek. Full 4K with maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
-| **Version** | v1.0.0 |
+| **Version** | v1.0.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **HDR** | ✅ Full HDR — DV, HDR10+, HDR10 |
@@ -238,7 +238,7 @@ TorBox Pro + NZBGeek. Maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ NZBGeek API key required |
@@ -256,7 +256,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-4k-essential.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ❌ |
@@ -270,7 +270,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-essential.json` |
-| **Version** | v2.6.3 |
+| **Version** | v2.7.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ❌ |


### PR DESCRIPTION
## Summary

Docs-only catch-up after PRs #73–#75 merged. No template changes.

- `README.md` — badge + footer: `v2.6.3 → v2.7.2`
- `Templates/Torbox/README.md` — version table updated for all templates; Apex description rewritten to reflect IQR + size guards (was still describing the old v0.1.0 min/85% approach)
- `Expressions/apex-iqr-pses.md` — header: `v0.3.0 → v0.3.2`
- `CHANGELOG.md` — `v2.7.2` entry added (size() floor guards)
- `ROADMAP.md` — `v2.7.2` added to Recently Completed; size guards moved out of In Progress

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_