### PR TITLE
docs: expand expression layer to 7 — Audio Pinnacle, HDR/DV Priority, AI Upscale Exclusion

### DIFF
--- a/Expressions/core-builds-expression-layer.pdf
+++ b/Expressions/core-builds-expression-layer.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 7 0 R
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R
 >>
 endobj
 2 0 obj
@@ -17,7 +17,7 @@ endobj
 endobj
 4 0 obj
 <<
-/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+/BaseFont /ZapfDingbats /Name /F3 /Subtype /Type1 /Type /Font
 >>
 endobj
 5 0 obj
@@ -27,7 +27,12 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/BaseFont /Symbol /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -35,14 +40,9 @@ endobj
   /Type /Page
 >>
 endobj
-7 0 obj
-<<
-/BaseFont /Symbol /Name /F5 /Subtype /Type1 /Type /Font
->>
-endobj
 8 0 obj
 <<
-/Contents 14 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -52,7 +52,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Contents 15 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -62,69 +62,107 @@ endobj
 endobj
 10 0 obj
 <<
-/PageMode /UseNone /Pages 12 0 R /Type /Catalog
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 11 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260613121154+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260613121154+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 12 0 obj
 <<
-/Count 3 /Kids [ 6 0 R 8 0 R 9 0 R ] /Type /Pages
+/PageMode /UseNone /Pages 14 0 R /Type /Catalog
 >>
 endobj
 13 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1812
+/Author (\(anonymous\)) /CreationDate (D:20260613133514+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260613133514+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Core Builds \204 SEL Expression Layer) /Trapped /False
 >>
