### PR TITLE
feat: add hdhub preset to 12 full templates (v2.7.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## 2.7.5 (2026-06-13)
 
+### Added
+- **`hdhub` preset added (12 full non-Lite templates)** — HdHub is a TorBox-native P2P scraper (`tb_only: true`) that serves movie, series, and anime streams. Added as a disabled-by-default preset with `resources: ["stream"]` (no catalog bleed), 5000ms timeout, and positioned before `torrent-galaxy` in the P2P block. Templates: 4K Pro, Stream, Stream FireStick, 4K Apex, 4K Apex TorBox, 4K Essential, Essential, Anime, Anime 4K, Anime Dub, 4K Hybrid, Hybrid. Enable via AIOStreams addon settings if your TorBox plan supports it.
+
 ### Fixed
 - **Addon timeout tuning — all 33 active templates** — Every preset was set to a flat 3000ms regardless of addon characteristics. AIOStreams runs all addons in parallel and silently drops any addon that exceeds its timeout, so an undersized timeout causes silent result loss. Key fixes:
   - `meteor` + `newznab` (TorBox NZB): 3000ms → **10,000ms** — multi-hop usenet sources and Tor-routed paginated queries routinely take 3–8s; 3000ms was dropping nearly all usenet results silently

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@ This is a living list of planned work, active development, and recently complete
 |---|---|
 | v2.7.5 | Addon timeout tuning — per-addon values replacing flat 3000ms across all 33 templates; fixes silent usenet result drops on Meteor + TorBox NZB |
 | v2.7.5 | Dedup tiebreakers explicitly configured — `torrent_seeders` + `usenet_age` (`before_addon`) added to all 33 templates; formalises AIOStreams v2.30.3 default behavior |
+| v2.7.5 | `hdhub` preset added (disabled by default) to 12 full non-Lite templates — TorBox-native P2P scraper; `resources: ['stream']`, 5000ms timeout, `tb_only: true`; enable in AIOStreams addon settings |
 | v2.7.4 | 📖 Chapter badge added to Elite/Apex-v2/Nexus Prime formatters and all 33 active templates — BluRay REMUXes with embedded chapters now visually distinguished |
 | v2.7.3 | `zilean` + `meteor` catalog bleed fix — `resources: ['stream']` added to both scrapers across all 33 active templates; suppresses scraper catalog entries appearing in Stremio instead of playable streams |
 | v2.7.2 | `size()` floor guards on BluRay REMUX PSEs — 15 GB floor for 4K Remux, 8 GB floor for 1080p Remux; applied to 4K Apex, 4K Pro, 4K Essential, 4K Hybrid, and 1080p Hybrid |

--- a/Templates/Torbox/Anime/core-nexus-anime-4k.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k.json
@@ -195,6 +195,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "instanceId": "d0ab7d2b-269b-4aa1-8696-f286186a2951",

--- a/Templates/Torbox/Anime/core-nexus-anime-dub.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub.json
@@ -195,6 +195,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "instanceId": "d0ab7d2b-269b-4aa1-8696-f286186a2951",

--- a/Templates/Torbox/Anime/core-nexus-anime.json
+++ b/Templates/Torbox/Anime/core-nexus-anime.json
@@ -195,6 +195,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "instanceId": "d0ab7d2b-269b-4aa1-8696-f286186a2951",

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -2264,6 +2264,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -2144,6 +2144,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -2262,6 +2262,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -2164,6 +2164,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -2263,6 +2263,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": false,
         "options": {

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -2263,6 +2263,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Single/core-nexus-4k-pro.json
+++ b/Templates/Torbox/Single/core-nexus-4k-pro.json
@@ -2263,6 +2263,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -2171,6 +2171,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -2161,6 +2161,24 @@
         ]
       },
       {
+        "type": "hdhub",
+        "enabled": false,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
         "type": "torrent-galaxy",
         "enabled": true,
         "options": {


### PR DESCRIPTION
## Summary

- **`hdhub` preset added (disabled by default)** to all 12 full non-Lite, non-Flash, non-Speed templates
- TorBox-native P2P scraper (`tb_only: true`) covering movies, series, and anime
- `resources: ["stream"]` — no catalog bleed into Stremio
- `timeout: 5000ms` — appropriate for a P2P indexer; not a Usenet multi-hop so doesn't need 10s
- Positioned before `torrent-galaxy` in the P2P addon block
- Users enable it manually via AIOStreams addon settings if their TorBox plan supports it

## Templates updated (12)

| Directory | Template |
|---|---|
| Single | 4K Pro, Stream, Stream FireStick, 4K Apex, 4K Apex TorBox |
| Essential | 4K Essential, Essential |
| Anime | Anime, Anime 4K, Anime Dub |
| Hybrid | 4K Hybrid, Hybrid |

**Excluded:** All Lite, Flash, Speed, Nightly, and Samsung variants — hdhub is a broad-coverage scraper that suits full-quality templates, not speed-optimised builds.

## Preset block added

```json
{
  "type": "hdhub",
  "enabled": false,
  "instanceId": "hdhub-1",
  "options": {
    "name": "HdHub",
    "timeout": 5000,
    "resources": ["stream"],
    "mediaTypes": ["movie", "series", "anime"],
    "tb_only": true
  }
}
```

## Test plan

- [ ] Import each updated template into AIOStreams — confirm no schema validation errors
- [ ] Verify `hdhub` preset appears in addon list as disabled
- [ ] Enable `hdhub`, run a movie and series query — confirm streams return and no catalog bleed
- [ ] Confirm Lite/Flash/Speed templates are unchanged

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_