### PR TITLE
chore: remove 48 dead expressions (SeaDex ISE + Sootio ESE)

### DIFF
--- a/Templates/Personal/core-personal-anime.json
+++ b/Templates/Personal/core-personal-anime.json
@@ -321,10 +321,6 @@
         "enabled": true
       },
       {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
-      },
-      {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",
         "enabled": true
       },

--- a/Templates/Personal/core-personal-flash.json
+++ b/Templates/Personal/core-personal-flash.json
@@ -322,10 +322,6 @@
         "enabled": true
       },
       {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
-      },
-      {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",
         "enabled": true
       },

--- a/Templates/Personal/core-personal-speed.json
+++ b/Templates/Personal/core-personal-speed.json
@@ -322,10 +322,6 @@
         "enabled": true
       },
       {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
-      },
-      {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",
         "enabled": true
       },

--- a/Templates/Personal/core-personal.json
+++ b/Templates/Personal/core-personal.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "brevity.core-personal",
     "name": "Core Personal",
-    "description": "Personal 1080p SDR all-rounder. TorBox Pro + RealDebrid \u00b7 Comet \u00b7 Meteor \u00b7 MediaFusion \u00b7 Debridio \u00b7 SeaDex \u00b7 NZBGeek. WEB-DL preferred \u00b7 DD+/AAC \u00b7 SDR \u00b7 HEVC/AV1/AVC \u00b7 Tamtaro SEL. Hotack L007CM Full HD Projector.",
+    "description": "Personal 1080p SDR all-rounder. TorBox Pro + RealDebrid · Comet · Meteor · MediaFusion · Debridio · SeaDex · NZBGeek. WEB-DL preferred · DD+/AAC · SDR · HEVC/AV1/AVC · Tamtaro SEL. Hotack L007CM Full HD Projector.",
     "source": "external",
     "author": "Personal",
     "version": "1.1.1",
@@ -17,7 +17,7 @@
     "showChanges": true,
     "addonName": "Core Personal",
     "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/main/Assets/core_icon.svg",
