### PR TITLE
fix(labs): remove invalid negate() wrapper from x264 Hard Exclude ESE

### DIFF
--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-4k-apex-labs",
     "name": "Core Nexus 4K Apex Labs",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Experimental Nightly. Tests: hybrid regex+SEL architecture — elite groups via releaseGroup() pin() PSEs, x264/IMAX via native encode()/visualTag(), bad dual audio groups via releaseGroup() ESE. Simple group-name regex patterns removed from rankedRegexPatterns. Added dynamicAddonFetching (exit at 5+ cached 4K or 6s). Based on 4K Apex v0.4.3.",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json"
   },
@@ -11,7 +11,7 @@
     "showChanges": true,
     "addonName": "Core Nexus 4K Apex Labs 🧪",
     "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg",
-    "addonDescription": "Nightly Labs v0.5.0 — hybrid regex+SEL: elite groups via releaseGroup() pin, x264/IMAX via native fields, bad dual via ESE. dynamicAddonFetching: exit at 5+ cached 4K or 6s. Report findings in the Nightly thread.",
+    "addonDescription": "Nightly Labs v0.5.1 — hybrid regex+SEL: elite groups via releaseGroup() pin, x264/IMAX via native fields, bad dual via ESE. dynamicAddonFetching: exit at 5+ cached 4K or 6s. Fix: x264 exclude ESE (negate() removed).",
     "appliedTemplates": [
       {
         "id": "core-nexus-4k-ht-torbox",
@@ -296,7 +296,7 @@
         "enabled": true
       },
       {
-        "expression": "/* LABS v0.4.0 | x264 Hard Exclude — native encode() replaces regex score -25 */ negate(encode(streams, 'x264', 'h.264'))",
+        "expression": "/* LABS v0.6.1 | x264 Hard Exclude — native encode() replaces regex score -25 */ encode(streams, 'x264', 'h.264')",
         "enabled": false
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: hybrid regex+SEL architecture — elite groups via releaseGroup() pin() PSEs, x264/IMAX via native encode()/visualTag(), bad dual audio groups via releaseGroup() ESE. Simple group-name regex patterns removed from rankedRegexPatterns. Added dynamicAddonFetching (exit at 5+ cached 1080p or 5s). Based on Stream v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -17,7 +17,7 @@
     "showChanges": true,
     "addonName": "Core Nexus Stream Labs 🧪",
     "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg",
-    "addonDescription": "Nightly Labs v0.3.0 — hybrid regex+SEL: elite groups via releaseGroup() pin, x264/IMAX via native fields, bad dual via ESE. dynamicAddonFetching: exit at 5+ cached 1080p or 5s. Report findings in the Nightly thread.",
+    "addonDescription": "Nightly Labs v0.3.1 — hybrid regex+SEL: elite groups via releaseGroup() pin, x264/IMAX via native fields, bad dual via ESE. dynamicAddonFetching: exit at 5+ cached 1080p or 5s. Fix: x264 exclude ESE (negate() removed).",
     "appliedTemplates": [
       {
         "id": "core-nexus-torbox-exclusive",
@@ -331,7 +331,7 @@
         "enabled": true
       },
       {
-        "expression": "/* LABS v0.2.0 | x264 Hard Exclude — native encode() replaces regex score -25 */ negate(encode(streams, 'x264', 'h.264'))",
+        "expression": "/* LABS v0.4.1 | x264 Hard Exclude — native encode() replaces regex score -25 */ encode(streams, 'x264', 'h.264')",
         "enabled": false
       },
       {

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -20,8 +20,8 @@ Nightly templates test new optimisations before they're promoted to stable. They
 
 | Template | Version | Testing | Import URL |
 |---|---|---|---|
-| **4K Apex Labs** | v0.4.0 | Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`, bad dual audio via `releaseGroup()` ESE. Simple group-name patterns removed from `rankedRegexPatterns`. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Stream Labs** | v0.2.0 | Same hybrid regex+SEL as 4K Apex Labs — 1080p variant | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **4K Apex Labs** | v0.5.1 | Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`. `dynamicAddonFetching`: exit at 5+ cached 4K or 6s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Stream Labs** | v0.3.1 | Same hybrid regex+SEL as 4K Apex Labs — 1080p variant. `dynamicAddonFetching`: exit at 5+ cached 1080p or 5s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
 | **Apple TV 4K** | v0.1.0 | Device profile — DV Profile 5/8, AV1 excluded, Atmos preferred | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 
 > **[What's being tested? → Full Labs changelog & testing guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md)**
@@ -249,7 +249,7 @@ Both templates keep the full inline `rankedRegexPatterns` as a fallback.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Version** | v0.2.0 |
+| **Version** | v0.5.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Base** | 4K Apex v0.4.3 |
@@ -260,7 +260,7 @@ Both templates keep the full inline `rankedRegexPatterns` as a fallback.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.3.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
 | **Resolution** | 1080p |
 | **Base** | Stream v2.8.2 |


### PR DESCRIPTION
## Bug

Both Labs templates produced this error on load:

```
Invalid stream expression: /* LABS v0.4.0 | x264 Hard Exclude */
negate(encode(streams, 'x264', 'h.264')):
Error: Expression could not be evaluated:
Both arguments of the 'negate' function must be arrays of streams
```

## Root cause

`negate(a, b)` returns streams in `b` that are not in `a` — it always requires **two** arguments. The expression `negate(encode(streams, 'x264', 'h.264'))` was only passing one.

## Fix

ESEs return the streams to exclude. The correct form is just:

```
encode(streams, 'x264', 'h.264')
```

No `negate()` needed — whatever the ESE returns is what gets excluded.

## Files changed

| File | Before | After |
|---|---|---|
| `core-nexus-4k-apex-labs.json` | v0.5.0 | v0.5.1 |
| `core-nexus-stream-labs.json` | v0.3.0 | v0.3.1 |
| `Templates/Torbox/README.md` | v0.4.0 / v0.2.0 | v0.5.1 / v0.3.1 |

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_