### PR TITLE
docs(claude): add preset types, SEL variables, formatter modifiers; fix torbox-search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,26 @@ Templates are JSON files validated against the AIOStreams schema. Key fields:
 - `sortCriteria` entries must use `"direction"` (not `"order"`) — AIOStreams rejects `"order"` on import
 - `addonLogo` URL must use `/refs/heads/main/` not `/main/` — the short form breaks on stale CDN caches
 - `stremthruTorz` is TorBox-specific; `stremthruStore` is for other debrid services (AllDebrid, RD)
-- `torbox-search` was renamed/removed in AIOStreams v2.30.2 — keep it `enabled: false`
+- `torbox-search` is a valid TorBox-wrapped search addon (not removed or broken) — keep it `enabled: false` to disable it per-template
 - `syncedRankedRegexUrls` is **blocked on public instances** (elfhosted, fortheweak.cloud) — triggers "Forbidden URL" error. Do not use; embed patterns inline in `rankedRegexPatterns` instead
 - **Regex requires trusted access** — `REGEX_FILTER_ACCESS=trusted` is the AIOStreams default; inline `rankedRegexPatterns`/`preferredRegexPatterns` are ALSO blocked for non-trusted users unless host adds UUID to `TRUSTED_UUIDS` or sets `REGEX_FILTER_ACCESS=all`. Self-hosted with no auth: set `REGEX_FILTER_ACCESS=all`
 - **SEL hard limits** — Max **3,000 chars per expression** (`MAX_SEL_LENGTH`); max **50,000 chars total** across all expressions (`MAX_STREAM_EXPRESSIONS_TOTAL_CHARACTERS`); max **200 total expressions** (`MAX_STREAM_EXPRESSIONS`). Current templates: highest single = 2,953 chars (47-char headroom), highest total = ~35,000 chars. Do not grow the `Final Limit (All)` ESE further
+
+## Known Preset Types
+
+Preset `type` values confirmed in AIOStreams source:
+
+**Debrid/service:** `stremthruTorz`, `stremthruStore`, `torrent-io`, `torbox`, `torbox-search`
+
+**Scrapers:** `comet`, `mediafusion`, `mediafusion-public`, `jackettio`, `prowlarr`, `orionoid`, `annatar`, `knaben`, `torrentio`, `debridio`, `meteor`, `torrent-galaxy`, `zilean`, `hdhub`, `eztv`
+
+**Usenet:** `newznab`, `easynews`, `easynews-plus`
+
+**Anime-specific:** `seadex`, `animetosho`, `neko-bt`
+
+**Subtitles:** `opensubtitles-v3-plus`, `aiosubtitle`
+
+**System:** `library` (continue watching / user library), `custom`
 
 ---
 
@@ -214,7 +230,7 @@ Note: inline `rankedRegexPatterns` are ALSO blocked for non-trusted users on pub
 
 **Array ops:** `count`, `negate`, `merge`, `slice`, `perGroup`, `pin`
 
-**Math:** `pow` (from expr-eval)
+**Math:** `pow`, `sqrt`, `random` (from expr-eval)
 
 ### Key function details
 
@@ -243,6 +259,20 @@ Note: inline `rankedRegexPatterns` are ALSO blocked for non-trusted users on pub
 **`indexer(streams, ...names)`**
 - Filter by indexer/scraper name
 
+### SEL Variables (available as bare names in expressions)
+
+**Content metadata:**
+`queryType` (`'movie'`, `'series'`, `'anime.movie'`, `'anime.series'`), `isAnime`, `title`, `year`, `yearEnd`, `season`, `episode`, `absoluteEpisode`, `genres`, `runtime`, `originalLanguage`, `hasSeaDex`
+
+**Release timing:**
+`daysSinceRelease`, `daysSinceFirstAired`, `daysSinceLastAired`, `daysUntilNextEpisode`, `hasNextEpisode`, `latestSeason`, `ongoingSeason`
+
+**Dynamic addon fetching (exit condition only):**
+`totalStreams`, `totalTimeTaken`, `queriedAddons`, `allAddons`
+
+**Groups (group condition only):**
+`previousStreams`, `previousGroupTimeTaken`
+
 ### NOT available in SEL (formatter DSL only)
 `hasChapters`, `editions`, `regraded`, `date`, `dubbed`, `subbed` — these exist as `stream.X` in formatter DSL only, not as SEL variables in PSE/ESE/ISE expressions.
 
@@ -265,6 +295,23 @@ All used via `{stream.fieldName::operator[...]}` in formatter `name`/`descriptio
 | `uSubtitleEmojis` | string[] | Per-language subtitle flags (🇬🇧 🇫🇷 etc.) |
 | `seMatched` | string | Name of the stream expression that matched this stream |
 | `rseMatched` | string[] | Regex set expression tier(s) matched |
+| `nSeScore` | number | Normalised stream expression score (0–1) |
+| `nRegexScore` | number | Normalised regex score (0–1) |
+| `folderSeasons` | string[] | Season folders in multi-season packs |
+| `folderEpisodes` | string[] | Episode entries in folder-based releases |
+
+### Formatter String Modifiers
+
+Appended after `::` in `{stream.field::modifier}` expressions:
+
+| Modifier | Effect |
+|---|---|
+| `smallcaps` | Renders text in small caps |
+| `rsort` | Reverse-sort array before joining |
+| `lsort` | Logical (natural) sort of array |
+| `slice(start, end)` | Trim array to index range |
+| `remove(val)` | Remove a value from array/string |
+| `star` / `pstar` | Star / partial-star rating display |
 
 ---
 


### PR DESCRIPTION
## Summary

CLAUDE.md additions verified against AIOStreams source. No template changes.

## Changes

- **Fix `torbox-search` note** — was incorrectly marked as "renamed/removed in v2.30.2". It is a valid TorBox-wrapped search addon; templates keep it `enabled: false` to opt out per-template.
- **Known Preset Types section** (new) — all confirmed `type` values grouped: debrid/service, scrapers, usenet, anime-specific, subtitles, system.
- **SEL Math** — added `sqrt` and `random` (both available via expr-eval, confirmed in source).
- **SEL Variables section** (new) — all context variables usable as bare names in PSE/ESE/ISE expressions: content metadata (`queryType`, `isAnime`, `title`, `year`, `genres`, `originalLanguage`, `hasSeaDex`), release timing (`daysSinceRelease`, `ongoingSeason`, `daysUntilNextEpisode`, etc.), DAF exit variables (`totalStreams`, `totalTimeTaken`), and group condition variables.
- **Formatter Field Reference** — added `nSeScore`, `nRegexScore`, `folderSeasons`, `folderEpisodes`.
- **Formatter String Modifiers table** (new) — `smallcaps`, `rsort`, `lsort`, `slice()`, `remove()`, `star`/`pstar`.

## Test plan

- [x] All 120 pytest tests pass
- [ ] Documentation only — no functional changes to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_