-stream
-Gatm;?$"^Z'Rf.Ggc&mn&XN@NLYZ[VF>qlJRg.42@G(n)(<2?=]TO;P^Y^PMN7/Ef:'q*CZ@1't3;6ZD_8/(<hru';D$&2\'I\TE$.L1@,TgE[N;adDm`p?F+D*?^d#/3iK,C4"I6MrZU\tYaZ?`KuKFkL\%3Sdu+p2Eh=_.#8kRp?fN7X7%-L[`Cn?spk9YZ2?.jSbHnb<lAnFLWAJiFhH5[;WZiWr(_%k$/+JTZ`NG<CX7[s)KY:b/5^+Y3?'[mIo_Yn6=PE=UhgHK(05oQ1Fmcl]h@7M0]i+;(b:(e/&RpbiD-(BgV)g+!:RLaXI+"]<bQnQrX2dT/;I%J/6X&:I@nDDBZN/>[qdWjhO"!t7M@F89P,.)FMj,!<;Z,0[hC7U]cAglMLAFj96a#eXFG/jqSt>D:23iD$@[6_XoomZMIUnPMEU)Krj24X2,DcHbOP[M$@q(@41JiM,X%;[F5uY<E.42L*QuL`cpcFHB<PG0D*<]TC"TT;0P4=G%F.,`6&pU_;fcia].qVssYH%Inq,$(0G,$Lt9kD'G0DTcoV6],"BKRF%o_DM<gW-*Z[U$`T#rW%c?N1*[J,U6N(,TWKt[^3O27SPUj4<MU(TA0n\"Q.RI5Jga&oiId,CdWQ).:EsY:95>j4l\gEH3Ih4fnFR38Pl]2dZNrRp2,pl4<8J":eo%tjBtUdp\B9--"'K%jT1uNZF#fkDDMpsqR.58U"N#6p(f)aQX(k86.J(1dr3d=#H0Y/gH_tn`#"NTN8JoI]$bd8_C[:=DapIPPi\>V\aJQD#;Qbe6$;!bj+"m$cPJ94!3S*8or3l3f6fU:0DeuBdEpWJqk?.mfN[G<b1(.DRI+pS-c2,+VG@:,VG5^RZh_9cMRnqYB)n>$62_-3/I.\bV91.c&h8>rcm'J$IU$#>s0(ZdOWNc)5i*(@m#cf/9<EcgKZDl<7K>8RKisJ"XT>JRUVcF]Gc/4fOd/6BOi!.Jg!QRX*@fZ1R!<p^#:NM&lkQ_?%:Pb\W?am&$>!,r`-mW]oTIe(009E5;V-C#+FEB6`ck/_RCf67ZGe)d;NU<j64;GXNWsUAn1SZVuE*G6s*;FsdYP(j;*d6)+QGjcm+bM(95LcUBW'sig-l66JAgLYkZS4lBNhj=>>L]7=gkgc'CWdYI9*aF>Rn@n;Ra3fA-A(<sqH"&IJ]`]KZn/&t+E(,o:jgXm,JMa$`@Jl/)Mp=IZl0rP%9B,*L0ZV`j9bQn0<+JKEeF'o,Lr?6^<j%S;haq^,DEjN;#0)n_X5JM2gm3=hJ(WD"9u$5l<=u%lCohI'j'.hq)oPl&+KX*G#PPCd7pmN&iIspYt='pLD"3F%!Q0=d:<A4Qhu:Q$\`[W4DJg\#oj>,2I+(]CXLhdAs>U+D/D@gJdo$&J/)1KN^B&$[VT&CT(dN"UhJYE.k<Qf>@XY2EYrbj<c*O``]4]FkJt,m`X%hB9ri47,Nm"VDTm'"Htr_/O;0^\&]A^(7dp^n">A`QQ^'7WgJIEc=p-M5n\*V`[A_:p`km.g3;BOcOgg3,AoLg<@+p[\g;u2=kf>/eW&_FD_u2:S1iYUFNnI7,n]V9H\\Pl:"["lGi!b8;d2=":!s-H+T@E<8[i@%MU"RteS8inCI`QgYFs`<t%QWNH(Opjg`O\90*eY;f>-R8E:+iI%&,EO\QF!]^`M@:o`M=,,Do?+j(+R?lfBnJff8#8ck8GXO4:G97>(:\=bAqtomX(\WJb-P\R+m+3I]j8Wr-E>#m.%gk59K?j!`uL#i8X'Prd>B0O['#?in72#mPgmLs%sgqUG2NdIJ+Dk~>endstream
 endobj
 14 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2079
+/Count 5 /Kids [ 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ] /Type /Pages
 >>
-stream
-Gb!Sl>Ar7S'RnB33,`fB=:o\`>$s]N::mV[g;_ltc?l39g/]G^.OEWm*qn?484p1X3,T]p^b?^a/5\MO`UDSG&[:duo`+.gi;!Z(0*i*o7Pc0Yjh^-i$qEfpN_"S2i*'P+q(@><BTX^!E#oKn[VnY<Yj;?S+W_jI#=6Xr3)9&bn:K!o8`2rX:F(SGl&i)Bi[kV>X\kYDQnU3BGRo8J%+6aK(V)p9%PCj&(aoJLgGsi4B,I0h>9E@H[c[g[YEuuPXP]Ih4(dA+fmadXK#:#,6k$7k.cWUQ>S:3B65gt^i4-K7JJE](>kPX]8jWVQ+O[3k7NGeF@I,rs%'QRC)7(/4$d%V<!U^E#1Wf2M&U_c*I_ieFgV?%f3[0k#.nu09b;DpNUi<:BI+Up&+8B.4M%b0URmk!2<eiBu6ILrk_Ck`NCiB0,n'st3BDa=-LE4)_=<$S>04cJNFsfq8cuMM.7XIm_'+WN0!Kn6&3+*1PhG#i^_@<e5""2c'`etfbY96X94CsUM--_g1R1r;].F5ir:b3H$7UDqqUe+n..Oc-pMH0[L8^jK65Y-^S/5<"K?neG+"`&OgB-uaV>T2?Wg:1V]Q5'h+;'*U_Z"+#5is8PIP(R9E:ugXk;`?SWqbf1P4k9>%/:b/O;js8VAQB@8Z/VEG(Wh&U;:)DL25hQji4Wf*"\<Oe\`(W.D'-XYCU&HopIiT.r7eT5p30p;!r%Tr!tCO*/bFq^RR=t$E5DEc16GO:kN_dfUG(:Xj>p9+%4W.#0`.UnCA0_YNg2>MS=oDd\H@'5WZsZ^$*+2lC@F!O(e(OO"r=j+YaT_;]/Es@2\Xh!.r_KOT8@)mA[71?=H.Co>R?fL3SlQkE$382Y#=%-1;2TW/mlul*ZVcgECcg@*1GN)!ZLM)_VZ1M4.]XeCsMTkPH^pPB_qMpJ^`M^32%.b9%!N>n;N'`O:lhk=#?c*e\4LX@q>@Ko_S`grlXJYmCda#\b3ton`t5$[uDERGED:lZ!^f??$W(-&DXmRf3%GFf!BHeWuN@F:/Vh4cf38^Y0qBWG="LP3l5$(cQS]B--A9J@PXY+.u9DB$o@mkTWF&7WPcXt=H1kYN>rS0MJp%J_'dm`F@s8.<CL7("^ZBUc^FlIA&.VX[gAWb\9F!ilg2%dGd_7S0RtQ4`"t%]BQ.#le\F#dSE#=3O+%X$^4ur[\G5A*()@u$k!>r^L^#q*h:bDkT#6`53?+H>0^`Z'a$%`1fE$qXojD'9`_C=mT:G#%`pC9X"g=?"[!Ab_`++u>O7A[Bk!'L8Ytgc?lGo6P%bO@[$Hm4hg,1tsBUtVs%$RG$^AF;DWj;FPOEM5n)pK(Iq`RojL]d-gXf13u-O8eFE&6+"gG>1+"d'Il7!+&>F)=WgDWLc*jmV"_o+:`p>L#3O61:Yk-k`]Jds_Z!>H.E1p$YW=#HM3EZ`NOp^L#8=CO!;&qK;5<H&&BVBQ1ITlJ!)Z,;2=G'pd?)e$PdR.CJ3+X8$!JU2Ne2m:]H2mS$q4BrZ;hh$D7<M+s-DbCl2cg(?-*-`utt%qTN9m3*-BW.LeM=fL7q<i5YuR=ThYmaH6A67Frk>[`tQWnW+KQ"ee;R"`)H';Lr5XC-FHbkP-gZP4pfP3,\:qIN\imDpPhn+'B-Z7npcV:;_`r$7c;j=:^;BT:qbFpY5=T[t7^M<$f'Q5=EP=>(G+HBkOs<PA:>6*a$kg^U'J_`qp'a$&1_#;.R3a2P^KE:WV%IdJ9'e3h_X[sa8X75qbc+1l&ID\09G'al!c+Ki/n7Fr-?=W.f#Znq,YWT%oiZW6079?LqnYQef2%EG`hF`X7(FP[@<"5fPI^4U28/#FT(']j]C\^3:pZ6^bV5;"'iZZXTeUj:M2`@FCWIoJOK"n"37jYADA&26_mP`u)udB=9S"eR+4;X+fmNe'pTF)c'RMS3N#^X:@%j=ngl3ScfYB+GY6A.[P.q?PjA+7*;3#H4BrK<g7,gL\W8%0A#K.0`>JmM)Yc'8n>MD:`uTCa/`Nm!,j3W#j;L44]6TrU.mEUM'=Cp&3;;l/A"*rqu()`sXdF05u*DT-X%im3`nP$^Y54_#~>endstream
 endobj
 15 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1739
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3199
 >>
 stream
-Gatm;bBDT1&Dd46C,<o_`sB'uoN9fW1RXZT3D!VA=g2U5%4DgOdbP8hn)nj%,THo33,jg_Xh*&*X)=1?\bIrWS$%V9Ai0@T&bB\E+;Qp;c!Je.G4FgKm8etU'1L$qVoXo=Q@oS$_dg_-]1G\V)r_OiR(.B3Ed:OA[D8O[N1>]X@iF>n$<g\A\CMpklqq&Hl93+^\4+4PI+pS^k;o,<_ghuIXb#+A(q@Bsbs'M@g=U_(Df797S[!>9XP%T+eitj8?Y(FXa^UC1\L>oYh,T`g6Cn>O=ldM[mBIYLbo;_c)$c#a*J%d!Mp!NRYeGg>4e9sTo-/K4`Bm*E17Dr,pj.u_R!bm0:b&Zk,Hgru^CO,Fhu7W3S2"k38M7,lQ<YnQC0uI3N;R\fLj\>2!I/[Q[Hk%F$mN,-T7u\6qr[1!l"A)*(<I*@4:CQ89J48sZ,,`qes-jq.>f@jO'FW@Ua%=K4Wf64Yt<_p@LMo5lmo)P[1&pl>jt]@H9$7p:V=p8p)PC=$8P*`?O<<$[D:%6&tbWj1G;.q'lA!)b"L/56&MiLI;4"hl`DngE=@H"U=%ndF=sA!+\'J!-Aq`-O9ZQ#(,?W4L7-na-Jq61+aUn#;/Pg>6`q`e_Br?>PHX:EC(;JH$;9<o-I;=!Qr^'#o"7BeiOfl(nO;,*(0.mb@elIWO?%Kq=U>YAF=$agMu>p5Q*]TkKqk0%]S$t&cf+h6[@pjSVNN%O\&nC#?U4U->o.,E\jAU$DJ_`SGrSB@\jG&6X]e0bJbYBD9pV,=.e3hdj`WHqr.Xo$^N/NrQ'G6h=#?(Y]@affr:BB,f&HSKh=/Ca&IraN\tdm<KY#!Om1*`pFVu@-Cc6l>P:a<haifa>c`G$kFD.+D[4nXT>!3.T+N5+6Y&b%^qn8!U^8rdfIoG[gIX<'aQ^."*l`+[.T9lP@Oq%aTQeLAd]\i0Fji\9>X%`YdbDu'Pamjg+9!afFH\>ggA.ldQJ-;#+c0#e,rs7r!f^Q!E)uQB@)9S6q7#+SHW$'5!`/EX@">LKF)DN<bn.ZbJP#\hnd8E;9(/7YBOXR-(T'_]n@o-ZVoFm:>7e%LK-hrOBW;*kXP&DCd_;PK$Sa?TBqX5I.Ql@+?!aP\308M';T>UMI!e]YsAI#P/nUeh&K5i`n!!f-a(A`,R86W6J+q)CAf]`1]ZuA1&[?+#^'sJE65EPU7?rmU)5q/*JPPJUqG,H#F_(J7?=#UIt$d%W$i*KK,D+6[;GhHh(>HX=TL95$6AgHC,jq8#0/q;T]?;s\2Ggs'#e1U+pAF8QNlQ#]1pmh`G@k"j8)%le3d6$euhabF/HH1H'?Th%?9[t3*K=O+E&"XF]?@lm<h!;lJ"dm?J?9l^sCA^(H<Pk#M>"tMH7e-6%l7qmZDuTM5jrNH2>N6<WV]n?I*S27N*_LoLK@rjF6)%;H<mNK#U:%B\1p,>O+kC7'1VI_Hf>AJm'cD^'R\q6G9ETu4ecc0uF,WI?\g;I\[Wf0didD!BG>2CSM@.):6t_7lWnp\@>'G-!(3[l[bH+4'9IFTIVtn/Y(^bm#)UY9oUieUL1JnPXPT&pr=3G.u9F#?[I[2L2@E&bi_J"d_E)G\0BP*L*Xg+URDX'#0]VE9%cZA.pnKCDo+j#KZ6i,Vhp:]C"UAXtGeuH#kG[b!<j`+`RPL3bE?^h9*ClBF2pl+dV*LW9)G;5Y8k[K<5IXm6`$eo<D25MGAotpY[LQ<$jS#2,D!Unn`P5~>endstream
+Gb!l!>>s9I(4PFJS<kgt'F=A#\!a8P,(q48D?N)6<O;$ZgMVXUABAOWJH,S<etj\3(7#7ae7=bnh<J%5n(c7R%KROKP2c4X!Ush47rJYE$KF,XDK-MCJCF&Ff0.<#m(`kLG4CWKT7K]<(Y&+a>eKG,N^Z+O"eQIOpMm0q0RpY-"lCU@(!!Xsb$5:F@p?ZWF/7KqJGEdXdOo2FYQ>_^`+B15rh>5o?t+@?,W:Sta8lHJE^2L2io+K55/GniN(t!Rp*pTJ=o&3>^Vfgm^=ZS?%"INX7;3\Wj/#T-iaW'5?K32H$]j=OK^fu,jXH)^I]6kHL.Mdq`(I$6=D."'^hg1`bc-+Q^<H]nR#COArAAtuKSKm^%6V\9!hZ6J.rjZbQ7Uthm.4ecUfaE8%G2@A.)u`-G*X[&R6u-B@4W1LA"aO^S4uC$UG/!gU[IjS*4^WUno^L0)fa9bl32M1%Y&r\ZO#iY3FG]N4BI$,!)WM.D_"1\!;D==WR#Mp_.>9JT38Vi"`*a%]mtHAJbBW37Jd=JfFB+@:T"0A%`2K/!@u85ih1B']@aI>8tcI$;+';b2,P/<fhJlU[_/9dP+n'D'TJp<Ch%RH,BT9RBnt'N@^\du":iHp&GQIT=U\dTMTB2icECZM%Rk-r)Gbnfisjt];e%hK6laC<J^U)qK>K`-C.d.-BZ\Z/N*)#t]bS^[9q=.WG[0$K\&dg&5ioI!JShq[0LG:J+7;hp>=jf@HR'%s$>m9)*<7/g^mIS#J9&tZ&:d7kNZX36r:W)]Ca]R!'PqHkfLVSW/)3&DM/E9f1!@jI$c+LkoD:n[:l!4D/hNO5KHhKL9q\S[gRZB.Z`^]FI2gA/L`ed]=WE\['?Wp'd4^u?fpd#k<2,sB"#J3WTG4T$2M5c@95dd":Nk)2qkLaY/GQeLJ?H97c*)gjbN8Tn6EO9rXO+j)Jm'TZLUtJ_$sKYQ`J(26S(1H9T$m2okk+GQ]5@aQP^6G29VZt^B2BrCg1jf2^OEQ?K*QAGk@0K_lE#c?ZhVpAI2`n*0]d!qcuG-nRhdXR89W:*fK!#R/sU_s5:4/K)u/B]f]gXQCKs;\\8(SWMm$mn-n0;fY2QnBSXk:8$k9VrSK6$6$apgb(n$g:NVL+%BnIWn0p/'8l64>j![M)BqPFhh9WZtLf6&e)3U*#FM6r_JdDbAGn]?,;K(FoHkGK,80%)Sg;+Z4bdr1)WD%VirRW#/+ck7dNSJVp#S#Rs>*2dJ)3`BfB3--\/Fa#8r9RkX!b.tmX8*m8;l>mBf2<=;Hg$o:L[(F;'?J[6)<a+q5Qs8"E=gpCC=47\'86GnY[T"O.H=/XC*\S76,i*dnct.C"JV%c&W2BH_f^!NdZN0<]Q4jccDoV)1[OeS>Z]*:WLg=e-j!()F<j#sYYu=B%O"G\1)_#BA5DsM@a!UOr/ou:<PLU:/,)i^`3EbNI]iPn#_@2ahZKQNVc,@"`XX9jaBo[PV;In5qI)XGHd@FC9J?s;O`BA-N%!OZ*CR3bpBos23PC*^]8KK$+,cpFN'Ii+d,"lSt$O]/=d0dfK$ZAH\9i!\t[LsHkC:[K5(&pc=n+&Y9ZP:9di$_@[_^M$'TiME;i)5HanfF)g&m;m[T[=MI[O@>!D.PoV7u*n\(<(.aA[>-pkWe=[PrAAOIj2!N/rP)36)4'EA,Omt3A<">$V!+#qWkdRF?rrf??XlH$FhaM[W@4haYSO@-@)+eN<[2j]OuonLKrX]C3DIljYcnSeS$,V21AMZIPiUg/A6@LOJ:p]qplGZbfoL5.,$o<=)oaeJ)HZi8sWBB?bI:!!LH$G"Kl)/diO#O$`E1*pb,`-[Qhj3YabNPNTso%#cR?R,1s*j+/1Bnhu3VoKKcFYCe)Qui#*.+"TSGX&<'hV)Y<2,jOpeC/0cuhp_Cu3'4%^KJEE&NRki]W1;ke?H$.A:e8rQJICEq5R(]ILgXaLZg3sE"4#_5634g3n4t+2ON`o8A*qu:_hUqs_8CgS]pFRG*kD?-c9!S[Q_M)C<R[r%VH^i)r'L>cVZ(IDGUS7K(N;;]0`944:6@Y!4>H-'%h*cHQ^R4s?_2rR\5[$<r$M3a.-7\fnlZj@DPF:hZYj[r+9'+5)6p;!Bnm"c\(:PL-B2b('K7H+==rAcXef\0KAUdSGJf?h+ro.l?&JbRH9QY5(</AU"BX4>gG@J-hPF-02&GYqgq2#HbE8"3#GJ7FH:@JsTHm>j#S3X2PTl^NrFhg=Qk;H$MM^89>"PcmG<8FB'`!Riskfj`Vn=$d\[uk,48^OoFYE#kp'keK.0LaH88?JCEJQgs5-7YONHKFUh*,\iXU&DK[6p-BP`9?eufGmO)G3A^Ea`b=ngT8TAWJopNk/CG7[B?C-BnT6,,F2!pdCGEIEuAVh>LZD!mnCq)1JG4MW`+T5e5m!2M\dS\:o4#bEr3`n.;i5+Ac"$,8?l^G,J]:r/Pi*6`L`q4+D]fU5*3Onn(@#!'`/Sj-+7_FiBO6D%UX]>SiTrp!m6C+.kR%O2OpM=Y=>-p2NP`PUZ7EMI4><*b%!!f[;R"lQC_BSYfoJ"AjH/$LcOb22Mt4T*INpGX/,Gd+0u1n)4H7BB84sL`G.`<XnFjelQ&heXVi,/'2I_Rd:k3NC$1kIRYsJkQR5^;%+^%8.e.5Pmpa!PeFUB:N)Um`lXTSD\s0^:_;FUbJ3M:j_7<O#a0QZ;p7!I%B(.\pW]p`i>n[Xjl^R>LYeB#6g_63dmg2$RJ)bm-*r5`K?5-5aj1t<himG1:J(I-*M--Y:JU"nr@$J[jWk8U.Yu$?7'i+<nc=!pZ.Af%c:6er@1/W8urgSf)OM>q.?KI6td^Qs"Qr^Ig^as\SRmd(Hq%%L(1?/rc6/BAUfM8?4O"uoU3e3E)+YueF77*GYVlR!FWb[J?`8mZ)Jk<+GHL>Q$U+fdhoYm:sEegf%;MI$M'db^E1s\BP8ZKd?CE,i_S;qQk-th[3[lr\L#iXccICVH;c&Zl\MDofXbO5'Z5CbIH5q#ZV.jAuJJg38RD>\>MGTVhMem_/=DY=Q5n(m\K")^5WlYWn!a(\c>?Z>$kS8F;'=XV\seMeNgo>ZmH%SZH>#eW4V*<;:JcNl=dYVs0EA&i(TVp"S[IC<KP#(82m$p'n*2ZFB.:e/%SJd=mj#PNcVU(so?/GL>jGlA4&Mf/OAia@DWiAs3!3-=l]&H_=t$$EMJmf~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3306
+>>
+stream
+Gb!l!=``?=&UsJXka.NIY6\QUA"?67Z6a:1D8um*P=h3t+Yb6T%:W]bUA43+1H5Z]":<0u1YKi<PCpDlqO>2b5f\@BrBFWk>Ya5:RK,'MZ2e?J(/3T#e`=i=-^nr=^'C+pi1Gqb^.s%\P3%luc*i%)1L/Z8cQ\h@iR!7oin9M+31#lAfWM(jVIP/BR[WD!"SY$a["T/F*,QOa$%t,NeL]=X$#$JYp_K#Da!:E1?5Aos%?iZ@`r]?A>fc_cS5C3q3Lc%B&;Y!\MV+)(fNbanM-hEu,rF:M7qn8C\k]/!cVm:8G1UtjcfT>`@R9nEfe3r.Z02UGReV.8PM]g>9X=+S#9+Z]O3!'Fi$P(]>j0!,b<7!^qGCqU'^d&N[W(jI'BoMA!KEK;miFK6MLlZI4@P.$8=?])*$PUVCWbQ]9j-2&1rJ3H)CYpD/npJ<OL_rVF@eY6ph`*a@ocK$C_&)3AFPsc,-:%#K;+@#FkcMHk,Hi]95i+m<\[<MZkQ#38k%VX<iM=@=9k0H9*/t2^u+j-e&SR16so[0`kY?X&]<$jfCB."n#(;%k?7OsSu5`*AIl0&4-:Pn&]d>W/pC/:K@8\E+T$jlFR2=t]6mM.$r[7^mj_%7P]7TWc"ioT:DodSm_Rd$/ZrMd-jqAA*=Lu^.'?I?',(K$kBg+l-NT04-6+tB@C?!Bh1'tR`-rR#aZ[o`Rc5pBQq6^aB6b,d-nA66E")[M][r_rj7>)<Zh-7oGd\61#'1]\OKB@1,0&#lL*B9AU2811KOV@C7Z;peCa'oP5u)hWegpnA"Y^P1V77I71ul'Hg-[r@$[d/K9CO-;G6R-[0@4I`=5ruqW%!"^3[Cjt>Z.>H_j@DEnu]WDj?7\mi:5GGj'e(+FU9)J)bI9.Hp(ulaqN8e5lof\>8D1(SYo^\oj%Aa![=WFO%#Ro1kCTu+Zft/isu0)`7M)@;-q"ARW'0Vh>3q%Z/5G$0\ZL;0IdQ+7(O"'ZBUQI5[8t/"A3JR'V"WZS;'/\66<&'D&>leb`]7%Op[WVbZJ,f=H-'XaJ?q4>FtCga:85cOT>Hqg!13Oe:Lg[O2G[[S!,T1S0f*T:3;XC<0BI2^_A$AN6XYcYf*G;&n*@)WHpA-?F=N#OC%'+#p<!q/ZLSUaO(c$e@]5W2iLXs-ZbfkN>Vk.c)(8rQA6S/jq+s[AunDm3i)#?LRkQU2+pt2lDo!@(7$#]CM5oV'$Ia.:n4TVD"f$eEsO`Q.u%AK<dJ_@8r.peY_<smBLTm06<44.^a$cYb'("t!Nf3u_oE+*Bipk9)aucPbT8FU4ATtA\VM#K\Q97?N1]"TF7uEJTE@R.PEFaI7cM5(f@[d9^$#(6':-lS5*b)HUI/r_ef+]16hW(,RFOc-]AM>E8.aKe(H/<H'[0#W[]0grfc(saW]H*iH&RVQ6G2=O8Lj#FmM*SqMMn2)X%(Y>TduA4D+jJ:cg2-Q9W&s$j_.Jr2j/GO8CCSF`hX5!'ZPGR9=&IW2_SacXG*\1nWcq=.+jhqmC)J_:\:(]US1LV*Vhl20u`?_H6]ViXE5p-e'h0LS&T@CIdXgFDm-YJGLIa\Q@]?CT<=WcH_]mW1+\9h$sLno102*tF,=cK]3JU1/T"_%YkOnDR!ehr`LE=Cp(C_JKb")=[6e(Ho[O7<<'mPr\s60Hnlf?G3O<VQ$_u&a:s8:<Z.l`[BrHH\#!"$JAqpdr""`&>aD`(a=$fGW`_jmU02^uJs6+id0M#W,Afo0RrpHDF.;VEo/^Yfh<p89UJ?`4>_K;TK_D!.+gN<9+2CjN2?QOr+1`M-fTFk#L/&T9mGa`>c'lmmcGG4aJ=#((C0p<'*GVg4MZI#V%$jf=bjDbB_-K0+f2oKU%d$]gs.>DtbN;^QDCDeC.$u)Am$jiemcLDa:.g[_dh?f5EG/obFK>0iqj;\9<-8i@Y6_+Hl9c73qVf=%%imL9jLg2VB(\g<c!%#ggkX82CZW_H]X8k8]6J')["p3sW,(g%pfXWiG.8+QT9r5=`LNLP4$XDFl4RN9+XJA_<cm!]29oWps*k=3>C$P[fB%X9S,jd?:lTp]XboS.Pnlt8?qrTI`SolLVB,<]@GL)M&?eXZkU"OP;K1s0F+dl>"]Eauq59ZRsk3HT[;Q&L"cZ4.gcHabsP;O0:o"jt_\UK")FQ$B+&r#S^-TkT$;tW,+B:\N7]dS!E8LaRqhLe;P4!BT5Ku`*D*bVhG';"S]pt*:Xd!3JYR>*YNTmTN_au%nknJcIOgAFJjb-<!fMK2ms.-E=]W!?oR^UY%9`.%YX;+'\nZkPqMR'O`!j]ECpSaWYNbm+q.8=b#'D^\3qK4I910sr65-D8`s`'EHBA"PE3l;9E*](e#jRB[sjbp1$N-C<CDZ.S/%<=BM5=8BKLc]mCN$o(^Q9*IMD7i3"Lkd)LEQ?/#.%OOjATbH?Q$*JbTUHu`\YC]![9dn[lVSV_4a.F/FE<TbpMhs6uO=B`<7^pJl%$k<)Dra`qkZ4!CA?c9ha5@P\ho`b3&BaD`.IhiJki;HLhe)nCW,al8UrAT%T4.M#<.IVHds48iQ9^ld$TaX%3SP8+/ng\:DkX^XB)G,@fgCMg(sf,5\C:iF=e:Tlq2?LR:o5aBYb+qWlpJ"H%toAGl7YaQ=#AaIA"0j@?TkG#nik9E#eFT>r$%M\]R<V_U3cj49&)8o8:,;GREakE<kuE-;'7bS#A5UB0G[Y;-AY)o]Q>80@j"]4o&4K*K.;;*G>D2cX&8n3f_KE<CNjfK.^\NQ[:/bde$j+[dCj6DEPHm[Oq=@>TBuu>@g=0cH^)Tjf*C+4F5I]\Gd8i^@@2\e*Y!0n(FoleA_-6/7,kql:t`b"V<RtJ/uM]=P0JF^m<W/17_A#*'Y0`WOiqGQ\_:>"fB'EGmG9JMm^..YG3#'n%T>SsjJl#';<05(3tp\"%#f`km-+qA<;]c*p`D#,=f3]h]bCL:_pr54kF>!4/R/W^A1ZtPjDmt:!g1Ug#jTF$e+]hZ^&K<X\*c'7s0\psN"2hh#,p<$C@m;;B<tY1Idt!tiVHM;h9FJg04?oQd1"'e5#mpE`GYnKNoQ+c0cOAPGs]"0n`oMFs%rZD^UbE"H?4XE+*h*o!h_&5"$-?L]qDc+LlL&RSDVc!GSqhY@k"sWCZr#-Y?6TM,=t`kau:AYrD2uA.C:EX*4+Ti[Z[tA+FS;>J)o?^Eu&CKr[_E:dbog9SS4a^\]TTt7dB@c&WOuCc-J[64u)m@"96fL`Bo5HiMmln81V_;X&fmsr^t$q'!R#m4fV8[^I)l,!68rmqAlS2Nmf6[T)8h&2n.B~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3422
+>>
+stream
+Gb!l!>?BQM&q801W0]Y,#o;gWI<d$(/@1ON'(BH&^e7mL@jS]T(Voq6Vn-)6@N-24QCJ7A!OYPbY-,rL<F$fAj$+`;q[pW5.3-#I5U];B5YTFUkrUko^A.[odk0Bs6.9]KEU^00'@2F"qF)sm[QI3XNb*iY'$YRhd>Z!&eVd5u/u_mV*)3>c9u1fXc*_D?CHaG[M(b=m1o7>UKQJQk9ZOLGBT>ME'3Q*s,Q%.;-5`0Tdg5\XJg2laidKV-kigQ21?Uik/J`mZnCV*aRj?)`T"R12$.H(3I3nUbB`mh4rf"K[4M0`WUB,0Lp1)aNF;Hj_68n=i;FMI1NA@(Q@9E_)Ho:b,Z7m\-=/2-iZN?!6B#7rAYmg*a7E/Jp?bJSG3LfWPc5jR\1OmO0rHecf_D5W%=ra;qZhJru3=l=f]6Ys1cHe\H*ZQ5kHmW;^5]VPW$Bk;Pm*0eGmQb)`"H<Q5-VD^.h-WHo)stqENtn1%rX+83C3Jos2aDO%Gt(IK`1bl$nbNKLT))`-+<R90TFjQhgg^S5TpVP38lhm$A]gc)6rh'q3JUP!o6^ORL9[=-;E\EV4m<RnY&5Fj6;A6p>./2cFXB@9I)2id4=51hT]rV=klEuM>HUW2]97(mB(mksWRl76MqYa99_<M71+fJn[;cPO@aHlqr[h21O;lG6mHa1X!o,1^6;>^D9Qs:ur>)6R0/g"gBPMjj[AVP=,fLOW5T-$`.ahnT)n\ebT(7d9Wt8Je6[Hp\8r&0PMV_E?^C/C:`JqmthZat5/->hjgor>;ENtq:<p#]LoB/rn7/nrs@jBG@<TZ/,$5hVocZ97&9]n)jblZsXL%X`k5(/>]9Q)kT&@4#@KcV>B+@7ac)0/$Z,8?C\*eQ_pqJMB^R6m$dWW*@sLkR"uTNJK::@KFXR*hj7El_D%TgE^_4EY%l').<'"bAMA**O)]GRcP-FW8P_jk*@<`,$4-Hk'`5ZWu6s1Xt1(B$>BEF-buO/cle<X(d@+E!@-`rL"(Hm):Y^)+Yc5Z7'r+=W%<r<L0BEQRnW`1.981K.*,k+U:tPN(V+ZSL`GT_AM"Z"`Gn4ZmB-,&S`1q4Q_QpJ41[+#q;sGMl6>.]t6A+I6CQ"`'L2L!RtZ_'PcF-4t1+HbWpY]r$7:l*7@s)H#UH5[GR`rf"OZJTmZ+uW!Ut@;!/9X\!:9*TU2D,_3ZH!.W</_]UWEC%(V2ga"UH"/9&7_fj+28,=jgNhCh5a!.87lHk'tYgu.XG-':UWK"s^C->$`[XU*jH4TN9/aq8JiaH2b:&;GspL'aUf].O&!>eR%Z=/-6d[Sc;f4mkN",QZphIC&A/^$&ei^CC;.N?O&'q$L^76`3XrV>=b@?0eaq3h+H:AK,K$Sacm0KKDO6j818LM23&Rg]k_Q.16OmGuge2&7;J`a,;(`$Ub^D"5_h1H^)Y$FaoSF4/I8pGN]L]=0jHF5HOg<N@/7,`5TTeL&ZA=D<q'^dUrFs40l+ts0uuM:C8dGa=dZ+YV8BI"2FHF108E;*P&J8@u(2>98jSm0Jo/E5!#<@[)an+)WrQ&=@LGi3Ql@W(>c>sXsTX?@#fd\%Rg6I)Y:'oB`2ehntjdA\hnnd=OFO,;<3Q&(u>S=H1;]i9^Ia)Vlsc01H_^81a^2t&FWW.=dk'^rb#XI"#aoI)?9lj5-.#k,gCp/j<9?G#ke>uM_W)c$??FcLt\8;pZ!_IAA!(i\4t+B"H%GT)c>JKb7L]hQ9go!8\/0/e+eF_s4<7i^A&5%Dk"<kC25d`%,nKQ*:=C1hJKst@-<Y0'59qL&/L%,3Y(HnM:j8E*>3DI-/l'T\NPi)&hLLb^emf[H5mjrQ3b?\1f?VW#42VO99jorH9J4kT/P6_-JH1L\]3e.>dp1-^->_6]BdW2*U7HN@%87$g@^9L:1e7,jl,3aP?El`oa*kXQ@]$Rg1Itp5ig<3->5?r@"+T\`upD1+)W\a$s1K>c_/OWNe,^aMA@]NSZ^X%D-#,4AVFP*A6j'Jj5jD[DE=R8ei2nNr-Ed+3Z*W;CMFj*c`l?)fq(KkBt;[>>GDGBZ/k-JB`WU/GOj_1fq`2g2p%+/EF1h6Gj+r9E<h)J],_h)Gmc[P5i'S%`1,#ER2B4/WE>7O6+a9s21+Dqoq3LIp/l`qa4:dZs/sBPZt4@=.Sb5g4]e0r,`t(;!CZH?jEWA9q.016dt$rs97j]*k7YRfhZ"o886JJ?Gp%m$`S^0a1eC"CrXdHZ8!jZ`Z"N`J3%6QYJ0UFn,sQ>86.^5!13I-n(.MB#-'h1d0<SVJAPQ9ed48tb'qrAEQqT0Rk7`)iJkLpc0=stuG&h>RG:0RObTAQWMpN<!OstrAM9".toq<@1E]1`JZc\rA_eF6[;EZBQ=Dq*(S#bDFbGL6A]"*cXU_L.K0P/XVb-D.cnf7YLnNmPqPC2s`*9=X[c"3<V#f9E'iR]Ua;=%d-[l+ZP[i`9:DIB?l26]TB-D*.8%q*M,aQCGrF!jTY^O*\CbTG9t25pM5*"VK0)S5O!Ce?LUZKo1^M'Upt*$-N@):h#>`rBa^BQ3K,?%3_?$((S=,U!.o#\!:M:d:&qmP@IC(l-+S\>0nn"+ib7+%Ru3HbJB/3iuUT&+fs0rA"79]@TKYkp-%Up5W_Z;u;,m=`87DE%e9Z]cT6+G],E5Z8]n](/JZ+g@F_H[!&C]S(O^JiG@[<?O!J@8:Ada1/QNdaiZRY-TK9piZ^TtLkUr^U.fWRN.^!FoAE)#g.>:7GuDZR)9['f?H+Tn&4Jc94,o&s\NC0&J!hPf%.^c&K>4GH@$-p"il'*SQ]m?="Y!MSPPZnsV$"qdR,$^!PL%diV0_@dFR'M_$L?rReJo/[p=490L3/@/T?"6"G9;TpQ_N_KGOGN)&`IWJ!rZV8aMMoAV79?"FYU5Dq"GD4L?6iG=CAN\\k4`8\#4qSFArHj?&J>CeMgCFbD[7CocOq7,Sc*T3%0rG8Ps<)BP_Y\4d\NP"!cJe++bueZHq,NFS'up>^\N'5"FqM?gIJ!B*(aB-#01*<W1=\&ULEmqb#XXoIX]PqF''DdKn+X\G!;0F55]>CeTMu2m2H5-+f;,Kt*jn@;G>YUAO-prqO/uo4c+[VU2R:S=N$2m_]kU0[%oVIM_)/gusX/%nj&pP9>q^lLgi5.,clYN0bW2Ym:F?`u84POPd9EILOR]hii#f)Z)'#m1<sJ%.G2WM^;?*/gAl:hZWrPFtkkHs*Kl_LZd1_Nm5H6WC-pWY<c`!*D,=G!,_DZ8.bZ,3U[t$.^ZA'6R#$qn#!4gE*aq.4ZWX/akBOHZK.ki!;nJ2R0kqU90+VgZeWlYf`l8l^L)7ij2nuY-N)mIZMqWgZJP%(D)d[o<CljA]BsPLC@k%VX@]#6V;S:!T[e2k3,6#t?E_!%D=9)7S(l:qWp&`L)IE=NS*_-b~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3164
+>>
+stream
+Gb!l!>Bei3&Ur'0QoE3&6kd4SrT(mlPHNM3@Vp;7WVQUOOG"'30Ec)orUh1],Y6UO/9Q+#oJARb#RlP-i0tYi+CO5:UApi<!T&jplobC/^h<qjZTK(1_q!u$pK*[JgMm@^*T3P$Iq+td!>P-,RJtp$IEMrq!$[J+;1u+g$tc\MIE$1s_o4!hmC7]L5nmL"&.mp%LQ2H6'J*_j;<6Z=X8]J9a!#]4CH5/N_@R[Z\@*Fl?YMs;[E+@?\7LO13=R&^1'&nK@LqA'@UD8TK+P@'39d7\1[9]7guaPAE(::2ZVmC3kRSND<h)@W9p%E,jb@*k1%i5+iV^c?@q6LN%!K";WRGKP,$ae#nrPt+?uR^c>JA!tdShlpaRWfdL[[P`aJ6k@DXt]5QrXh9@8cVP3<r_6>X2W")(SfIA\]T_2AK@]M\VHXVKBCW+P!q:gsR'=SNNC=<PmIH$mns\.:;WY#L3]</btX.^m@&F>$I=R!8fj>W#$=Y1)N*OcnnH-5hBt)=`i%^%MH\L2kaHZ_Mi*4RRf]"iViGg3tMR#i"&PK6C,D.&3%`"=LpPKM\>p47Rb9[>QR?H/FYlVf&2kA9D3mj.]]q@0HSTJ?o2"PcEiHUj&9(,44FJaNX<V.[3hGS)`<F7TLMMp7><He=E5+9VIjL"S$?Z68>TMTmhI?4PIiZ*pd`\qpF2Ac>#X]Vn)rlAUdYOYEa86T%O#8RIM!e;4LMk1PEs.Q)uE)tDFE/lM.=M!2pLq.%;1hB_\r`X,5@`+S.6^oK652jUd?.Z=eb!do9:HA$_@\So#7VO&sB)IR_faNk!ajG4+(?0"/Q.nMCQT7;TUh*q)A6Ga4>tBnlI*o2h>XFLPupbZ,6\SeSc@\Cp3Tf]%_7pZ1,0G*sHYVJ?>-qXpsRJ%=t08CP>SqdkCleaJkl[jL3Ht5<m$0&).p>g/d9)>/rN+=l1qe4<%g&e-iQ-3]tKlCtqL<!r_`?\q["\EoM7pH'[p>aLkC5^hE7!iJA>^BPCf2FmSk0ESCcXoSi^cjVKn/bHLE7i1f/kC9*3'O_p6-FU[0S%36NlfCrb/fe@9`0^LA7)R/N>PeNa^Vq\8dD>-Rspj6mT-VuCE`sXV2J;$mGpu;u5c[K<D$=]?pd$iG:H[!a'AQkfuT+'Z,ou52#eR^,rg)s0#p[RhH//FMQB/A2o@@Ea@S+egFGXL?H0J[UA7X*@KVI9Zu)m(8aACKc;\os'`k1_d4nogf$[hruZJff>fUYRk>Krn:6lbm)(oGbi,MN[to7cH?LX("Pr9Z!Vs-S+u7FeGR6!_W4Ar!2Ee__m5fggVr6?L^+G1*fukpEIFi%s(!Xo8Sn1Ub(Y%%7'9pQpBJN+Dj5CnG*+f4U1mTSbt?2a,V5uK_654A(6,QqPb*U4IBP`-S`[VU7*`7]G],YE't(b.80AoBCkYmAbo/4PI$RF'nGG&?Xi#(,47]DM-O)KTpBdQe^@jWW_$K0P"6V>Q5gR*Cp'VSJ;@^o,*sLoj[3s)7s7'1=c,3p>@PB!=oD>Ro>0XX<]*/c3aMHcbf^`o#2;0!6DPM[PpZHfiJa5\B^@]%a<o_<=ItBb<#K:cKiGp,:R*seN8eKW1^s7bWbfmFY7pQ'b-R+@E+LB/LIbkCN(AN7(@AR!<]t:RXeR#PIB)C_Sr_G<elMLsc9-'J-@tk5<0&C+3I?`fTCjDKla&b:oI*!)G=>iD@a;uG4iDI&(DO26[h52"-)qWkTW"g5,-=h54!&'"P)KV`S"h!bgXT'p"Lh"(nN\SEZBXCu2\KCJHg(.$^>AI<2YRl4g11-#IDP`O>^eh]F&KVuo70;MZA7AHrITXi[C0BUri_[iEr!I.""tcMBa.c2CBN3VofXsS;:XPk6MDcnl[BI1P?*#U3^U\=C@X7W<AJeh-/2`Tlu<MZDpq:fk5#?9Y3hof9u^!,+:?=N*Og<`p?Bn>mN%g5pQ]J6]Y/OE,Lj'E!^9sP3tB#d\r=:m>?_1k%_!BSma)5E6ZSE[Fj;&n66pI8lGd3WMRVSRLS]+Yg<!_p"^upbAN@.*m8Yo<-*"+gr=0KI<OM9307*72V8r?Zp$6f'e[_e'f%V:j`4oRUo'>c3eeSo2O:+p^$./=9Y,'qR!M,$.VK[o'3HssNXU;YF5]*,^<Ao1crRPmgDhj\2a<q(caJiWB4(`lkhb'nCU`$PmD;o.ZcWR.>FYe=kWWMt@@h'+mUO%ogE[<%"i-C++Frfi;quLmbn.4!1bpQV*qT<PL<sjV2@P1RP:*K$R:K7]Ae?0keE,]/#;"+p#i(eSrn3j$t%eX_cTIWuA7)>o]jVqDi:5`!b:s&stN@upM;=OOg;W@'EDTD5O!7q[@!H(&Ea=C9VR2'0;'2^A]Pg0hJjT92d>27?DP^YRM1OXjXJjasUFtOc@<gLO#A<P,6d1+;'VR&^S1+<sX\Da(OCa[@N52$n(4pOk(^],k6_4644`8LNDcPIV1CU>,7g@6o%7FeR(c(!]tU2+E)5aMP7W4R@5:?@HS:YujJ4"kN&SI&lRGC6D`D\S>;nm%j,mWQV/JLIr3HCJdbTYrmIS(=LEl83EA\>""d_sZVM5s6PJNcmgN!Oc-ig,GdX;KU.8DI@?9DSaBgMugZs^9R(V8Bk<jBj%1FhZ^*lM=Tg_'C95#L>?p+AXh&(/16D$\aJAlJ^a"_eAHG*G/X;g+?$SYgEn(a)r5!*9M9i4QCp7.k>GXq3!Xka^i[&9WJ^ip+/-h'`X]@D1s3:oXV8,WT'`=i4hPdLZK,^,$^TofmMARQ5@AVE<u(Iu$%"q8XmR5aCMk;DWZ3ufE`s7TL5@sD<]dh]kq9qo%TJB=(9d$@[Cpd@8:?nV([MoikI8b/<HiL=AY9PAp2L-$JThP]CKBeUSS$]b-ON#elG'Q=4*:sE0Np0;md?$EP)AM5k4#.H0`eCT\/A)ib#(%[S=Su;hD'ku=/(^MbT]^MjL.Xrb,W8$r#bs?[h/C,V7q`WVJ[)QIbU\MLE>1:\7]g^n37KP#@<;AGa%3sV!8"adR8Km\jY"2Isa%#CW63MpI/%IV0?gYRX:SiG;!htJ8XW615W$Bo]]+pCP9XlB@h.DN!.EE$(H\1H>=dB)Nl,BOg*N%_DOs<&\PM]Gcs2`hf:oqq+aSl/=S<#[.LI*jMY+I(q*M4bM^pc!GtjCE<~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2821
+>>
+stream
+Gb!#]=``=W&q801kVp[6RjPptnru,Z-500uZ;RQ7X&LqYMibma%u#dUjk%f`n<>0>;FOerVd^<U&:Io!7OJ*hrHjhA]p[6d4%>1XA5:?,CmnVXe`=]Y(P_1AJPV$bilAso^gr!hq<a)>J*dB!_*,gbhe%W3@r!]2rpn$@I*3EZ%Ppdr\XYe6214"e^o<Cg?$o6K1EGB9phQk$p2&lT*EWO/^.%4d4kJ1r@S9A"WCc4m_(AQOX9OYqf.=H.%r4@@SI!LY9bJGcM-9dc[c'1HOCQ0RUlfjnPJ:i&P0VY[_"i88=j%"9fC%%%JMAn]*nWI+#TWO,!u5E<"Rh0a^&C9(QGlP9P-,j<EE,D0g/@JdC>Uk8BCR%N`uR5a_d]3Q6[?<[pg_gd6Tku-j5>Q@O.-*LnPprfFjLY0fN+d/Q4.YXV?8S7C+MLG5_\#li=C_ugq[AGY;'=qZ\H7m/VuuiN9L$%f:P64^$WpI4(LVEYPA.l<[n"1?NAumVO7"qLfI./`r653c*c/8^Mg@:a(#M^gUH)ES,pD$CB^6=$@PP%Di@89fe'df/^LR7Y/&kfa(q*N+uJ/"d==GGd[K3=:24uJ\oE?AfL%=Ke%XYXb8:D*OO;5!7NKX'MDCMB.Hl5C'l`dnQDmD#AN;'B'VQoYc*F\j;-FO$U=)dKV76(sY3rVY/.DAQi1+g2l*'7*F>Q/ZMrn##/)`B3_GGt$FoDL+qY.KcHcHR:(bSNQ^PN\FPIo:BRW@i\"6WNfP]W<:"MLe/3%RTa/9=rBDko.`$7(srW9A1<1_KPc/;mj8?Ae2a,bjn!ApMtd(K((0iCAW8PfbHlnJTGj+jube7:acA-t`pe(dDBifaN\Q81nC$C6h:[@_%^I-W*\ib32T`rK1tI]Ec\M2TJ0'p5&<<cGckI?V#1G1?_(4;+`O7AgJ0BKskP7Er9)PfT^S8?dV,LcpXi]"<k5u%qAF)fpp&`f7/h\qs![tf9_h*j)Khfg7(UAi(_C-CCKO2bR^:!6dH^?TlM=e06W+rjN.B(")J^_#>(Na"A,c&QJ]-K:0Z-+[?5tKP,;Z7[KCaEC,^J*82aV*;_qmHV]P$dHc=.Hb>$[Lji&:"3W'cZm_!ZQ6ET/`#u+jlV4<PY$/_>7ioh^*q._s*@b:8EXH4Wj%tch+>mK2<5OL][IjZG#:\LKF=jK[9Ni4=<-[eP9MuL6rVKf2;.3A>)HEmd.VYQ/Z:/@LZ:mKiu6]pD57u30=R4Mk#]ZR@t6HD'3OQQ/ZUpXKYAZZ,R#2u"/k\BAfk.&.[FTL9@2RNQ]oF<?loj=]K_;,4&b_AB\koUo&6tliC6MmX0QiOUQNH+RuT'[U+hhPa!]Y5DUmi-EMOWFb^Vl\Z^&We10*E4<<D2gNnnp2`,:lN3_:t*pPd3QomA.LaaV3bsn_g^Fg`]f&CCk6L`c-U#CPn?@,YTk(%GDP)9LP_QbP"6T:+GZmJFdIB<+9tc2,q+aQrA?-d?dV9\b!FF"o&]i)PJ2.?X2_;3MrcN-99d=qBc4m3(Wh"AU&]$IVE#!(<4dEA9<hCV[sCp6Q**'\<PVe@[MO.fFg7!8&\rMmG!I6BC+\KEl6_S/V[[*#_Xe]LoB]s(`)u\)-o6`3<D(Z(HY3W2o.l6aWg)4J+=^@'<F"O#(9>0"EfkgI7<H.t@7efl=rPqBF`pVMhdsJu()[T[D,8cL-)rt&=DqbSWA_Wm\C1L!pD>V.N=pqZ%s@XArX[M<7fOTRF(^]Jf,A$b!h"cuM.UGCTHsm+'a\&C[jjLNb:M9A6>21Zm6TlV@XgM>2g1<kcl1%fB_9;s0:D'o97$1FX^m\APSc6Ci[lAE6H7282k"/%MtEf5Q]=P?mM<E%bG^B]:89M6_i02XgT<dIK_k4".Ym>MTXWIr*gX^VT;nKMB/#Bh7e7]#eJl^NCkoiohD+"W*t,qTQg<oaq%+8ennPXLSnA@T>\eb6C=#&)(=`l-^\Zt'(>#$KS7MCK<ViR9Q6NAJ7-Xmi+gB1Z9+766ZEQj4b:J&0#bg6`/;hDQTu);.I="I]pSED96P\j.Lkk`V6AX(P[V_*F?:">NXU6@F%gbZ2U;l"3,h*VnjZ*\$eNQ"M$'([dnP[pXB^b=h^W4muK!SBd8&=dGdQOhK[^N(+ft&qO);<_*<B#?.Aa`NOIGd!MAnC0VN*6sW$EnYN0#pM;?_>nA8'4a4R8#a4%IPCU>)c:+6O:d=IF\-SI(N]9p:lH^#^,tJFI"3Zr(Ub@gH<+"7JK#DE9hnoc(I+K^aNii/u;OXep6"T`9=Uq=V7WKgd5B+VC9m=^WSa7,#UA&K0$](i*iLgDg`9NeSgj'4+f%FE'UfU\5#Ot#lCu=*S-kH4.1#S:1&udBD9)dY(:b`_%FS$D#h^=?`fA9Zp?t'GHd:<,Z3,AYqMj%c+B"WWf7qPPUFXVQ86GBRhXM6XgZQ8g9HpS3uJHse8hb/<PNPFjJmnQ<f77N`Xn/AHQiiL[@nD&*QV`++=oU9`Rd@WFs(iHAG./<;?I2*/H@B<!.\&Wi+ms.h@@gJbXbs=@_5k:@UVI(bt,b,718!6=gPVPpl990]sP+rWnm/=X&3SXkCg':V9amrgkHnf$M/nPkW-;NJKNegRk+"g*mD^j-l-Zl1*L21oVh"%-;Cjm_DIYL'Z>OH[2WjObk.^4bZ-P'@QiZH,Tj%<RZ)I2%HMlbT]%&S3lKL&THm-.KE)U=;5o+>oO>CrdYB``]\gYcWr_X^ipZ_2D\+!BgG!'%9mdr+/T4\^"p##F>b/Tk7i'X7!BMlOlM%J8eGf&O^Y\Tu"gt=tBHLj<0Jk?.Mgk_[Zq,9~>endstream
 endobj
 xref