-    "addonDescription": "1080p SDR \u00b7 TorBox + RealDebrid \u00b7 Comet \u00b7 Meteor \u00b7 MediaFusion \u00b7 Debridio \u00b7 NZBGeek \u00b7 WEB-DL \u00b7 DD+/AAC",
+    "addonDescription": "1080p SDR · TorBox + RealDebrid · Comet · Meteor · MediaFusion · Debridio · NZBGeek · WEB-DL · DD+/AAC",
     "appliedTemplates": [
       {
         "id": "brevity.core-cipher",
@@ -338,10 +338,6 @@
         "enabled": true
       },
       {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
-      },
-      {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",
         "enabled": true
       },
@@ -451,8 +447,8 @@
       "definitions": {
         "overrides": {
           "tamtaro": {
-            "name": "{stream.resolution::exists[\"\ud83d\udda5\ufe0f {stream.resolution::upper}  \"||\"\ud83d\udcfa HD  \"]}{service.shortName::exists[\"\u26a1 {service.shortName::upper}  \"||\"\ud83d\udce1 P2P  \"]}{stream.proxied::istrue[\"\ud83d\udd75\ufe0f  \"||\"\"]}{stream.library::istrue[\"\ud83d\uddc4\ufe0f  \"||\"\"]}{stream.title::exists[\"{stream.title::upper}\"||\"\"]}{stream.formattedSeasons::exists[\" {stream.formattedSeasons::upper}\"||\"\"]}{stream.formattedEpisodes::exists[\" {stream.formattedEpisodes::upper}\"||\"\"]}",
-            "description": " {service.cached::istrue[\"\ud83d\ude80 INSTANT  \"||\"\"]}{service.cached::isfalse[\"\u26a0\ufe0f UNCACHED  \"||\"\"]}{stream.nSeScore::>=75[\"\ud83d\udc8e {stream.nSeScore}  \"||\"\"]}{stream.seadexBest::istrue[\"\u2b50 BEST  \"||\"\"]}{stream.seadex::istrue[\"\u2705 SEADEX  \"||\"\"]}{stream.regexMatched::exists[\"\ud83c\udfaf {stream.regexMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.seMatched::exists[\"\ud83e\uddf2 {stream.seMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.releaseGroup::exists[\"\ud83c\udff7\ufe0f {stream.releaseGroup::smallcaps}  \"||\"\"]}\n \ud83c\udfac {stream.quality::exists[\"{stream.quality::upper}  \"||\"\"]}{stream.encode::exists[\"{stream.encode::smallcaps}  \"||\"\"]}{stream.container::exists[\"{stream.container::smallcaps}  \"||\"\"]}{stream.visualTags::exists[\"{stream.visualTags::join(' ')::upper}  \"||\"\"]}{stream.bitrate::exists[\"{stream.bitrate::sbitrate::smallcaps}  \"||\"\"]}{stream.duration::>0[\"\u23f1\ufe0f {stream.duration::time}  \"||\"\"]}{stream.network::exists[\"\ud83c\udf7f {stream.network::upper}  \"||\"\"]}{stream.editions::exists[\"\u2702\ufe0f {stream.editions::join(' ')::upper}  \"||\"\"]}{stream.uncensored::istrue[\"\ud83d\udd1e  \"||\"\"]}{stream.unrated::istrue[\"\ud83d\udeab UNRATED  \"||\"\"]}{stream.upscaled::istrue[\"\ud83d\udd2c UPSCALED  \"||\"\"]}\n \ud83c\udf9b\ufe0f {stream.audioTags::exists[\"{stream.audioTags::join(' ')::upper}  \"||\"\u1d00\u1d1c\u1d05\u026a\u1d0f  \"]}{stream.audioChannels::first::=2.0[\"\ud83d\udd08 \"||\"\"]}{stream.audioChannels::first::=5.1[\"\ud83d\udd09 \"||\"\"]}{stream.audioChannels::first::=7.1[\"\ud83d\udd0a \"||\"\"]}{stream.audioChannels::exists[\"{stream.audioChannels::first}  \"||\"\"]}\ud83c\udf0d {stream.uLanguageEmojis::exists[\"{stream.uLanguageEmojis::join(' ')}\"||\"MULTI\"]}{stream.dubbed::istrue[\"  \ud83c\udf99\ufe0f DUB\"||\"\"]}{stream.subbed::istrue[\"  \ud83d\udcdd SUB\"||\"\"]}{stream.uSubtitleEmojis::exists[\"  [{stream.uSubtitleEmojis::join(' ')}]\"||\"\"]}\n \ud83d\udcbe {stream.size::exists[\"{stream.size::sbytes}  \"||\"\"]}{stream.folderSize::exists[\"\ud83d\udce6 {stream.folderSize::sbytes}  \"||\"\"]}{stream.seasonPack::istrue[\"\ud83d\uddc2\ufe0f PACK  \"||\"\"]}{stream.repack::istrue[\"\ud83d\udee0\ufe0f REPACK  \"||\"\"]}{stream.seeders::exists[\"\ud83c\udf31 {stream.seeders}  \"||\"\"]}{stream.freeleech::istrue[\"\ud83c\udd93 FREE  \"||\"\"]}{stream.private::istrue[\"\ud83d\udd12 PRIVATE  \"||\"\"]}{stream.age::exists[\"\ud83d\udcc5 {stream.age::smallcaps}  \"||\"\"]}{stream.indexer::exists[\"\ud83d\udd0d {stream.indexer::truncate(12)::smallcaps}  \"||\"\"]}\ud83d\udd0c {stream.type::exists[\"{stream.type::smallcaps}\"||\"\"]}"
+            "name": "{stream.resolution::exists[\"🖥️ {stream.resolution::upper}  \"||\"📺 HD  \"]}{service.shortName::exists[\"⚡ {service.shortName::upper}  \"||\"📡 P2P  \"]}{stream.proxied::istrue[\"🕵️  \"||\"\"]}{stream.library::istrue[\"🗄️  \"||\"\"]}{stream.title::exists[\"{stream.title::upper}\"||\"\"]}{stream.formattedSeasons::exists[\" {stream.formattedSeasons::upper}\"||\"\"]}{stream.formattedEpisodes::exists[\" {stream.formattedEpisodes::upper}\"||\"\"]}",
+            "description": " {service.cached::istrue[\"🚀 INSTANT  \"||\"\"]}{service.cached::isfalse[\"⚠️ UNCACHED  \"||\"\"]}{stream.nSeScore::>=75[\"💎 {stream.nSeScore}  \"||\"\"]}{stream.seadexBest::istrue[\"⭐ BEST  \"||\"\"]}{stream.seadex::istrue[\"✅ SEADEX  \"||\"\"]}{stream.regexMatched::exists[\"🎯 {stream.regexMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.seMatched::exists[\"🧲 {stream.seMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.releaseGroup::exists[\"🏷️ {stream.releaseGroup::smallcaps}  \"||\"\"]}\n 🎬 {stream.quality::exists[\"{stream.quality::upper}  \"||\"\"]}{stream.encode::exists[\"{stream.encode::smallcaps}  \"||\"\"]}{stream.container::exists[\"{stream.container::smallcaps}  \"||\"\"]}{stream.visualTags::exists[\"{stream.visualTags::join(' ')::upper}  \"||\"\"]}{stream.bitrate::exists[\"{stream.bitrate::sbitrate::smallcaps}  \"||\"\"]}{stream.duration::>0[\"⏱️ {stream.duration::time}  \"||\"\"]}{stream.network::exists[\"🍿 {stream.network::upper}  \"||\"\"]}{stream.editions::exists[\"✂️ {stream.editions::join(' ')::upper}  \"||\"\"]}{stream.uncensored::istrue[\"🔞  \"||\"\"]}{stream.unrated::istrue[\"🚫 UNRATED  \"||\"\"]}{stream.upscaled::istrue[\"🔬 UPSCALED  \"||\"\"]}\n 🎛️ {stream.audioTags::exists[\"{stream.audioTags::join(' ')::upper}  \"||\"ᴀᴜᴅɪᴏ  \"]}{stream.audioChannels::first::=2.0[\"🔈 \"||\"\"]}{stream.audioChannels::first::=5.1[\"🔉 \"||\"\"]}{stream.audioChannels::first::=7.1[\"🔊 \"||\"\"]}{stream.audioChannels::exists[\"{stream.audioChannels::first}  \"||\"\"]}🌍 {stream.uLanguageEmojis::exists[\"{stream.uLanguageEmojis::join(' ')}\"||\"MULTI\"]}{stream.dubbed::istrue[\"  🎙️ DUB\"||\"\"]}{stream.subbed::istrue[\"  📝 SUB\"||\"\"]}{stream.uSubtitleEmojis::exists[\"  [{stream.uSubtitleEmojis::join(' ')}]\"||\"\"]}\n 💾 {stream.size::exists[\"{stream.size::sbytes}  \"||\"\"]}{stream.folderSize::exists[\"📦 {stream.folderSize::sbytes}  \"||\"\"]}{stream.seasonPack::istrue[\"🗂️ PACK  \"||\"\"]}{stream.repack::istrue[\"🛠️ REPACK  \"||\"\"]}{stream.seeders::exists[\"🌱 {stream.seeders}  \"||\"\"]}{stream.freeleech::istrue[\"🆓 FREE  \"||\"\"]}{stream.private::istrue[\"🔒 PRIVATE  \"||\"\"]}{stream.age::exists[\"📅 {stream.age::smallcaps}  \"||\"\"]}{stream.indexer::exists[\"🔍 {stream.indexer::truncate(12)::smallcaps}  \"||\"\"]}🔌 {stream.type::exists[\"{stream.type::smallcaps}\"||\"\"]}"
           }
         }
       }
@@ -798,7 +794,7 @@
         "instanceId": "tb-nzb-1",
         "enabled": true,
         "options": {
-          "name": "Search\u207f\u1dbb\u1d47",
+          "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
           "timeout": 5000,

--- a/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
@@ -448,10 +448,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Anime/core-nexus-anime-4k.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k.json
@@ -471,10 +471,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
@@ -449,10 +449,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Anime/core-nexus-anime-dub.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub.json
@@ -472,10 +472,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Anime/core-nexus-anime-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-lite.json
@@ -448,10 +448,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Anime/core-nexus-anime.json
+++ b/Templates/Torbox/Anime/core-nexus-anime.json
@@ -471,10 +471,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -259,10 +259,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -369,10 +365,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -263,10 +263,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -421,10 +417,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -274,10 +274,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -352,10 +348,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -278,10 +278,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -400,10 +396,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -1310,10 +1310,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -1468,10 +1464,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -1294,10 +1294,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -1420,10 +1416,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -267,10 +267,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -425,10 +421,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -279,10 +279,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -357,10 +353,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -283,10 +283,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -405,10 +401,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -261,10 +261,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -379,10 +375,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv.json
@@ -268,10 +268,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -378,10 +374,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -267,10 +267,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -425,10 +421,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -267,10 +267,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -425,10 +421,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
@@ -286,10 +286,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -364,10 +360,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -290,10 +290,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -412,10 +408,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -276,10 +276,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -354,10 +350,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -280,10 +280,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -402,10 +398,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
@@ -1309,10 +1309,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -1463,10 +1459,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
@@ -1294,10 +1294,6 @@
         "enabled": true
       },
       {
-        "expression": "/*No Sootio Library*/ addon(library(streams), 'Sootio')",
-        "enabled": true
-      },
-      {
         "expression": "/*ongoingSeasonPack*/((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired <-1 or daysUntilNextEpisode>=0))?seasonPack(streams,'onlySeasons'):[]",
         "enabled": true
       },
@@ -1416,10 +1412,6 @@
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
         "enabled": true
-      },
-      {
-        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title','year'):passthrough(seadex(streams),'title','year'),queryType=='anime.movie'?passthrough(seadex(streams),'episode'):[])",
-        "enabled": false
       },
       {
         "expression": "/*Library*/count(streams)==count(library(streams))?library(streams):[]",

--- a/scripts/remove_dead_expressions.py
+++ b/scripts/remove_dead_expressions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Remove dead expressions: disabled SeaDex ISE + always-empty Sootio ESE."""
+
+import json
+import glob
+import os
+
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+def is_dead_seadex_ise(e):
+    if not isinstance(e, dict): return False
+    return not e.get("enabled", True) and "SeaDex" in e.get("expression", "")
+
+def is_sootio_ese(e):
+    if not isinstance(e, dict): return False
+    return "Sootio" in e.get("expression", "")
+
+total_removed = 0
+files_changed = 0
+
+for path in sorted(glob.glob(os.path.join(BASE, "Templates/**/*.json"), recursive=True)):
+    if "Deprecated" in path:
+        continue
+
+    with open(path) as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError:
+            continue
+
+    cfg = data.get("config", {})
+    removed = []
+
+    ises = cfg.get("includedStreamExpressions", [])
+    new_ises = [e for e in ises if not is_dead_seadex_ise(e)]
+    if len(new_ises) < len(ises):
+        removed.append(f"-{len(ises)-len(new_ises)} SeaDex ISE")
+        cfg["includedStreamExpressions"] = new_ises
+
+    eses = cfg.get("excludedStreamExpressions", [])
+    new_eses = [e for e in eses if not is_sootio_ese(e)]
+    if len(new_eses) < len(eses):
+        removed.append(f"-{len(eses)-len(new_eses)} Sootio ESE")
+        cfg["excludedStreamExpressions"] = new_eses
+
+    if removed:
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        rel = os.path.relpath(path, BASE)
+        print(f"  {rel}: {', '.join(removed)}")
+        total_removed += sum(int(r.split()[0].lstrip("-")) for r in removed)
+        files_changed += 1
+
+print(f"\nDone: {total_removed} dead expressions removed from {files_changed} files.")


### PR DESCRIPTION
Full expression audit — two categories of dead code identified and removed:

**Disabled SeaDex ISE** (`enabled: false`) — 19 templates
The SeaDex ISE passthrough was disabled across all templates; SeaDex is handled via the dedicated preset instead. Never executed.

**`/*No Sootio Library*/` ESE** — 25 templates, was `enabled: true`
References addon name `"Sootio"` which no longer exists in any template preset. Expression always evaluated to `[]`. Vestigial reference to a removed addon.

**Kept:** Tamtaro no-op ISE markers (`/*Part of Tamtaro SEL Setup*/[]`, version string) — confirmed `syncedIncludedStreamExpressionUrls` IS populated; these anchor the Tamtaro ISE sync system.

**48 expressions removed · 29 files · 0 behaviour change · 0 errors**

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_