### PR TITLE
fix: re-enable torbox-search in hybrid and apex-torbox templates

### DIFF
--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -2340,7 +2340,7 @@
       {
         "type": "torbox-search",
         "instanceId": "5f6",
-        "enabled": false,
+        "enabled": true,
         "options": {
           "name": "TorBox Search",
           "timeout": 3000,

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -2194,7 +2194,7 @@
       {
         "type": "torbox-search",
         "instanceId": "5f6",
-        "enabled": false,
+        "enabled": true,
         "options": {
           "name": "TorBox Search",
           "timeout": 3000,

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -2242,7 +2242,7 @@
       {
         "type": "torbox-search",
         "instanceId": "5f6",
-        "enabled": false,
+        "enabled": true,
         "options": {
           "name": "TorBox Search",
           "timeout": 3000,

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -2341,7 +2341,7 @@
       {
         "type": "torbox-search",
         "instanceId": "5f6",
-        "enabled": false,
+        "enabled": true,
         "options": {
           "name": "TorBox Search",
           "timeout": 3000,


### PR DESCRIPTION
## Summary

Reverts the `torbox-search` disable from PR #73. Re-enables it in the 4 templates where it was switched off:

- `core-nexus-4k-hybrid.json`
- `core-nexus-hybrid-lite.json`
- `core-nexus-hybrid.json`
- `core-nexus-4k-apex-torbox.json`

Statistics (`statistics.enabled`) confirmed already `false` across all 33 templates — no change needed.

## Test plan
- [x] 120 tests pass

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_