-0 16
+0 20
 0000000000 65535 f 
 0000000061 00000 n 
 0000000132 00000 n 
 0000000239 00000 n 
 0000000351 00000 n 
-0000000466 00000 n 
-0000000571 00000 n 
-0000000776 00000 n 
-0000000853 00000 n 
-0000001058 00000 n 
-0000001263 00000 n 
-0000001333 00000 n 
-0000001614 00000 n 
-0000001686 00000 n 
-0000003590 00000 n 
-0000005761 00000 n 
+0000000434 00000 n 
+0000000539 00000 n 
+0000000616 00000 n 
+0000000821 00000 n 
+0000001026 00000 n 
+0000001231 00000 n 
+0000001437 00000 n 
+0000001643 00000 n 
+0000001713 00000 n 
+0000002018 00000 n 
+0000002104 00000 n 
+0000005395 00000 n 
+0000008793 00000 n 
+0000012307 00000 n 
+0000015563 00000 n 
 trailer
 <<
 /ID 
-[<1ee562e8f986de8fc6af62b322517c6d><1ee562e8f986de8fc6af62b322517c6d>]
+[<3929052b6e9d8b37d3ab4d740a44a5df><3929052b6e9d8b37d3ab4d740a44a5df>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 11 0 R
-/Root 10 0 R
-/Size 16
+/Info 13 0 R
+/Root 12 0 R
+/Size 20
 >>
 startxref
-7592
+18476
 %%EOF

--- a/Expressions/generate_pdf.py
+++ b/Expressions/generate_pdf.py
@@ -1,0 +1,444 @@
+"""Generate core-builds-expression-layer.pdf — Core Builds SEL Expression Layer reference."""
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import mm
+from reportlab.lib import colors
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, HRFlowable, KeepTogether
+)
+from reportlab.lib.enums import TA_LEFT, TA_CENTER
+import textwrap
+
+# ── Palette ───────────────────────────────────────────────────────────────────
+BG         = colors.HexColor("#0d1117")
+CARD       = colors.HexColor("#161b22")
+BORDER     = colors.HexColor("#30363d")
+ACCENT     = colors.HexColor("#58a6ff")
+GREEN      = colors.HexColor("#3fb950")
+AMBER      = colors.HexColor("#d29922")
+RED        = colors.HexColor("#f85149")
+PURPLE     = colors.HexColor("#bc8cff")
+CYAN       = colors.HexColor("#39d353")
+MUTED      = colors.HexColor("#8b949e")
+WHITE      = colors.HexColor("#e6edf3")
+CODE_BG    = colors.HexColor("#0d1117")
+CODE_FG    = colors.HexColor("#79c0ff")
+
+W, H = A4
+MARGIN = 18 * mm
+
+# ── Styles ────────────────────────────────────────────────────────────────────
+base = getSampleStyleSheet()
+
+def S(name, **kw):
+    return ParagraphStyle(name, **kw)
+
+TITLE   = S("title",   fontName="Helvetica-Bold",   fontSize=22, textColor=WHITE,  alignment=TA_CENTER, spaceAfter=4)
+SUBTITLE= S("sub",     fontName="Helvetica",         fontSize=11, textColor=MUTED,  alignment=TA_CENTER, spaceAfter=2)
+H1      = S("h1",      fontName="Helvetica-Bold",   fontSize=15, textColor=ACCENT, spaceBefore=10, spaceAfter=4)
+H2      = S("h2",      fontName="Helvetica-Bold",   fontSize=11, textColor=WHITE,  spaceBefore=6,  spaceAfter=3)
+BODY    = S("body",    fontName="Helvetica",         fontSize=9,  textColor=WHITE,  spaceAfter=3,   leading=14)
+MUTED_S = S("muted",   fontName="Helvetica",         fontSize=8,  textColor=MUTED,  spaceAfter=2,   leading=12)
+CODE    = S("code",    fontName="Courier",           fontSize=7.5,textColor=CODE_FG,spaceAfter=2,   leading=11,
+            backColor=CODE_BG, leftIndent=4, rightIndent=4)
+BADGE_E = S("badge_e", fontName="Helvetica-Bold",   fontSize=8,  textColor=RED,    alignment=TA_CENTER)
+BADGE_I = S("badge_i", fontName="Helvetica-Bold",   fontSize=8,  textColor=GREEN,  alignment=TA_CENTER)
+BADGE_P = S("badge_p", fontName="Helvetica-Bold",   fontSize=8,  textColor=PURPLE, alignment=TA_CENTER)
+LABEL   = S("label",   fontName="Helvetica-Bold",   fontSize=8,  textColor=AMBER)
+NEW_TAG = S("new",     fontName="Helvetica-Bold",   fontSize=7,  textColor=CYAN,   alignment=TA_CENTER)
+
+# ── Data ──────────────────────────────────────────────────────────────────────
+
+EXPRESSIONS = [
+    {
+        "id": 1,
+        "name": "REPACK / PROPER Passthrough",
+        "type": "ISE",
+        "status": "trial",
+        "summary": (
+            "Pins REPACK and PROPER releases to the head of the result queue, bypassing the excluded and "
+            "limit pipeline stages. Ensures patched releases always surface even when downstream ESEs would "
+            "otherwise suppress them. Only activates when at least one REPACK/PROPER exists in the non-library, "
+            "non-SeaDex pool."
+        ),
+        "expression": (
+            "/*REPACK/PROPER Passthrough*/\n"
+            "count(\n"
+            "  keyword(negate(merge(library(streams),seadex(streams)),streams),'all','repack','proper')\n"
+            ")>0\n"
+            "? passthrough(\n"
+            "    keyword(negate(merge(library(streams),seadex(streams)),streams),'all','repack','proper'),\n"
+            "    'excluded','limit'\n"
+            "  )\n"
+            ": []"
+        ),
+        "use_cases": [
+            ("All templates", "Universal", "REPACKs fix broken encodes and corrupt audio — relevant across every template type."),
+            ("Anime · all variants", "Critical", "Fansub REPACKs are extremely common; a v2 or REPACK may be the only watchable version of an episode."),
+            ("Hybrid · 4K Hybrid", "High", "Scene/Usenet REPACK cycles happen frequently on new releases; catching them early matters on Usenet-heavy builds."),
+            ("Stream · Essential", "High", "1080p WEB-DL REPACKs from streaming services (Netflix/AMZN fix runs) are common in the first 24h after release."),
+        ],
+    },
+    {
+        "id": 2,
+        "name": "Per-Addon Flood Guard",
+        "type": "ESE",
+        "status": "trial",
+        "summary": (
+            "Caps the number of results contributed by each scraper addon on cached non-library streams. "
+            "Prevents high-volume addons (Meteor, Comet) from flooding the result list and burying "
+            "quality results from lower-volume sources. Caps: Meteor ≤5, Comet RD ≤5, MediaFusion ≤4, "
+            "Torrent Galaxy / EZTV / Knaben / HdHub ≤3."
+        ),
+        "expression": (
+            "/*Per-Addon Flood Guard*/\n"
+            "merge(\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),\n"
+            "  slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3)\n"
+            ")"
+        ),
+        "use_cases": [
+            ("Stream · Essential · FireStick", "Critical", "Meteor returns 15–20+ 1080p results; without caps the top 15 slots are all Meteor, drowning out Comet and TorBox-native results."),
+            ("Apex · 4K Apex · 4K Essential", "High", "4K results from Meteor can outnumber curated Comet/MediaFusion results 5:1 on popular titles."),
+            ("Anime · all variants", "High", "AnimeTosho and HdHub can flood with low-quality upscales; per-addon caps keep quality releases visible."),
+            ("Hybrid · 4K Hybrid", "High", "Usenet + debrid stacks generate more total results; flood guard prevents any single source type dominating."),
+            ("Speed · Flash", "Moderate", "These templates already bias toward cached instant results; guard prevents cache-flooding from Meteor on speed-focused configs."),
+        ],
+    },
+    {
+        "id": 3,
+        "name": "Usenet Propagation Guard",
+        "type": "ESE",
+        "status": "trial",
+        "summary": (
+            "Holds back Usenet NZBs younger than 2 hours (0.083 days) when fully propagated NZBs already "
+            "exist. Eliminates incomplete or corrupt early-propagation grabs that appear immediately after "
+            "a scene release hits indexers. Only activates when there are propagated alternatives — "
+            "if all Usenet results are <2h old the guard does not fire, preserving availability on fresh content."
+        ),
+        "expression": (
+            "/*Usenet Propagation Guard*/\n"
+            "count(\n"
+            "  negate(\n"
+            "    age(type(streams,'usenet','stremio-usenet'),0,'0.083'),\n"
+            "    type(streams,'usenet','stremio-usenet')\n"
+            "  )\n"
+            ")>0\n"
+            "? age(type(streams,'usenet','stremio-usenet'),0,'0.083')\n"
+            ": []"
+        ),
+        "use_cases": [
+            ("Apex · 4K Hybrid · 4K Essential", "Critical", "4K Usenet releases on NZBGeek/TorBox Usenet are grabbed within minutes of scene drop; corrupt early NZBs are a top complaint for 4K Usenet builds."),
+            ("Hybrid · 1080p variants", "Critical", "Hybrid stacks Usenet + debrid; young NZBs arrive before binary propagation is complete and can stall playback."),
+            ("Stream · Essential", "High", "TorBox's native Usenet scraper surfaces new NZBs fast; propagation guard prevents the first-grabbed-but-incomplete result appearing at the top."),
+            ("Speed EasyNews · Speed Plus", "High", "EasyNews returns results immediately; propagation guard catches the window between indexer post and full server propagation."),
+            ("Flash · Flash 4K", "Not applicable", "Flash templates use only cached debrid content; no Usenet scraper active."),
+        ],
+    },
+    {
+        "id": 4,
+        "name": "Codec Efficiency Booster",
+        "type": "PSE",
+        "status": "trial",
+        "summary": (
+            "Surfaces HEVC (H.265) and AV1 encodes of Bluray REMUX and WEB-DL/WEBRip content ahead of "
+            "AVC (H.264) equivalents at 1080p and 720p. Delivers 30–50% lower bandwidth at identical "
+            "perceptual quality. Applied only to the non-library, non-SeaDex cached pool — library and "
+            "SeaDex results are never reordered."
+        ),
+        "expression": (
+            "/*Codec Efficiency Booster*/\n"
+            "merge(\n"
+            "  encode(resolution(quality(negate(merge(library(streams),seadex(streams)),cached(streams)),'Bluray REMUX'),'1080p'),'HEVC','AV1'),\n"
+            "  encode(resolution(quality(negate(merge(library(streams),seadex(streams)),cached(streams)),'WEB-DL','WEBRip'),'1080p'),'HEVC','AV1'),\n"
+            "  encode(resolution(quality(negate(merge(library(streams),seadex(streams)),cached(streams)),'Bluray REMUX'),'720p'),'HEVC','AV1'),\n"
+            "  encode(resolution(quality(negate(merge(library(streams),seadex(streams)),cached(streams)),'WEB-DL','WEBRip'),'720p'),'HEVC','AV1')\n"
+            ")"
+        ),
+        "use_cases": [
+            ("Stream · Stream Lite · FireStick variants", "Critical", "Primary 1080p WEB-DL template; HEVC WEB-DL is up to 40% smaller than AVC at the same quality — directly impacts FireStick and bandwidth-constrained users."),
+            ("Essential · Essential Lite", "Critical", "Essential users often run cheaper hardware or mobile connections; HEVC/AV1 efficiency is the main benefit for this audience."),
+            ("Anime · Anime Lite · Anime Dub", "High", "HEVC is effectively the standard codec in fansub releases; booster ensures fansub HEVC results surface above any AVC encode alternatives."),
+            ("Speed · Speed Lite variants", "Moderate", "Speed templates already bias toward cached results; booster adds codec preference on top of that without disrupting cache-first ordering."),
+            ("Apex · 4K Apex · 4K Hybrid", "Low", "4K REMUX content is almost exclusively HEVC already; minimal effect. DV/HDR encodes at 4K are nearly always HEVC by definition."),
+            ("Flash · Flash 4K", "Not applicable", "Flash prioritises instant-play speed over codec; codec reordering would conflict with the Flash philosophy."),
+        ],
+    },
+    {
+        "id": 5,
+        "name": "Audio Pinnacle",
+        "type": "PSE",
+        "status": "planned",
+        "summary": (
+            "Promotes lossless and object-based audio tracks to the top of the ranked pool. Ordered by "
+            "priority: Atmos / TrueHD (highest) → DTS-HD MA / DTS-X → EAC3 / DD+. Applied only to "
+            "non-library, non-SeaDex cached streams — library and SeaDex results remain untouched. "
+            "Tam-Taro has zero audio preference expressions; this fills the gap entirely."
+        ),
+        "expression": (
+            "/*Audio Pinnacle*/\n"
+            "merge(\n"
+            "  audioTag(negate(merge(library(streams),seadex(streams)),cached(streams)),'Atmos','TrueHD'),\n"
+            "  audioTag(negate(merge(library(streams),seadex(streams)),cached(streams)),'DTS-HD MA','DTS-X'),\n"
+            "  audioTag(negate(merge(library(streams),seadex(streams)),cached(streams)),'EAC3','DD+')\n"
+            ")"
+        ),
+        "use_cases": [
+            ("Apex · 4K Apex (TorBox)", "Critical", "Flagship 4K template — users running home theatre setups with receivers and soundbars. Atmos / TrueHD is a primary reason to choose REMUX. Without this, an SDR WEB-DL with Atmos can rank below a DV REMUX with AAC."),
+            ("4K Hybrid · 4K Essential", "Critical", "Same audience as Apex; Usenet and debrid 4K results frequently differ in audio track — guard surfaces the better audio option automatically."),
+            ("Hybrid (1080p)", "High", "1080p Bluray REMUX with TrueHD is meaningfully better than AVC/AAC for users with audio equipment; Hybrid is the template most likely to have these options."),
+            ("Stream · Stream FireStick", "Moderate", "Atmos EAC3 exists on 1080p WEB-DL (Disney+, Apple TV+, Netflix). Relevant for Dolby-capable soundbars even on streaming devices."),
+            ("Essential · Essential Lite", "Moderate", "Usenet + TorBox Essential stack often includes lossless audio on 1080p REMUX results; surfacing them correctly improves the experience for Essential subscribers with audio hardware."),
+            ("Speed variants", "Low", "Speed-focused build; audio preference is secondary to cache speed. Safe to include but limited practical impact."),
+            ("Anime · all variants", "Low", "Anime fansubs use FLAC or AAC almost exclusively; Atmos/TrueHD are rare. SeaDex results (already pinned) have the best audio; this expression has minimal effect on anime queries."),
+            ("Flash · Flash 4K", "Not applicable", "Instant-play philosophy; audio selection is irrelevant to the Flash use case."),
+        ],
+    },
+    {
+        "id": 6,
+        "name": "HDR / DV Priority",
+        "type": "PSE",
+        "status": "planned",
+        "summary": (
+            "Within 4K results, surfaces Dolby Vision and HDR variants ahead of SDR equivalents. "
+            "Ordered by priority: DV / HDR10+ / HDR10+DV (highest) → HDR10 / HDR → SDR (falls through to Tam-Taro ranking). "
+            "Tam-Taro's cache tier PSEs treat all visual tags equally; this adds the missing HDR layer on top. "
+            "On 1080p-only templates the expression evaluates to an empty 2160p pool and has zero effect — "
+            "safe to deploy universally."
+        ),
+        "expression": (
+            "/*HDR/DV Priority*/\n"
+            "merge(\n"
+            "  visualTag(\n"
+            "    resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),\n"
+            "    'DV','HDR10+','HDR10+/DV'\n"
+            "  ),\n"
+            "  visualTag(\n"
+            "    resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),\n"
+            "    'HDR10','HDR'\n"
+            "  )\n"
+            ")"
+        ),
+        "use_cases": [
+            ("Apex · 4K Apex (TorBox)", "Critical", "Core use case — DV REMUX and HDR10+ should always rank above SDR 4K Bluray. Without this a SDR WEB-DL can outscore a DV REMUX if Tam-Taro's tier ranking happens to favour it."),
+            ("4K Essential", "Critical", "Essential 4K users target the best available quality within their debrid tier; HDR/DV ordering is a key part of that."),
+            ("4K Hybrid", "Critical", "Hybrid pulls from both Usenet and debrid; HDR/DV results from different sources need consistent ordering regardless of origin."),
+            ("Flash 4K", "High", "4K Flash is cached-only; among cached 4K results DV should surface above SDR for devices that support it."),
+            ("Speed 4K · Speed 4K Plus (EasyNews)", "High", "Speed 4K targets fast 4K cached results; among those results HDR/DV ordering matters."),
+            ("Anime 4K", "Moderate", "Native 4K anime is rare; most 4K anime results are AI upscales or BD sources. HDR ordering still helps where real 4K HDR anime exists (e.g. recent theatrical releases)."),
+            ("Stream · Essential · FireStick · Anime (1080p)", "No effect", "These templates block 2160p resolution at the filter stage; the 2160p pool is empty so this expression returns [] — zero impact, zero risk."),
+            ("Flash (1080p)", "No effect", "Standard Flash blocks 4K; expression has no effect."),
+        ],
+    },
+    {
+        "id": 7,
+        "name": "AI Upscale Exclusion",
+        "type": "ESE",
+        "status": "planned",
+        "summary": (
+            "Excludes streams whose filename or metadata contains AI upscaling keywords. Uses the "
+            "`keyword()` function added in AIOStreams v2.29.6 (May 2026) — the first Core Builds "
+            "expression to use this function. Targets: topaz, ai-upscale, aiupscale, upscaled, neural, "
+            "enhancedai. Catches AI-processed releases that appear as native 4K but are soft and "
+            "artefact-heavy. Inline (not synced) — works on every AIOStreams instance regardless of "
+            "SEL_SYNC_ACCESS configuration."
+        ),
+        "expression": (
+            "/*AI Upscale Exclusion*/\n"
+            "keyword(\n"
+            "  negate(merge(library(streams),seadex(streams)),streams),\n"
+            "  'all',\n"
+            "  'topaz','ai-upscale','aiupscale','upscaled','neural','enhancedai'\n"
+            ")"
+        ),
+        "use_cases": [
+            ("Apex · 4K Apex (TorBox)", "Critical", "4K is the primary domain of AI upscaling; Topaz-processed 'UHD' releases appear legitimate until viewed. Critical for users paying for true 4K quality."),
+            ("4K Essential · 4K Hybrid", "Critical", "Same reasoning — AI upscales pollute the 4K result pool and rank highly due to file size and resolution metadata matching genuine 4K."),
+            ("Anime 4K", "Critical", "AI upscaling is endemic in anime; a huge proportion of indexer '4K' anime releases are Topaz upscales of 1080p BD sources. SeaDex helps but doesn't cover every title."),
+            ("Anime · Anime Lite · Anime Dub", "High", "AI upscaled 1080p anime releases exist (upscaled from 720p BD). Fansub HEVC is almost never AI upscaled so this primarily catches encode releases."),
+            ("Flash 4K", "High", "Cached 4K pool on Flash includes AI upscales; excluding them improves instant-play quality."),
+            ("Speed 4K · Speed 4K Plus", "High", "Same cached 4K pool concern as Flash 4K."),
+            ("Stream · Essential · FireStick", "Moderate", "AI upscaled 1080p is less common but growing; worth including as a precaution — false positives are near-zero since legitimate releases don't use these terms."),
+            ("Flash (1080p)", "Low", "Cached 1080p pool; AI upscaling less prevalent at this resolution. Include for completeness."),
+        ],
+    },
+]
+
+TYPE_STYLE = {"ESE": BADGE_E, "ISE": BADGE_I, "PSE": BADGE_P}
+TYPE_COLOR = {"ESE": RED, "ISE": GREEN, "PSE": PURPLE}
+IMPACT_COLOR = {
+    "Critical": colors.HexColor("#f85149"),
+    "High":     colors.HexColor("#d29922"),
+    "Moderate": colors.HexColor("#58a6ff"),
+    "Low":      colors.HexColor("#8b949e"),
+    "Not applicable": colors.HexColor("#30363d"),
+    "No effect": colors.HexColor("#30363d"),
+}
+
+# ── Builder ───────────────────────────────────────────────────────────────────
+
+def build():
+    out = "/home/user/Core-Builds/Expressions/core-builds-expression-layer.pdf"
+    doc = SimpleDocTemplate(
+        out, pagesize=A4,
+        leftMargin=MARGIN, rightMargin=MARGIN,
+        topMargin=MARGIN, bottomMargin=MARGIN,
+        title="Core Builds — SEL Expression Layer",
+    )
+
+    def bg_canvas(canvas, doc):
+        canvas.saveState()
+        canvas.setFillColor(BG)
+        canvas.rect(0, 0, W, H, fill=1, stroke=0)
+        canvas.restoreState()
+
+    story = []
+
+    # ── Cover ─────────────────────────────────────────────────────────────────
+    story.append(Spacer(1, 12 * mm))
+    story.append(Paragraph("Core Builds", TITLE))
+    story.append(Paragraph("SEL Expression Layer", S("st2", fontName="Helvetica-Bold", fontSize=16,
+                                                       textColor=ACCENT, alignment=TA_CENTER, spaceAfter=3)))
+    story.append(Paragraph("Custom AIOStreams expressions built on top of the Tam-Taro SEL baseline",
+                            SUBTITLE))
+    story.append(Spacer(1, 3 * mm))
+    story.append(HRFlowable(width="100%", thickness=1, color=BORDER))
+    story.append(Spacer(1, 4 * mm))
+
+    # summary table
+    trial_n  = sum(1 for e in EXPRESSIONS if e["status"] == "trial")
+    planned_n = sum(1 for e in EXPRESSIONS if e["status"] == "planned")
+    summary_data = [
+        [Paragraph("<b>Expressions</b>", S("sc", fontName="Helvetica-Bold", fontSize=9, textColor=MUTED, alignment=TA_CENTER)),
+         Paragraph("<b>In Trial</b>",    S("sc", fontName="Helvetica-Bold", fontSize=9, textColor=MUTED, alignment=TA_CENTER)),
+         Paragraph("<b>Planned</b>",     S("sc", fontName="Helvetica-Bold", fontSize=9, textColor=MUTED, alignment=TA_CENTER)),
+         Paragraph("<b>Tam-Taro Gap</b>",S("sc", fontName="Helvetica-Bold", fontSize=9, textColor=MUTED, alignment=TA_CENTER))],
+        [Paragraph(f"<b>{len(EXPRESSIONS)}</b>", S("sv", fontName="Helvetica-Bold", fontSize=18, textColor=WHITE, alignment=TA_CENTER)),
+         Paragraph(f"<b>{trial_n}</b>",           S("sv", fontName="Helvetica-Bold", fontSize=18, textColor=AMBER, alignment=TA_CENTER)),
+         Paragraph(f"<b>{planned_n}</b>",          S("sv", fontName="Helvetica-Bold", fontSize=18, textColor=GREEN, alignment=TA_CENTER)),
+         Paragraph("<b>100%</b>",                  S("sv", fontName="Helvetica-Bold", fontSize=18, textColor=ACCENT, alignment=TA_CENTER))],
+    ]
+    st = TableStyle([
+        ("BACKGROUND", (0,0), (-1,-1), CARD),
+        ("BOX",        (0,0), (-1,-1), 1, BORDER),
+        ("INNERGRID",  (0,0), (-1,-1), 0.5, BORDER),
+        ("ROWPADDING", (0,0), (-1,-1), 8),
+        ("VALIGN",     (0,0), (-1,-1), "MIDDLE"),
+    ])
+    t = Table(summary_data, colWidths=[(W - 2*MARGIN)/4]*4)
+    t.setStyle(st)
+    story.append(t)
+    story.append(Spacer(1, 3 * mm))
+
+    # legend
+    legend_data = [[
+        Paragraph("■ <b>ESE</b> — Excluded Stream Expression", S("leg", fontName="Helvetica", fontSize=8, textColor=RED)),
+        Paragraph("■ <b>ISE</b> — Included Stream Expression",  S("leg", fontName="Helvetica", fontSize=8, textColor=GREEN)),
+        Paragraph("■ <b>PSE</b> — Preferred Stream Expression", S("leg", fontName="Helvetica", fontSize=8, textColor=PURPLE)),
+        Paragraph("● <b>Trial</b>   ○ <b>Planned</b>",          S("leg", fontName="Helvetica", fontSize=8, textColor=MUTED)),
+    ]]
+    lt = Table(legend_data, colWidths=[(W - 2*MARGIN)/4]*4)
+    lt.setStyle(TableStyle([("VALIGN", (0,0), (-1,-1), "MIDDLE"), ("ROWPADDING", (0,0), (-1,-1), 4)]))
+    story.append(lt)
+    story.append(Spacer(1, 5 * mm))
+
+    # ── Expressions ───────────────────────────────────────────────────────────
+    for expr in EXPRESSIONS:
+        tc = TYPE_COLOR[expr["type"]]
+        is_new = expr["status"] == "planned"
+
+        header_data = [[
+            Paragraph(f"<b>{expr['id']}</b>",
+                      S("num", fontName="Helvetica-Bold", fontSize=13, textColor=ACCENT, alignment=TA_CENTER)),
+            Paragraph(f"<b>{expr['name']}</b>",
+                      S("ename", fontName="Helvetica-Bold", fontSize=12, textColor=WHITE)),
+            Paragraph(f"<b>{expr['type']}</b>",
+                      S("etype", fontName="Helvetica-Bold", fontSize=10, textColor=tc, alignment=TA_CENTER)),
+            Paragraph("● TRIAL" if not is_new else "○ PLANNED",
+                      S("estat", fontName="Helvetica-Bold", fontSize=8,
+                        textColor=AMBER if not is_new else GREEN, alignment=TA_CENTER)),
+        ]]
+        ht = Table(header_data, colWidths=[10*mm, (W - 2*MARGIN) - 10*mm - 20*mm - 22*mm, 20*mm, 22*mm])
+        ht.setStyle(TableStyle([
+            ("BACKGROUND", (0,0), (-1,-1), CARD),
+            ("BOX",        (0,0), (-1,-1), 1, tc),
+            ("LINEAFTER",  (0,0), (0,0),   1, BORDER),
+            ("LINEAFTER",  (1,0), (1,0),   1, BORDER),
+            ("LINEAFTER",  (2,0), (2,0),   1, BORDER),
+            ("ROWPADDING", (0,0), (-1,-1), 7),
+            ("VALIGN",     (0,0), (-1,-1), "MIDDLE"),
+        ]))
+
+        body_parts = [
+            ht,
+            Spacer(1, 2),
+            Paragraph(expr["summary"], BODY),
+            Spacer(1, 2),
+            Paragraph("<b>Expression</b>", LABEL),
+            Spacer(1, 1),
+        ]
+
+        # expression code block
+        for line in expr["expression"].split("\n"):
+            body_parts.append(Paragraph(line if line.strip() else " ", CODE))
+
+        # use cases table
+        body_parts.append(Spacer(1, 3))
+        body_parts.append(Paragraph("<b>Template Use Cases</b>", LABEL))
+        body_parts.append(Spacer(1, 1))
+
+        uc_data = [[
+            Paragraph("<b>Template</b>",  S("uch", fontName="Helvetica-Bold", fontSize=8, textColor=MUTED)),
+            Paragraph("<b>Impact</b>",    S("uch", fontName="Helvetica-Bold", fontSize=8, textColor=MUTED)),
+            Paragraph("<b>Notes</b>",     S("uch", fontName="Helvetica-Bold", fontSize=8, textColor=MUTED)),
+        ]]
+        for tmpl, impact, note in expr["use_cases"]:
+            ic = IMPACT_COLOR.get(impact, MUTED)
+            uc_data.append([
+                Paragraph(tmpl,   S("uct", fontName="Helvetica",      fontSize=8, textColor=WHITE)),
+                Paragraph(f"<b>{impact}</b>", S("uci", fontName="Helvetica-Bold", fontSize=8, textColor=ic, alignment=TA_CENTER)),
+                Paragraph(note,   S("ucn", fontName="Helvetica",      fontSize=8, textColor=MUTED, leading=11)),
+            ])
+        col_w = W - 2*MARGIN
+        uct = Table(uc_data, colWidths=[col_w*0.24, col_w*0.13, col_w*0.63])
+        uct.setStyle(TableStyle([
+            ("BACKGROUND",  (0,0), (-1, 0),  colors.HexColor("#1c2128")),
+            ("BACKGROUND",  (0,1), (-1,-1),  CARD),
+            ("BOX",         (0,0), (-1,-1),  1, BORDER),
+            ("INNERGRID",   (0,0), (-1,-1),  0.3, BORDER),
+            ("ROWPADDING",  (0,0), (-1,-1),  5),
+            ("VALIGN",      (0,0), (-1,-1),  "TOP"),
+        ]))
+        body_parts.append(uct)
+        body_parts.append(Spacer(1, 6 * mm))
+
+        story.append(KeepTogether(body_parts[:6]))
+        for part in body_parts[6:]:
+            story.append(part)
+
+    # footer note
+    story.append(HRFlowable(width="100%", thickness=1, color=BORDER))
+    story.append(Spacer(1, 2 * mm))
+    story.append(Paragraph(
+        "All expressions are inline (not synced) — they work on every AIOStreams instance regardless of "
+        "SEL_SYNC_ACCESS configuration. Expressions 1–4 are in active trial on Core Nexus Stream v2.7.10. "
+        "Expressions 5–7 are planned additions pending trial completion.",
+        MUTED_S
+    ))
+    story.append(Paragraph(
+        "Core Builds by Brevity · github.com/brevityA/Core-Builds · June 2026",
+        S("foot", fontName="Helvetica", fontSize=7, textColor=MUTED, alignment=TA_CENTER, spaceBefore=2)
+    ))
+
+    doc.build(story, onFirstPage=bg_canvas, onLaterPages=bg_canvas)
+    print(f"Written: {out}")
+
+
+if __name__ == "__main__":
+    build()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,10 +51,19 @@ This is a living list of planned work, active development, and recently complete
 ## 📋 Planned
 
 ### Expression Layer
