### PR TITLE
fix(personal): sync debridioApiKey field, bump v1.1.1

### DIFF
--- a/Templates/Personal/core-personal.json
+++ b/Templates/Personal/core-personal.json
@@ -5,7 +5,7 @@
     "description": "Personal 1080p SDR all-rounder. TorBox Pro + RealDebrid \u00b7 Comet \u00b7 Meteor \u00b7 MediaFusion \u00b7 Debridio \u00b7 SeaDex \u00b7 NZBGeek. WEB-DL preferred \u00b7 DD+/AAC \u00b7 SDR \u00b7 HEVC/AV1/AVC \u00b7 Tamtaro SEL. Hotack L007CM Full HD Projector.",
     "source": "external",
     "author": "Personal",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -898,7 +898,8 @@
         "options": {
           "name": "Debridio",
           "timeout": 5000,
-          "apiKey": "<template_placeholder>"
+          "apiKey": "<template_placeholder>",
+          "debridioApiKey": "<template_placeholder>"
         }
       },
       {


### PR DESCRIPTION
Syncs `core-personal.json` with live config — adds `debridioApiKey` as a second placeholder field in the Debridio preset options (alongside the existing `apiKey`), matching the field AIOStreams now exposes in that preset type.

- `debridio.options.debridioApiKey`: added as `<template_placeholder>`
- Version: `1.1.0` → `1.1.1`

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_