### PR TITLE
fix(nightly): replace "order" with "direction" in Samsung TV Nightly sort criteria

### DIFF
--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -1163,7 +1163,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1222,7 +1221,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1281,7 +1279,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1340,7 +1337,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1399,7 +1395,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1458,7 +1453,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1517,7 +1511,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1576,7 +1569,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1635,7 +1627,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1694,7 +1685,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1753,7 +1743,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv.json
@@ -1170,7 +1170,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1229,7 +1228,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1288,7 +1286,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1347,7 +1344,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1406,7 +1402,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1465,7 +1460,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1524,7 +1518,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1583,7 +1576,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1642,7 +1634,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1701,7 +1692,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {
@@ -1760,7 +1750,6 @@
         },
         {
           "key": "encode",
-          "order": "desc",
           "direction": "desc"
         },
         {


### PR DESCRIPTION
## Summary

- Both Samsung TV Nightly templates (`core-nexus-samsung-tv.json` and `core-nexus-samsung-tv-4k.json`) had `"order"` as the sort direction key at index 8 across all 11 sort sections (global, movies, series, anime, cached, uncached, cachedMovies, uncachedMovies, cachedSeries, uncachedSeries, cachedAnime/uncachedAnime)
- AIOStreams rejects `"order"` on import — the valid key is `"direction"` only
- This caused both Samsung Nightly templates to fail silently on import with no streams showing
- Version bumped: `0.1.0 → 0.1.1`

## Root cause

Audit against updated AIOStreams docs (`sortCriteria` schema validation) identified that only `"direction"` is accepted — `"order"` is rejected at import time. 22 invalid keys removed across both templates.

## Test plan

- [ ] Import `core-nexus-samsung-tv.json` into AIOStreams — confirm import succeeds without schema error
- [ ] Import `core-nexus-samsung-tv-4k.json` into AIOStreams — confirm import succeeds without schema error
- [ ] Verify streams appear on a Samsung TV device

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_