-- [ ] **REPACK/PROPER Passthrough ISE** — Pins REPACK/PROPER releases to head of queue ahead of limit/excluded filters; ensures patched releases always surface. Roll out to Apex, Stream, Essential, Hybrid, Anime after trial validation
-- [ ] **Per-Addon Flood Guard ESE** — Per-addon result cap (Meteor ≤5, Comet ≤5, MediaFusion ≤4, Torrent Galaxy/EZTV/Knaben/HdHub ≤3) on cached non-library streams; prevents any single scraper from flooding results. Roll out post-trial
-- [ ] **Usenet Propagation Guard ESE** — Suppresses usenet results younger than 2 hours when any fully propagated NZBs exist; eliminates incomplete early-propagation grabs. Roll out post-trial
-- [ ] **Codec Efficiency Booster PSE** — Surfaces HEVC/AV1 encodes of 1080p + 720p Bluray REMUX and WEB-DL/WEBRip ahead of AVC equivalents; lowers bandwidth without sacrificing quality tier. Roll out post-trial
+
+**In trial** (Core Nexus Stream v2.7.10 — roll out to all templates post-trial):
+
+- [ ] **REPACK/PROPER Passthrough ISE** — Pins REPACK/PROPER releases ahead of limit/excluded filters; ensures patched releases always surface. *All templates — critical for Anime (fansub REPACKs), Hybrid, and Stream (streaming service fix runs)*
+- [ ] **Per-Addon Flood Guard ESE** — Per-addon result cap (Meteor ≤5, Comet ≤5, MediaFusion ≤4, Torrent Galaxy/EZTV/Knaben/HdHub ≤3) on cached non-library streams. *All templates — most impactful on Stream, Essential, and Apex where Meteor can return 15–20+ results*
+- [ ] **Usenet Propagation Guard ESE** — Holds back NZBs younger than 2 hours when propagated alternatives exist; eliminates corrupt early-propagation grabs. *All Usenet-enabled templates — critical for Apex, 4K Hybrid, Hybrid; not applicable to Flash*
+- [ ] **Codec Efficiency Booster PSE** — Surfaces HEVC/AV1 encodes of 1080p + 720p Bluray REMUX and WEB-DL/WEBRip ahead of AVC equivalents. *Stream, Essential, Anime (primary) — limited effect on 4K REMUX templates where HEVC is already standard; not applicable to Flash*
+
+**Planned** (post-trial, pending research — no Tam-Taro equivalent exists for any of these):
+
+- [ ] **Audio Pinnacle PSE** — Promotes lossless/object-based audio tracks within the ranked pool: Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3/DD+. *Critical for Apex, 4K Apex, 4K Hybrid, 4K Essential (home theatre users); moderate for Stream, Hybrid, Essential; low impact on Anime (fansub FLAC/AAC standard) and Flash*
+- [ ] **HDR / DV Priority PSE** — Within 4K results, surfaces DV/HDR10+/HDR10 ahead of SDR equivalents. Safe no-op on 1080p-only templates (empty 2160p pool). *Critical for Apex, 4K Apex, 4K Essential, 4K Hybrid, Flash 4K, Speed 4K; high for Anime 4K; no effect on Stream/Essential/FireStick/Flash*
+- [ ] **AI Upscale Exclusion ESE** — Excludes streams containing AI upscaling keywords (topaz, ai-upscale, aiupscale, upscaled, neural, enhancedai) using the `keyword()` function (AIOStreams v2.29.6+). First Core Builds expression to use `keyword()`. *Critical for all 4K templates and Anime 4K; high for Anime (upscaled 1080p); moderate for Stream/Essential*
 
 ### Templates
 - [ ] **Deprecate Core Nexus 4K Pro + Pro Lite** — Apex is the fully upgraded successor; Pro adds no distinct value and creates maintenance overhead. Move to `Templates/Torbox/Deprecated/`


### PR DESCRIPTION
## Summary

- **Regenerated `Expressions/core-builds-expression-layer.pdf`** — now covers all 7 Core Builds SEL expressions with full template use-case breakdowns for every active template
- **3 new planned expressions** added (Audio Pinnacle PSE, HDR/DV Priority PSE, AI Upscale Exclusion ESE)
- **ROADMAP updated** — all 7 expressions have per-template impact ratings and notes
- **`Expressions/generate_pdf.py`** added — reproducible PDF generation script (reportlab)

## New Expressions

| # | Name | Type | Gap Filled |
|---|---|---|---|
| 5 | Audio Pinnacle | PSE | Tam-Taro has zero audio preference expressions |
| 6 | HDR / DV Priority | PSE | Tam-Taro treats DV/HDR/SDR identically within 4K |
| 7 | AI Upscale Exclusion | ESE | Uses new `keyword()` function (AIOStreams v2.29.6+) |

## Template Use Case Coverage (new expressions)

**Audio Pinnacle** — Critical: Apex, 4K Apex, 4K Hybrid, 4K Essential · High: Hybrid · Moderate: Stream, Essential · Low: Speed, Anime · N/A: Flash

**HDR/DV Priority** — Critical: Apex, 4K Apex, 4K Essential, 4K Hybrid · High: Flash 4K, Speed 4K · Moderate: Anime 4K · No effect: Stream/Essential/FireStick/Flash (1080p-only, empty 2160p pool)

**AI Upscale Exclusion** — Critical: all 4K templates, Anime 4K · High: Anime all variants, Flash 4K, Speed 4K · Moderate: Stream, Essential · Low: Flash

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_