### PR TITLE
docs: add complete reference PDF + generator script

### DIFF
--- a/Core-Builds-Reference.pdf
+++ b/Core-Builds-Reference.pdf
@@ -1,0 +1,346 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 6 0 R /F5 7 0 R /F6 12 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/BaseFont /Symbol /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+8 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+13 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 32 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 33 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/Contents 34 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+18 0 obj
+<<
+/Contents 35 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 36 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/Contents 37 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+21 0 obj
+<<
+/Contents 38 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+22 0 obj
+<<
+/PageMode /UseNone /Pages 24 0 R /Type /Catalog
+>>
+endobj
+23 0 obj
+<<
+/Author (Brevity) /CreationDate (D:20260617053557+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617053557+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Core Builds \204 Complete Reference) /Trapped /False
+>>
+endobj
+24 0 obj
+<<
+/Count 14 /Kids [ 4 0 R 8 0 R 9 0 R 10 0 R 11 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 
+  18 0 R 19 0 R 20 0 R 21 0 R ] /Type /Pages
+>>
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 534
+>>
+stream
+GasbV9lHOU&;KZOMYBZB`5.0ck.%DEW)9BL$--B9mZ:7r8\AZ9rqh_HKI*[:<EipKq.8]V%uH7SN8Mk[>h6F[,U!of(:"JTl7_p7-VoSH;/.D!V(.=B<=#A-jStC4^C$3n"]'u:RB61(YU7OD"a?SX:cWT9`.8d?<+Jfd&BHUC8udd+lRgNqUEa#=?,,4/6i@\kH^qj90_3HpWiTB%j`083*`M1H<*YhB<[J>VbV;6Rj9`<FOs@R^Hrm>dqX`<#n#.+IW/2g[V]#+`RBH1F9PIfZNpTCn'>\2^]-9n.UMb'7=lT"C6"N[g%n$'ZVJ9U/IXk\^(Mg/e@H:$"%:P-!k"KR5Ch4#mY7_d[$n*qKhGf4_4ml&HXHrkCA1Gcal>u2W_Gs,dMqd&4>u1H.FId>t[jS\r,OO^AoKCogG[A\B:3P[0dIQh4nX`uF20Oo&B_Q&t';cf%Y-[U.KZ1=7^U03DI8A8:CJiOlkg4U+Dc;JW`W8pLAi_-6590&Ps*K/+4J+:hGg7cR8$,,K#9I@7nc~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2916
+>>
+stream
+Gb"/*>BA97&q9SYkfSec-]rPd:pkEq,QYc5,fF;%#S1EZCl@Ld7T(iBr:fT@XBRTKKc&)KS(^u.*`#R]e'ldpT27em+!psSL&`l>0R9LFU;C^IMD"-IHO$ITdFXMdl"R/\l)9UDQ=W^tBe&nkd>')2k[rB(lU[0r6ZmL4F@EH."!lXJ*E`QS*2-9,RKmR9E=OI5cf\^-)=/k-UZ"6V.>=b5U*4ddZS+"ZcKFn0RsJ)_C@qed@@t"Ra]8i!2Gq5l.@Ps_Q>G23>eM1Iq%+_5VBad&@q-a6l.5B)UG;b_D,<&QF,m-8%?^6([Y4US+FnQD9`fuFGWWSuLP6gXo?L-5OP[s<`p:NmhU2D`q%r=naU?1,k0W/kmY<VF*_FK9cPo%E5U,Z:=#Z-TrpioVW<\08?.o!`#Lh(i+=jbW?pi?_>LjdUe,nsVCTJ7dXF[)[ITEPTUd3,#Vl"'n)pPr?2`3\->CkjSKc5F"o&pS8bZ@eEnI)d'XQlKg!J8%1Ne?npZB)(OeYaBYb"Ye0Vla]'q(9RoG)iY+nrStCD>2,?3Fl[>ff_*.c(?*22KfRHg&o>PFt]IGB_@s%]ZQ57cf3-%)tR?HkAI>:Jn)^-%8[e-Hh[LiT*AW>N>nE&%#gLLC/s0E_jWdF<L"RrG4^+5o,**LUMh#N7[qKTSloR\JE"Y>]qUtj+%Et7T3HK<hAgUopU4tab,h;*>-m*^;W^KmXkG78`+]#bq-PobB.%Z#WYT+OKfPp;Iek1t0r'L9^!DkZkHJQ?iSVNsArrg!*mcs4Di\&bB:8he,8/EGkRZ0#&:G_U:Ab5LHiS%-,cg\m!^D:3Z\rP?-j^R^Gh.SO@1#9OUP[1lFm@"E&!.$r*!ih]D:;M/;Fn)I,jYQk"f/3QHcHGo1U`=-m2h#R^bbr@JPP3`\U>HCTXKCg$dlCQmo.@Q'("^'JmbU6TnFH_i>TP1?GC0IWWHQT=c*UD"6P0g#/VoZgYPSX=Y;0dHs$U:]e29U6NEXcPU68p_a&>HnJ%^79#JCm.uq@<7rL&`V"\Nbq"sVqG5S3>>.cfm3jLAULLn[NG!e>fh(WAn.,-hWF67grn/_4_,!Vn!dg>lP><JMSb>fI&qQH`O#eH7?SQGH!jtk^9M&WD$D>lYX"%p"?RL3jSg(ksL[#N,^0M^&&U"7SE@%5I$.Cl9f&a"a4n=E,&DL_tl*XJt]D(3@:3=c`/>+7bqA"&^QN#24:K,E(Gr1N@@>dK*[&0G&Z)s2_JL;aQEar%[QQ@?Efjudd*j!^a$MRS[dZFQ);9of%7jCRHY?8B>)8MXFGJr_)FUWKnn)]e^S,&Vu"MF:)U`62I[0Mpl8,nQg;1A7J"p[@-$8*@'Ohd*m\64\$Hi8`A"0(0P^D@bnG?n5ZECd38^f+t%Ee$i$eFT<Hek5QJf@;GGn'DL5,5<a"[96gW`f"<)L5'\',\+ouiY*,r`_d-7C%-q@5Dt;V"<Uq^FEpM%lULU(BQ@X8aYpmP%.H4pUL57c=OjtA32_1#a[7&ZK7%2dA@C$Rq:.p8b8gLGh&N3:ED)<Qk.Ku^*'O[sU(bJ.8)@*AJK@W;]%75o&U+:pZF!.JPN@Y-6p`Po)NDfaa>OblUc0jT!hI[%BZ$;9&R_6dL\8Y`f?gpBi7h/E4[-_<XjZ2.&d+403AS4^Z;Kh3Lmi5IO;Kc+.h.:6L)H(`ZNSS_i<?"h\r^.\'+V+KI`.=eT4,F&<Q5nSVq[R6@1fZrgP^$LSSTgBrX!nQYfMO'RPVD]#n7oU_e!6?C,&3ITY'9CkmU>TMKl)J"B6]X%CrF*ZI(8$oiY4:Bs0GG^KU4D#a!^&?]c]7EM'sN:m*>&Nm&H)%MIV]O=UEAMKoaAWg^?YNZ,T[!K8RY<np5g.*Kp*,9IJX2m;s)n&lC>f'8H7ij-k8^#%XCP2BWerI6gKs1Z*ib^mZOj?-N(R8D0/$;oU>*5$m/-2T7d+mL!lr&GXXIf/3p`C5AhaXVjiH\ihRDE>b^XNQVpKj7%;Un))6a(^@TaJa.A$`OD52a37=.o=)Kf:n'RDBA;Kcb93C?i5MU42tZ(Eo,2\]DuBD.UMu7Y0+d[c1T)oRM*(]#juh;k!$Y*C)2us]-l[@RUl$RoL#i5j-<\^=,mJ+3'NiI?7a$BhA2MP5KX'N_hkLR2e%hdIqH7GG778#o[ec.BI#<QXRsqF](oY.X_(f*1)AefARUMeu2`,C0@!BI1k+)R"mfo1M^!k&^]oI,MA\K#(^Bt<QWs_@I.51P!#kJNbZhj'jIVJaXk5"P+/Gn'QKQODM,1k&bJrlcq?k>Z>o+ro*@mAuW6<Nb.'&DKkYLFBFcq2Oj@DOIJJ,;f,Jt<?'KV[Ilr9!'TEgnS7ZqJ"Z6FsH^p[mJ\M'<l10j4io9VnQgT>m1mN"<otr`bZKn`Se)**6b(!PXWB6?q;oIX4qaf&745+8ZG<iT"8K6WQqKG>l-`%$pPbP,/"%M&n&NiF'hfLC]S+Fo@$_k-mhkO$0!@VSC)\MDoGerj!=]J!Q%,R>Tdj"UJOK=hYi)&f;d>l1`uen!hp\NL&p727;^tiMODP+j&l62T(-c+XD;'n4T&hE7f7OXu5i,rI5'F)o]--g[b1@kE*/n'"elW0pHLGfq%!k$pX!cj+K+^QdaEZfP'r/;To;X4W-YFY<&8]SOa$[9$?j9qX]LK@5C\06uMoFR*:38]kLsG];\Ce)Jm/".e0V6#eYqj.i)d@'hi!kYF\RH82Q5-%g,LdPo!j'X&<5](Wgk)NElH9+/#&7i,uqur8J(S!)L=>gn3omj@GJb19>q0?et6dY-0hs-WaIs=$7C5:mrT9B'hQtdM0e\CWG+j-@':VX;rZWRNeeEm5X^b'H&cH`sIg(8?8/j%PmYeLH1I61lPo0j;_db-p;/m7qpX6l1\ThUON8#q*)I~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2534
+>>
+stream
+Gb"/(>BAN>&q9SYkfORl1.$2\V"TAIERs:a-O]]K*aD,CBRkpc%6GJEP@&fcF@.J9i[h'WfF8RJR%ER1Y@m^tBaiAYAYafg&\r<pkhI"_QnY+a@;@c[#LFQ"r-;`3P-1dp^?HT`mHU/'\d$Ht@Em..+!3>opN4R`bqpElF$V?0E)!*,A&1,k'c%WUVEu_F)4C`$"\kqK7#LY2Xp'4]j0(097;;c(?X!mX2n-Tqbc1i\D&?Op1g_]?n@`Tu[]_6<ELu?Dm2;AUq&Zo&/dMgU?Z8a4b!fR=8YfHY9-#h=]4Y;B1!)/1Y%u]TYV+'U9e'O'hm:EBbaf[d]G+BkO';d7#J.>F^NIG-(f\kaaS<?$b?<XfoSuS5<(-CYY#&`[PZ:$QNh&\ZFR`]SlL0)nKj@ui`IbdmTX==r(%'Z1]"c"nL,g%mQP<KR7V$K_8N])=%ft5\FXQ9_[9lGgjq"KGFYc6k8u"F[/7-,EBm(Yn'`K'CkI<L)A!BLo3,\"oE1FpY)U]9cr.E^HI@kO$;A*UPcUjL#O;n=f-mRZ<aX(:e4Co+S6<k!(r=#k#Q"3#6O75'oBCK.0Z^n2]N6U#aAiuZk"n:bX3g9'[\fVEF9B^f<Kh&_j:Qe-\O[pPM2H]\qr;ZFVo<R/SH+%:WOdanP*RBAsLC5Adk9A_OgB<7,+cOhM^&#FVo<l;tX%5'#K=SQKJ5=,ak2XSa4r"0eKe!9#<"*/TXUO,d2W-T@%$V([6Z0a_[=FODk]XY&PF;Xpqi%n=mke4%6rLO,![GjZBS'*p@uI/l2_ZB'"F(o()T,_<;oa%\jjViQBaK/CV]*.+;)R/r]K`$`ptnTAP6m`Ih$^'aB;*j+*X>AM3YK:djKllXqpHi)Y&VW3aK[6h2;65";NQ-41Q%g^6aC%#\<%#Y39Y>/H/[aqPON+WCtd4Q,q`ihi??/b4/5)64$Xq@`$E4TSD!s26HD`[B&]H-_37HB2U%K-*Bso<Ip@bl[AO)lWhj1!@X%`\\t)Mm?9]aKB8Ne>Q)(f5qBuZ.<MbEAg7][LBImREGa+45e)C]/LGQ($BAb9JMU0=feoAsP4R4up&HQs.LiplqI2e#FOe.1r,F@WVG7h<jLmogsA&u>?jCV^^s,Vga+;-=?_f^3sK!#raCY%&B#@jcCIj"/jA6lqgfmW2P<b;4Z/")eUL8>kd>M*$V'O1dC#G^%-e,eZJ3nR%Y.piT0WF2+#1>:c./sNQdb&Vm::*`MIZ%AMW^+!^.WD1!XR*4s:\Ho.4Me3lR\"?,f:_G(qjf4\BlEes]osm0h(+FRWN^q.`]JH9PJq1lD^>ON!pO:K?a`j\+"J$p2,pbk*M(kKBlE_G&CDP-sHV8Hf?$@N\,(P`S6H&aD_0aPZoc;8tCl(Q-!^,;FDCu?0,aVt'k2KU?h)OmCIjqQVn*;Tm.u`s#deXS-8T4ADe#n4O:'D$JWWOd6?5R"H?XCV=qVgfjmQ9Ue*GG"C3CeqIl+$0\P=dG2#g\+(<`F@;j<<>`mu_,DWfB]#c$l!bHL!*A*>gH)MMGS.79eo`M,W3=oY'[&C4CC$2_e?$6P;WC?b2m`pEE9LEC_TOF<*=-C-<$2DCSgI.ZQ?U06n`j`Y$+J_1'BEY0B;I%PXn:(2U7K,(V[3#WN1n)AfQVX7.($6?&Va5FS=('p4mM@TB@]/>i1H@Varcm3jG0_'u&AjuG_#blBLdf:0%Fm=f!K6iY?jk&rHH%k#&kX8Zf)Wt]=Q=2T#T"\L)a#'<VEIad45"/>mR&k[c-X577VW=5(RH81K8\Mf`77&%L'_q!&loaXsaklcW1(tOX/!I2dFp&]0sY6KI*+2F%q!(%GUfo5l"ncIC=Y%-FLU5:p<5[RK70gYfVXno<sAV(:a#5u.Ej51s8^.5c;a@e.pQ#S;j*tS7^O-BR0cU3BFp=%i21B',u%45/kpP-@36trIJ0l`=tH:;6D&UDd^C+Y)g6!&:^hLTt:4'&4sX%=0Nn<?lfJj611i.e4(gd$,mrDES/`#YaD]NN&DNsHTYC2rm4.Q$HK%F0h7423J>X#qmo/k2[AFL:(;i''<T)DQ1I^V2Yd]9PsbpJ:/;(l"Z+B<I?o(0k[9oPt</[$@4hgJ@j;A61GPi3\?*'dT?E,cRlrE)$$(1Ydk3$80s_ShPMeBqij3A<dIK?_D4rcAkPBF]0?@Altd(OW=(jCV7q+_esL+`ZmUq&IfSFYLDiAq:s8rKWbNH8E/G-<g_E(,-Vmu36i+['$!D'ZH^mF`1i+."U[48.i@dY.\c3`U)]d/$-C?p^9R=NKk7Jn:P!tY:PSpj;PJ*c-T%^k0Ka"4pr2n$)u9Z$@$*mMPO_(f's?k*E5tj<A]@b(B$p<"KYnRtV&b>\/5V%[dOR?7=!4B$]KNB@8p6.NX_cmsVio0Xg\:O?=nUZlBUfe5g.t`V-kOCV0+Zb%B'+!8pkb#=H3R;82AJVr@#"=jNuFtcoT#+ZU1tdjdSK0hD$?Du:=Y%4O]@2+Yo#g9Wf5lbhqP+[XPV^31:hY*'*T3P#<_2OcN~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2580
+>>
+stream
+Gatm>>?BT<&:WMDTf4kYGV.\@V(Xun,p=]tD.&k,JJ[:qJfA&4?T-8<hi[B]iu>jjK5GmEc$\D>o(W<G<;=<*d1$YufV$bbN3J$p4+n'^5auP2\QM$HE7r^i'[tGLN%E.QCt$>lgu;ON#K*W)4=q7I-^nNf`PC+]#uYSK33%_mLBTZVFWB<oJ/C-4T#Y71#aP\+]t?fVZd;F[-q$"1a'ogqllFgXM`1$LLu8''ckO0MJtSa_kK?2s0emMY_D$)5>B%#M@b^,/dj!"k#`rIUMJYF51jjE"4$IPC00m>ha+AGoJ@"N[5\g935G7,Kn"X0F-pdJj4eLU.%!a!Ws89oS)D`9WW&UQqkC(R;KS.%:iBp'VC@'-UAU_2dBG<(bHg:T\%`ukQ@^\m<GI=>g_W"RY&(Z]9Ue1Aq);XlOSMGapeZ:KLFtdcaFKApV)N*M+WpUuu/%@f=]j@L@7i3&kY=Q?YJHVEf8a<iX_cUiE`%7\1/Z0VCPKu@e38D%SB1mk+aJ7Z2f2\2b2D-b6#-!Lug:`8-q+o[6Zh:IbeOW:B:ZH(ldn0M&Bo\5_O%YG5CZ?XL+u(j-c=8)/)p=1V)WN%]QH[GHGQomgae1G]5YEGRk'6_2RI"YTj?]PgW*4rK\TkVdL4%1Po4<^#4hnB_#n6(fe[_cii7@1/ou!Z,3%AXRY?Bl)hYu_qC(FR6Y8bl-CF-mPEQZf>X2m,+T0>=1lleiFb[j&3n!5ejn)!_T)GT:U*X*8$YOpKUZ2boDTCosp^`1\`^upF#nO\$h_WQX%nA1oJ4$It8..NuG$5e0p>"S`<g@Nri*s2`9TA9;T?Dpr^N]5(3km/RuM?n,DQdMs,kJ3Q%Be#\Thk%e>$WGAa3R#rk&l;0O,1&#l7#h'EUt@S;5l--]-W8NhLef7Z!Q'pS!7]^QF6gMKD9<&*![d2C^dO^qYWa)#UdG`e2*I_G4p+(=.@uPrd\DWfF-s9..AJW<LLU%k@H\2W7ch)c&UL)"?S(TV#Zb,Y^^qqQBAho;A!l4-Rnf'@>7oY_d6@/9roI?Q0EBXkUL[!Fm?Sb>j-91]oFac1\>A^2JS1#beVqNsm5YNOI'-0J.HqHef:oI;f2132Y[GaR?3S`"3XLrjO35Kk8^T/&:Dmt`UICt5925)3r<uhl9Em!2ok<GB)CMb*/+3Qgof4M&+'G+'M)QHOUfS/ijg,?I;!!(<)kNh'.]V"1AYE]^VeG6JIldu(lb$`&)f6Kl2_D\.,r86W-pSI]+X%u#^*&l[SM1FR$m,uT/HpQYJfkDM747gNN0:K1;fn1Is1u73o1fq<[Ob0K3q.NJhg^F"9>s.\CHX1]A,tKI.V:8M<X/*&g?R>UdPDHd_ceDDXA,Q@R%RTO$qE!;ZSq':@"N!-_F-(DZSHO*Wb(27g14^0"O5Y2)M/9a[E5WU'/XKg0!N0][0[4Wn7H6P">ZL%$VR/0C7$[Y,0YcH6_M7<X^m6u-k2Q*@d`itlUI/YDg`8%DNS@a=!r5^M-$a"m[`N.1&)ZPQP:W^[BU.@]NgdA<D9Mi=`-oS,FqGt33qD?WfE(?Fm?'faD.WQ3i8:uSN<gMQs-&\lIa1R;eHh8eiRHnZ'"R$#-fYA6$k_FVG.!1GkuN]lue6IDc1j4H]#s]3sq;dX57b1H-%$0?HeSRcZg#'b!8f<\3Eq2<*1DU&5.Y:`U7mKJsp@t:#L^9nB0@U%b[JESm^*oc^)RHGFD-Y'K9N^\e)TYI4p!\R<b7<Mkp56?HPN`N=.u27FKHBf>%:c1B,##3*T`+(H:1R?F2^b8J\o5a%r0?\2T*Y8cO4Wn2O[GjU.S,X/jG4++OaU0NRB4p%`e?a6t+qn2NAl*7A0iZ9MeFS\g;\ms\T[P^atLBRlZs3d=IP6]E(4//`"#4*,(a#;:XB]:fb=VaE@m5!#jt2^kMM2d(Xn'4cNDeR,<aI_Pdaa4p:33&T8,C*Cj1?6mRMV#NVjnjq+[M?B:K4e"E@=)6`']t$;<>,/:aHjuo<1h"go3OHXcSe$l=%%3`DoXKr\plUN0G9I]p^k0]q:6;=ArIj6%9i8r6dHAjkrUQR^6pgf#Hq=,&j.hJWhg'urCNCn`8Tp_PWIKSJ8nB44^CPN'8PQu3G'+:CZ.(R5ciYqS"+C/c$@^)6HL^1G'[*0EA&FDN4@`s4:3V6%VCtk'0Bp+_Gj-8<4pR^s?;Le\JDQ`io]5;'AEkK>pLSfos1H:f6$Jc0+mQXTT-ib)P><"-/Dn5TZ./1@%lf0^**$XNrCO:=)+#DqAM?WEOK\EUKYJVYiaRi_I?'0uMRnH'*q,5H.HS(8s#s>hlot-OW!isgQ>%&j8'aF+"QgNO$"`l?S@I'sAD<Q98JV"/<;b%o*^ub5F[I38[=J`\JJlgHiTp$Z;+<H_WsAn0:D`!#gaIuacB6i;h!%koO.YWtmC?KTI_oi6k![_C8P:Yd7CcN=1iofY[S9r#R<+e$D,OT,\LhRYG"XX#7*XM%C$%h5b_b1Sg.bFY2d8nd,:`'i8R2+-S(*0%>9Lh$\1e(9b_?EJ&4%3UFFaY0`I^WI`<!E,I&c<II!K"o[ZKFpidX[1^hN~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2616
+>>
+stream
+Gb"/)gN)%,&:O:Slq9i@C=Bh&o$VM^\W\r=1mZm_WXk0o9<<D95Ua'Qo'p#T!g3m^;%29K:)ctSK)g,A*\>)iKJcTr7nZ'J+i(S]E.+d<VSi?7BVo7UrB$D&?[TB1nr]6?fUhNi0:nrK[]SM:fWBCqVE$O_Sn5OBJ_uK*R3&TW73q;B*ACbnEF$nE/'S)aiScX4'gKYS7r9/C=Ah7_2*>/l]=MFm].E!LA]#Qu=n>Bm<qQKZ?0e:pgDs\RdSALRbTTY::7e2ZRYUKAIV1V"9kbO1i20YQjZ.u1AJ0R8Q2;,i\,0jXrA]*,pOC$Xl_AHglRBEAbL,4rAB"K&d1'hO\o=\j\ZMY[-B"FmX)?r^#EHPT,FVjPL2_KfCK>:I)%@uckRT6$mhXB*1J5OF&emdf/7)=q]uQbn]8U;DL0@j2><h&1_=@Rd)V><T&<W'_69kS\DZg+SF;RN_P1=%gr%MI+52d#?:_-nmHNTHk$4cYA9JV/p=aRUK'C<sr/7ZDbFRc'j,Oc<5"7G?$,pRiJ)!JZY`D;`d5XZ)2N[pP!JHnE48QY8Y2+$Y?]oJla.M+Vm/,Xqug/^NIjjXWVh%>5Kr$<TSE6_]!o\2:S3J-QE_H5L-:H7E33^S%tERt,X5+`Ma5dtTmj*L`s5$s!fE4YHL[UkK(`+bBr%B]&B8Y=gfT_!L!2k6)^('q#8$'.Hp_#TOCKPrgpKYJa'_RK;nfkf!&qLQBHdGIg8B2K6i@)9&nd0?Lt1%j-Ti]]SK5d<RU7j,U.0^C/,[a>OPd'h9^=K\nE,!3GZ@`L8o#lg#.Smo.2KMOR?.1)&2I1frk!e(n8?GrIg5oro<Qj4;pX:mEa/go37%%ALJ-B/"T`;b<m.'=m"$Ri/lBUGr[l_kTeeTX5_T_Neqi[$-+@*oBj/i?:h%k4[C=0O'a;VmcNDQk?=ebc0H[GISu\SnuFF3V@:('A*JMB$b;oi>nO/sK#Z/o8Z_e3qh>Cs"Ap6Id])(1!k_.QuE63`+p;3j;V+TTZ9r@&rKVrDMmq<_5`NM'F3Z1upL,5>"s\QdXHHd^FFOm8^Q4+b7d95%.K)3Rs;C7[h[j?DhLS.L+*u0l!_(80;U9ODCSN?+gg.VIl>A_Z,tFs%98,lK:_"I.S4Jj\_7>6IXH`k=&7VU@;TR3<o>m@otT3)u1]<5%QB"N\]cRl2,i`7Zg5#JPQo'L`,:Fn^@8id1(Lf44mCUP+;:]"736YTIc`-Qe"X*bF^S!19=@n:Fd1AEhS\Y&HQ?Hk64_+f$:%(V^a9:UH;>cQgBBSF;^8)InE>`\9ZfJ$-`duG(m<1#!W^-,niON>$**CMt1EnJ^qQXI$SA;Siqo3^ViCi-@llYorV4MYg=s`n#0FpXM3(_+kC"(Ue*=+b;'WC#6"+/'XcN##*E$)M_p=p/4Dj,0.c!_9:C]m@';D6nQkAhM.q5\T-;_<2,0!Zb-dZXfV6=`9B%@\[8e37Wn/h_%+cCp*1:c`(ce6K>/_(dEH$q#_LTpn7n2P7@pR#dN=tN0..A-4<R%bs.%j>f[2Ti\c*#`uT2+%hX,76'@u(t,%&ZOQP@]b'LX5on7/4JsYu\m1L8Hp?L/j34;UsfeEBL[epCV=<:)W):^A8PsP,a(Nl^R]'qf#+E`"-lY(GFge6LBpO@joKUD?t/6b9X\E3]i8VJUZqW^5Y<S`aPS,%P$(1Y[:>e=GKaFpB-=@E=(6/Z4Ao%]Cq2i^`GkeL6Qi1_ijfbHnD3tU81B2Mtqpalcahp7k:*MgiR4QS@T(8d^/l>3bgCid*>5@YBnPXT!(aXQuKq;-.$?(9cq@[@]2)3:ECqr8G:6-'TUgF8<*2Cickmb^8!5B/N?K$W9u.J5LRFuFWsC!LnRT?4$WAJ3'Tg/E_d9[8_II5+J,`[@q3.cf_JAT^<^jGMT/+]'rlIto$(b)H-4RA`EXATb5$UMNfQ"UINhPYjE;S#S;l@t1?RSH(El:tZr%r-qb5q/5@H:;c"Dr9J0U-9F:fK&\J%=E&`amuTY\aJ8S59mO'p6E<^p@*)(/4WEa`O,FpQZ68<h[_oi,ZYY9pfm;K4]S_<$o-bHAr=]2W!H9l6;pg<sbO9/"e\UZSO(E6C_->M&6n01<Qk'`G-X8iPRD&Z+gULa'tC9^s^sLNj8W76cs.,LoEqWa!;94_m==+["]tTm`'YSo@bqfe?]FN`3S?1:,9j/q-ttQR&8kiamN*?f!jrMOe#mM)0Q(8pCMg95&XsqtBt/U]qU<Y1@\`%W<91X!m?f@?"(I\K@s;?$6q;-W\JJ7Z95#^p#5:D@&)oYU:iu=<+g%CaCcJbXl1f>0!>0Yn:-i%1b`u3;fIVC;$RPX41.WehL.g0#O2&]EnX:G=65`f(coPq)5&(?U9X3,JmrF45&6ICWG`-=7mF$X7.%1i@E,pkQTg`\eh)QBdX*u[Bj8kY]S40Pq$)t=Laipc;sVa<bfp8Sutr/m\\VgR*XX*n&PQ5G5^r;`OVf^V/m%=CU('em-/Q:(.[$=T&!l5F&V[BqqS3r;g\+upji\P8-2GHmcc7h<$k'>piSd<=dl1ZDt1.rSl8AhmHGpq`W:5lop9NeQD+D;!gEg-0JU\<E,l'n0)c'8d-AU~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2371
+>>
+stream
+Gb"/)D/\/e&H88.ESoakR3Lp%+1!<Y2?YHIHc(AG*uLKUe]Lc^8ne_#a6uR4=Rp9"<S:a`<hkfAU[E47:Nq1],%0DcW5%p5^s=er^Eu2sQn<kKL'+b$\=/t94sB#]f/((d$KW)Y#X"1+GpkR;LCi>F,BUW7Zgm6`XqLkDSKrHOAJ&k_@K\t6^e_lRc=$GdQ-)l[a)hg9WAGK$@+q;#O+ClSeQF0eHSlJo*2D2pq_d-b(sO>mf5+V81^@p%@P8RlfBlp/Hdq=$>WdY+,fIdX*K--O,Scsf"=cT,)4gP4*M-XN'4r2Nr'>Tr+(FpNAfkITH>ak0/]2]cN2u3LmGkINTjr`kYoB.lS-_01gGEE7EK[<HW32<M?"N%;6Ch_6hcLs!o3qZ$-mA9NBhQY4f1o9-jE&WAG43<*j(E#(G&sb$Q4jponL.N\[oOZKa4fc)I>ZZ+r!fQUnV@MEPpXn5)*:\M/ghXP1kaYn2*`4>$YaMZi$6LS+a?Q,R*fFEi`aQ;4D4.pbn?sB$R,TT`36egFZg2lAl0<SJTdioOg2",g7'q@=HYtZM[6+!C&i:t-m+!"86]rWP'll:3ipjkC9_s&n9toWUk`oMMb&+o%$i>t+q*2@l2oVD1]_uh/-]KEdbIBP[9,f:G*'"?_%n?$?*Kd##$;&3D;(->C/d],)i:R1CNg2.WlPmAdS&dYmm7S!J<W2d,$bVuW["X*K2dc6*MTBorK-kD"/PQTUiE!2X.dn#ZoS\#/]KD8(MdREBo^a0I\O7PSI*ki1dJ]_$1Gqo26nHd*SLgIpo>K@/`tn^h]RqI#0^0enDX"KSjd@6H?OVVl%YcN^CV2t?N[kZf5f4bG,2NcJZHcB?/Z\i$#H=]cT6uMV1XGt4Bb/[NGiL9b3<X@W[#cKgV.DWp?V>k`2.sN$8<R#a?=)iBKsotg80FDXf7[CHHD``7-mR00"mLME"P$6);bLB`r$t/%P1g/"Zs^CI`)1-:Q0hF[Mp'7@hZM9N5.AXXKctf:CIKBe1J2TY1k.U0hdkRC^SD;cXpZrA',BPZA$mEiNNs:5$^N$LUG3A.?q_RjOu0t%Vq3o[7!!U73l]+E*/#lX!PVk,mrG)"@n`m$^q,:<<BX`W4Ts`DS]^>:hYJX@6cBY#[[m+4kLoNK!:%j-*IN<r;BrLH</RjFi1dZH[(/02LDr6]?O3t3fN)CWfG$&X[6-uM,b\1L'8;R_\CmkSE_0$*I>VMa@CQYmB5^4c>$]&no1e?V>5(C[7BcG?>E4&iQc2!hS[%X]q2_,c76*S+e;WR1ORr_lflGOX-OVAB'AS<ImZS'$iaJYXdDT"S<\YQ]EH_Z^'#,*iM=HH-$fka\r!hK;;=^dBmbp[$:a,oMkO&(`=&,W[ApU\di.cBLl:UDiiJoS;M"f[<40_NMm3KI74SP-dU/Z<%Vt()29%Rs0Z5V1=_ii$(i)CL8J,.Ok-ErL&_K:C[Eqs2o^>=9i`l,HosP)TXL5:TTic(bVQc@[.u"0iX[0[n,]#oUkQqRJ;KB!QT&mVs?_E,#,"),TaL-!35+YS\Y/QhR$A^1/CgK5h!ARrf738d(CDFQBiJk)nLhteoWi_B6_EWe[[h`Jg7&r2/\bV(OZ/"LNDV474\nSHBYm:kopEfV&/roUZ0rF0JQ8hA,4Qd^UG.a(Xq_3jDc?VK2@OL?p9g$XFIr)FTO<Si^RB-TSQ]STkb:ViKTTUBCRn+d8aenG/)TeicQeMZ;X)jql"bt<cAb3=b^"uQ;F-OL'9brk-X$W8ngTCl_O\mV_LQg-c?aKjkq3q%ob1YemSsBghQ=_tF.]2f8:D[Wk,S]SPdp!a2Cp$ZB$;8Nmc?UnDR)cIXk9<6L$L"Y,[?`D.JmoL4fSk8g".m&<fu..7oMM9>Rg&mFhDG?,.)0h]Y%@?*Jpbt*Z//gcXkGa"\h'0`<u[oCZ)q()4)ZQ%[YDAoUV[fJTBuH6Cd9U20(]"i2\l"\V6dM(fCKJRo`%1g\%IBh"kN7XmK.17QGs!l^g!DmNrf^S8q%XT;+VT5YGaZ^j`:X>@Hs7MBY*m'nWcmChL">M.8"[/>PtMEeroi$CC#6Po)oa,_\T7&JKh2J1]ALbe5Pop6D3=a5io&.d#o+)6g7:u3rm+qA97OB[Ga^IBQ!*/MJi0`]l-J^Y$6FS;Hu(uHQH;2-``deNqgj^3iR1ViAYe6LZ^Y"?Tju3ms(hXnDm<(.DdNok2,*C.fK<]p!0bSFur#Bec$3!RYj%>qNruic@?Y?'#/FpicN!PB<%YcJ+JF#3>1T_pQjpakI_b&iL+XF]i"UUJD$@t#*cH7o4\%.bD=+F<D%H_'JBNDZRU>L\*mo_]t/cm1-Gs(BSc+ropXqN:At8/i(^3~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2947
+>>
+stream
+Gb!#^D0)1;')q<+d9j%M'FQ_0PIoV8*6Xi<ff;Q#C/_Oo8g,$S,R?(+[WN\c[r2dq!XVH>G1Bl'ANWX^:NoU\dk?B)KKgaZm488j-?+E&JB0F4"&VK%-J'rASD9`uJl7q(h3'>kL1,t:XqP&anthU:eLQ7K'2_Xafht+8#r-N26rR#98V[$."?.Wl*4Y#AAWUp+9Ep\R+R!c+*l9%C(1'=u,`V%-R/DJ+Nsk\nfD`(SXS:?)&SZ\W&P]"aVN(_V$;h4Z)Nn^$0`'lVaB0uZeLf0*/JA@QN-Fh?At;/KLkPq.[7j/s5a:kW2YC!hr=gA"[rJRC8Dqs`&PUWFF9P`&E%"B`p"qH!I30*5N-m^\D#1#]g/;3n.@]1&A-,dYK9F>1=i?Qu'9C.@]69E`%hrV^''%!IW/kQb_>kcA8SB)/b,>\S!%?kMU/,G"O,p>Em((fA6cNf$Gda6(#/5RYq:rU"o';T=akojt@<Zf@'p#VGEq<pm'nFSPeVsD[%0L&Ho3TGEAe#ijjS%L:EfF*s_;nW/1HmQXnNkN//:O/t1'Z^MG<NGQ?MDa]$.C#b$Fdq3kkjl(mAMuf!V48qo>gaJ9,4*Sr`<UJ]`6EZ:`+X2N$kCZi+@@;)GXtKh=nE,;rPRd;tQPrI](oE/7PO+2eT&-*<*VpID7K\U=Sr(j#'V0'`!o)M5D!1)fOWBn(63iS381P0,H&-L+V:?7bph;(eL:jk^HV[c-d!.Ct=fs]f*suVen15b0hoe4,M_!a0`4pIYhutQ_+JSHW,Lf,uO%uiT!n!d/VEsHc<uGK$t"q^h35La8c2:=KDGpYj,F/VY.Na(E9=;F0Bh3>M#eMUZkmqs3W,LksT6>G"jUq1e"N6]9VIb(%R6J+_/r^6b<JU"fb.7D"!Q#gbF)jT7TItgIOq#U6UK@I%%@8Q&AW/+CEg'Ol2nj>G_DNZO0-(?7"cc-''iqV-4;U5W<rs&jCu"lg[5EZY#3Bd'Am./]l&$/)77AeFeXD6i<N=23R,'>+J3Ob.<c+gK6%8g(7+"ZeB$W1TVj#c/SA+*WKP5hK\HZLmhPMF.kV?L#0X/JO662Yl/`:0m65*g#-\DZD>=M!cMj-72RCqij$FCCu8S#6WA1-%Ukh$R/SdYHnUAU.rMk=_g"e>6j[BRUV45U7NnsC(^qb,PlMjjEnrEgjKEg4&7Mk0Osgb;G;u]<=o''_Thf0fkEL/622-"hB`*Ae*59+]He$%B^t"Z1Bm?/"6uCClNEECo=[8UR0ZZ%CE2d?N8sP^lp$A>F=N*sX'm3"f\5fTu9P$q:G9=QOb1A,h=tF<E/)]$?B(BRX\g>$)@72jKG:8)t*P7t;I6N9I3hL=3h0i>`&GWN6be^=IYsct#)TZm9X.?6r.c3mYf@$+j7a]KciO:^rUN-DZ[Pi]3EWWMQ2M%WN_N5*8j#^7n@](lk_MtE`q^VtIdU082PDf8B-=M9654t]'$Y(hmPpOo<pkT+Do1HKcm4>R>0rs.n##S&7lJ_u>i<:Y6$3Psmj:U>OMeVTZ=@WT)IfBM_3<WbV"tYV1]jupL$$*0G[_?+dDsJ&j7m(@E/FZQo/NQjXWhDYXQp]Ws.-?a=CH7E.SqH9,QWtSKr;HIVg[@=Tg6JLQ]M67f(-\:4ad,odJGZA3CV$\N@;m$/_;,s%2U$OOV?.edfM:!*33!@[''WQ^W[PL)<S!0_dMiPLg<NJFfV_gSh5<)99i_jSs8E^nhkTPFECsZp(tQgr^fs^A=L=4hgO\*i;r<$o&[8fX.TA_&g1JIBMeSC5+,s-ilk>nqqMMQ+s%K&J@H=]?V2+@OW@D\n\/Y*YAP0Tg3DOBM3!YjVj":.EQ4/P^821YLZLS-0'8T8"b6:?@G()3f!:Xto!sC"Zr)c+8aFXOldn/R:Esj8!]bjNTn8pG6bj?(:\Hsu!1JWK-,2C31!LHcBOV$2#:JUb67s&=.q?_e"(kWL]oq=sb+`!"lS,-W0[2/lYNP$G<W7e$Am2>Rogjgp+X@.5gW>PYF&3oV@HttLM\\0%XL>T<q?#p>tAE1WTAPVS\Q)<[?hK]@FjgoqZa6D@s/)Mlu(^'Jqc+S\A/*!\!;kP<g\/g$NEM!W]H`&+"9JOAM0u;bGMP(Nci\-h0Yfl&D%!%*;%57REf?d)LEle&%CHmAd2#Q?%?N:Kk`#X8XYnL_No=/]>Z6@i77D/K+!*QGq56e&5O!/b!9-]>/Jcm_0f936QL0I'6.,s?f[mV(<!ue&\?QnVI4nug!@Ss@'&Xn;*Jae61^)b%K-BBtg\Rk1gDAr=Ql6;$a39AdAUYpmkbbolT)moblabmh4X,fpmQ@9Di)'\%-m$o7N]@l]jRPPB4ANJ7P&TtaskNkc5WWj+[<aE<8%44_/fEa6seje!u%Aml;K.lZDf!p#tK?;1uEX7lGCli$ke)"WP.KnGaFXWQ'i'$+D;PFe$6H^+.r,V458h=,0d.AVuJUh<O<:;@XdD<\gOu#ImXKp:W3Ya0(rVDaX'(>6"8ZGXk]rFupfToTcj'uW3FrV<C59XYn%YNo%K&Z+:9=XK?fNr--Y@@B`N[Ne!h2*6C//9ciEP>'R9/<?BZN5tQk'dCJ<#lDr9<W$Ehrq.Z^2eI@rUnn_VJa*i5#V+`/j<U%PLT7lV"?j@!KhMgOL5PhFo0C\B.E&Pmd,CJ2sl.iAOINKpRCQkITpSTnT,Po4@il2IYjc]';g9f9RJQV_%bSrGmC,@r;343PL\k1=]2_P;ao<pDQ9s-0Wt/DPf)l87+U&pNq*KT.o)#k<"5ju#f],Y9RO;HHTc']q;GkjjhR&Q\#K_]p4lY+'MYc4$*,h"r;PK3WGH!QUkOMH\*/03/7B0!l&=#cdsjL,l67:3%$/:_`b[Q'6P?<=@Oih?npD,_o98cNl@,$DoukE"r[>tUFX!?&1r1#6;W.eGJEJpLCQ`O7?Z>QPf:67k~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2031
+>>
+stream
+Gatm<968iG&AJ$Cm.=19Po50lcLg*UERVp&*D;fDVWr^V+c-d6-mWIp1\pQH&0s\)Zm`PD-76Q7/G?t6p&P4Ar^ciD?3.\V_s;(>`.ILfLgrCu^4CLgZ`e#;iq+e>$a#M@n$kjFGm*:R)(1S:Q>OK`"iOH*Q+0X^1Ws,`LV^UQPU7M4gVQ"7P%Hh39e$ru%c]3%_9ru$ht'r\oR$PieXs8%_8Pp2IK#*(Y$$1V(*3lmQ1?,SLi7i7.uJ6rUJ\=NPf#PW1R_l3\YjNFmB5#Q1-i\YjYAKCNF0LE&]L!^$`-hFkEBrhme4#kebp4?_"kOZ2/qM7j>;3S@gXu[k<kn6.T=0k-:;0MF!4JN_)rCM)H\hm/>&G"PU%qU)22e@QAlC96<q<`7N=kC$3jYOQfT^]S4Cf%=j^oTnCM524)>>WAoPG@_=L7AZ:=$hid5'dXqu=@5(1Us6F>eka*Ctk:4W7.(r-=F+ep`<Keh2^@W=sU9.e0i"4I`3oaED+XXDdsY?_"Z-'suE7-/Vg/KZ@*hJGPTH4-]W]B-RU\A%Oh_3hCV/<X\Pm@(J,[)G[3a0:B]ePiV=_;u?3SnWkTgIND8565?f*0t^&SlHkqZg&YS:t7!*ftdC`ZI1Z"dBoJW[.nh,DmZnMb4(^Ps*T(heCq<*]9<"]fth>Wpk>(^3q=T2"mY1Y^3Jr)NhW;G3DCiQk%M6e?8UiSrREK27*h@`]4qt:i[$3*T/G.sg-7VmHNp]HhudEmk5&a1<0J<rYRN/T'K3`4;n:T"Z@&IMPiFn=n\bOS=L?BD(p39j3<\.g6!Wt[/T;tU4icpZ]bA2q@PgDn)Db#.kX?2P&Q_J)SH0A>J!R<rAA#^jTQ'BU=EfGE5Oe]>1F""lrdbY@2SgVI"MX+)!Sm]uL08Oqa26@Z,iOQqW$Ibtn)iJ>F2unlkSAf%Zphc-9u(/i,2fCH?rUqSE23eKW,87EWo':gM!Jec-u(Q:aIf'H.\7Frc75Y+a(?&!FN4#EiST#K?6QK-0A6&*,+4,_P"k6GOor0pE-E5gOkZFopZ-LqiP(jBI:?6kdcA^A8E9K"Mh8j$GDr6aWM"nj:dB3*\%8/W=XGJ5=:.n3Y>;Q`FjqE9)mrr>"G-%_9<j/dE*dq@YtpXmf3*2g7q6O'K^5,RIh1M_qmReQ,cMWt,%=Z7dUWWYoEm*K)&n?0+E8rl4QlrTEF/>=\&/jZJ"P"&(LIP$1?93!O$uC9%6+X5E]"];(JMgDV?`&kSK`t"Q6q^6PTL(G$oA6f(IZ5feH<[1:B9B0Nj6rjY^b)83TVtG&kp_LG@7F84G4DI8dX#4"'RFn4cC%Qq>Z4q)eJUTMd$XRI]G`Z19j0A/4C67<$"Bf4$Ss$?'m+MO0k!O`""$`aU+&W'NKdr&+'oBh<c1bCqDi\X4HO$/e3MVSPpLgL&j]Bl\W2O3?GSGZArd9H;IZ`>LP8H`dX)jm/n.D?J\::4+LN.n^.4uK3+$F2LL9GT;5Ds6+D"p':Aucku`;KM^@)j+1:hO0CQ"RF>_K'X?H8@!V3unQ6YVHN:NcY'X'--LG0bYX/psPeFN,F4KgJ;ja=ZN$2igeUE*igDq#Pug4?qDB.$C'r,!&V)\SJ5D%[<t&oM]YKYrOtAUKu#_jZ7dHAdBMRdaj/Gd=KtYpqCV2khA[p.2UNV;mf">s5.N:NgoAmrrqu3sO;SGBS+Sn!)&t\tet[-f!*%4],KClaU?TODfE'eNh'><DDsCA!L[R!k==gjKufH+0/rV/[\-u@N']rePn]9j8+'LZ!Pn]MNVUsW]S&R`mITR&H].8q1fXVqV'[c@(\9.^g/[+Bag?Cs#DRtM0#a/EZ$$><MWPO>DQOa8mDOr"l8)K1h%ehA9&/Y-K6=^dDhQOE`#MM2mQP)8\$ZeX>E,uhrI.dMbIs:`UH[T,+GH$6@!X3N#\%4\n/nP.oSM<3.I7>M_%ab,sN8daYqO)#?kHa2n/FjL,!)KTWk4ra;:RY#tud9di=]-UF2<L"oRu\&QdA?A[YhOcMdp?1;D6~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2792
+>>
+stream
+Gb".?flGh<mbM6$dYjAnS*#._c/Z3U-_"Wdfi'b.;'%-j.<WKpBi6s+4TE-/hGhF'R.``1DH)J@C_17[%5a*2!]#4hm,(MCnFIl0h'o"qnE>M!90,2LK%n>P:M39#Br[?\W/^qFAP9IG.eqlRgQMWK=TNn2P@Vp7*??D2;(U/raYn62<e5,6OJl'Z""Au7"r4+MCU!UAju2#6/9K@*0Y!l'n6eh8_FV$W0Au@&4T<9#q6k&^Whe/Q1#NGV]KDBo`@u-B=/'JfB&U3F)n$4!J"/qFM@amYO_idWE=foQ-[sTZi;]Af7H6LL\N66,3W$$4b^W9A#;cLsi[n[&l;#YKkE-^Hi_f7:r9=R+,KY\fI7iP`#SN;bd:f#"RiLJe"/gqo8j4'Q)^M^k`-]AV1hQ2WWbf?Jo*C[>6HY0a8YHGuQj&#C>>6t7fgYt`iC_Jd)o\a;Hp;T7X-O+(XlRpF<%MD[r1=NLs-,3lE=/S],WW<73@b';<R%K!dd1DdW\OaaX:Jc@Chj)a`KH!2)ql"MRQ6=0EMd-0LG`a@;4oqN5@]TIZk;"RXZT$Q*8K0=GE+n3D;:K2R4D2CBA2hd#,q:uqM9FZeJ_K>!)cd%Oq$KOKRNd,-QSkgM%8+b.aU+o8eSXcgTPM)&"7F%DWn1kq<^$tlk`X7Zrtqt5NjPW^5m]PQMYX7M0$CPPFJ,T7k^3N3g6#]M'Q;Abh$hS&3&l$=%Q$j\^IN:3*e'`5!4pNZbiE)XZ(!]h0]R9Vl/57rL^;l<=>,%YCHEi2E=*+]AC!na?s74\c?"JO7EBaN1qZICNH#<<:A\)d$,)fV5?jK(Q/eYNE5WgMB$W[<\Fg=s.(pN_,KkdJX]#QJS(.0a<TOFr:9^\pHCa]Q8h$d:r>\AVpmCe#stTH;3n"SYR#4_I-ZomilD2^aiKdYW4l\k:8Kns!Jqt$DX3H[!T%H&#P!@2JJ%gqmG8q`-"KGtQM0b/is6Z"Uc)4C6HI\<i_3+rd.6o0qW;-TVZ_KkFhdkIrcU<#-GpOj-I5Du:SM#a'5:249OaqP$1<V&!9Xpe0&pZ7cf,L`)NZErl]A72Llh"4]cQ:4-;p=J!^at6+$:GD9jiKE'W.l;&8![uQkQGn'rDO_s2=7F),+`_OR@?&74B/W7!X#*8DT$j#<F%mS4[s>Hmja+4^j\.)f6,R2F$e`AGj;ZIbISA39oZ/-L"!'^$*kQD2YV<o%Hes].q;]OkqoR08(1GHU7!c\g*:Yb!<]/)+bG^O/=utKlDQh""Y%`1&D?!Sk*h#4UE:@,[9gS&sB[+9F4qJPLYR';Dpog[F#)%fYhSobVG;cS*B,JXpH&5YRk8^GQg+#4Abj&.jpj&FBpXkMPehf2)GnJCR"(1UoYqAS0i"p`#>pnq8OI/?WBK0lc4QHfE6l,j%;-P;TlgOTb0RCB+ArW'Aar?%m`f@PPdF:SbdpY&QrdBqfYc!f^"BqlAb]`Q*L[1"`HXM,YO<5'?-BR>eBh"cI/@a]YDD"+8S$3Oq(j!7S[&ec2!I1d]*d]3?bjQb725k8-^?q#\m,nYaX#,eeAUp.91(ViNSc6p!sfeb:2;`Bh\&*2.a0raG8<1Ts^b:=A<LACC5jIPiB'IE*,iV/[=kT3G#[Q@Fqe=>G<fe8Jj$F(pt?jQ5Hu`'\Yl%AUl;TNI_J3)Utcbn;V8]B(P,WS:B;D>1@]^A8AFSB_3?1ebp=JC\48sjP.&Z.(%2>r2el$>Kr>ZBJr(c((%0SO8?5eF]#>2eu!SBYP7pq[LB<gU(t=C*4L.>>l36dMa^`!qRDsJL^fNd0LM:=pG[7qeK3W#rI6?h^UBE,(f&Y'/<-L$7B)c>V5[W%Id?lAP>:C:MCGt[(sW:(GMdJ_=)/RL!*aJ*a06m:?W1j^f`D.T5Z9W*/`I&8LTr+:km1ULe>JVn1U9V*3DFH1F2,P[pcMsH/[rH1?W>9"(s/qBb0d879/ga=fg+Vq#Nc5Xhe&t1Ia7nuQYZ`7+dc?//k[j:TCo!)($e3/.?BFBKn@bjGI<3o&Ta`(DRGks#moY<aRWsrlsXK0<AZ[0Duke:8DY?-H,"r^,*nm:#$::JZU0NW%nI%-RIWVaUWG\b2HOsl#!l:-E*;c0221ugIYB'BpLlV;%5*k5q0qb]^?>d4:J^;J,d??18?2WH%nJM4IDZTr4][6*RKNqJFl$4_ABh<F6.+;7/@^)qj?(,:ELr9jq&#S:OU]&nP(a?pU$3&K[[Z*/lo+(t=`@/OfUE&rJ>]a3s2>sV=)t-M3Fk,u"jr`*WiFpJ6`RFC0S`UH3@))u%@U>D8Q_ifHq05mV,!omXXO3k+u"8r<-W/NbCc-$/OP[QIQLT50.p#3Xsh4#pU"DPPmVNGf,4>@n8S0c"%Bt.hZZfclNQQ*@$\AI*_#VcR@UKNI#Q.Q$ZQeK2iLUp,k'"dlK:;8;CN1iIe_NH19?+Qo.`I_pmhe3,7b^%h(a6`nOQDHH-cGE*-A**l?1DfghH6T,@8ZYF-1'@XrJ,]4.VnipnblB!6lJ`OS,IQqOo!J3.R,*M,K:hDg&Y$EM#`bh81Z\IH3*tL?tq9g62BCShn)aRH%hm-7K%#iP4Bfs"s7eL35mcI958X!gBs,=G8B8_EknQQhsHQNND!7jRp7(et`]bqHOuSPhNV<$K*"f=7hB^!;"l-P@#rNfqL?J%"%X/iBY)O2[XAfRge+a#'!M_rA9u>bp<)tZN6""e4'Dk6Gg1l+iWAsCahr9)&ouZirq3$ORsC?&J0qFK[FnmHMZ-G+k[%V?BESmf"rpq/Y)bYlSo?t~>endstream
+endobj
+34 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2279
+>>
+stream
+Gb"/'=]='G&:XAWki)an$aN72S0nDN6NRCLP"O91[3]$e>="$GLOm_4^MhH^#5KB]o!Ct7nu,dAkB)2:"@W/\q#;!Li5gN,.01WD2$K][$<ZIFZoW\\8C"2+Jn@V%!F69@6dl<iLLbrI>uPjDSq\Y_&k''$!#g<cW4H@RV?)PU&V]K8c8C'*o#cqXf"gj-&14`-WdqpM&GSF%54Loq&56([1`86,0"_8Ob>s\;Qps_m6K>b./(kBo1ieen`nQ!44S0ejJ[:Xg>gb$@*P-I1?WaL=UuTtt&fRlKnKjW)C;<JI'Lmoub]YH7]=\\E^7CoASga.C/K[K+i2ed6=4lk;chWZ@nMC9\2L0/[$%kn*Vbd7iWmH"hD65%S;SU&W6@V,jfDLRk5P_TgT):X%WoXYXg*dE-_MU[*EWoC.<5m'RK*[2=MF"Q%E(KW63+*34^H%3a[':>B#\I+Pn7bG!>(!-/NVgl@GO168D''@PQtUL4/F+C]WDZdAZJpVAXVF#79.;B=h4#[q'0:KA7A.Y4."\OYU/>k?QF?,4@uiqn[!tA`<=j:?0>88uVf\*OGX]n[W(>L=W9Sbgr$^(gW5;mkW%*)N,n9l^06m'3"Hp(`aDC/io"2?n6&b*?@1]V9ajS%sLch9@Sc`\#@p%@q%?gZ,QF<,X^u'#t]uMLX1d%Rigd>52=RRA8hgr4oLrM9.&"mTQS%Z0B\JI)kdG.%W)bdcj4?$$,.a[[F`:rO42/9gS,k73Kcq["""=fT^Z0tdA7;do/Ao6gPgs^*uJINL(")V?1GtZa\D%F/?D%^Le@LERKCsbp1gnWaTjL#0g0I1^sFYuo:SFYQ_**X,)L]>)1"G<r8JfmpQ$"g_Ukb;f/0`&J8&GEj%1O`?7ETP"G-]%Hi@cOjun^TVQ\%sCk,N,RE?mDZ`E)dIRrR;+_.L=[,C'7dQ"Pq:scVu;/V$]U,ZR@PK\]DnEX-u&#p"!_]0uuthRFbY4R2uth7ANX!BphKfQKUAg;QQEQ%qk+&/;eBs8U=6!VDO^bW<3FA^h8qO_7Tc*3V!G3RXE'5G2']Y"VX#DDij$CjqT7=_MC7iB!e9Eo1/GfE!+]frCgrJ^8.-]?ZYUq_dMcTqRB:!f/^XUEI8it%Np_QXK353,/Lb9=o9G8ruTi,3_f-LU\qA[\a+l0/NfU/&[a!-L)^\\l5eSRN.`_^>NhuR`qlK.9ka]^eprRNX@f>k!_8+tSmMV.U@bO[j<dMZRW=l,DDMk*,I(cRH<mYVA0Xp9/(lBf#ZaLI'To[pBP+qO>dqUX=]ObaYD9m2C^%9WS4\`@/@u4eC9@!6\[0_EAiK'-Mm]`6UNL2Xhog6CIi,t/B2Er>H?9=n-\``_W_p'ncie!4mfW:9./4jUBG@f4*+M#&g[SDm=5+%C*5)/&&h_H^nc,Y@Fo4-JRD'Vn&WBY<!E8n.d!KRAG*6;:l!<*RYuo9+$*1Jd3&nt.I<YsFRjP-QpuGf:A*UISX3*PI(LXKA)Q_o:ebR!!rcLCa)P2TCdKiT]4GhhsDhP<@5_YU+a?$gLIYO=ZcD%t,&bXV.bTCKL,I#TXqM9"p-58[JCMS*MefAXDX1Sg6LB_"/[N!"9R,KGI#H)"l>(qgT'dfXu0'XinQJ,45**"F@W\7;B.'8@$n]$0k]qf&r"5A#o$i2RI;LU=HU\u+m[MpUH8H&<k?QtrKfK\"9MLnV,.m.^:D)"G%E/1u/%a83+KHNsoD&[!31WNlJiKjTo,%Zk'q?tVE<X]2/9<_e%GW8J_*I_Belb/5GKk1l+(gM%:'RDine8[k!T#H-Q_hq@gp>c3KXII,:-ZCfu5Pq&`i:MD9r9$*[MlR944/$.($F[??-TePq`Qq?B;0p-Q,_d'\itr6eHRk'SH%Y&WUlWEK_jK0*AA6?\r0HElS]qh&<(#PMEEQ2.ZBLc9;k0Ih5^Wem*2$mEK>q%0VD3Q*[c>.H%T=O>B@#-U?@J#VjtFS"JWHSt%Dg]=XTG@"(W@+17s'S4o:U;dL)_82Lf%ZlmBV@cP[Dr^*b@ICYI:r`(gNU4(=3M6m,SN3Eqj?.aod\RKsNWM/AN"/f.b!ORGiRuMP%S6g<5)6(C;IZUctO,buY-O,J^kMDX)rM)e-45>7NJ?@C;9+AsCMcE&OpHG'oWZJ89fN4r\uje-KZg[o;&-mL1Am-XtQWDL/K'gW0'b7LWhZ8ObS91F-6RBsgfDC!Q"$?BO<G/@j2hJ`ActQN_*b29!nV?Q_b^Z@lR-'T9gu.rPu0<@l1]lOJ%9"(mV&SH~>endstream
+endobj
+35 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2067
+>>
+stream
+Gb"/)h/f>L&:aF]Z&d3'bTRN?*g7pbn"ZFHm+uhFH/WQciIX9(E"`3F>nG(t$5d9ldrTl($PC!a=1cZDD^>[Vpd=W0j!hds#i8i"+;ToRJP_!9kS%3[HJa(Fi,gQgoduedk:qV"0#?^s=-X3DPmlPsL1r`8:Vi]WGch,QF/X"\&E!.W.$8hK`$stZU%DRpQ>+\n"A[!OprHm^Vi)ro3P:tInl\#7=)cW<Zj^PK2^]t,q?E]RRDr<N8m-n^<m#t@jS@.Y(i`gCU/obj[YIr1F;TYr?[B&+MCDBR2]2-(%O)b@c;0fg5;A"U",$Ho[!aVZ+m.m\D6[anE1OPuo0j2-fj2O9H)#Y42LgJ-n[r:eNa&I?0Lo-ZcOCA=T1QK]l<.fr9SI:o`(#qH,$$TE*lK%9hr(<`:WYuj.\:Z-,@?q*?(#7cj\rn*F^i\c0X#8/SX2AXk-^TI&.XSQ8e9(FGZ]2EMc5pgN"dq&i`6<QqO(jjQXRfI^F;8JK8Q,m>*Q*qG[/L-RD+62lUfEJ1607@)U<!<'5#NrC.DTDVaLpfIM!]gMuPKl?X.AUPc@[Ua7GZ/B)HqB%-YSO=R]t`>I'sLArt1.G*K_GT`1^#@#Cs!-;C@+fOYcP-26@"kXW.f/.^%@]_hC")Qk`Bqr:JbKCcaj\q\W'JZn!tcc-qg%keP]=j3LUqDTcUiT"<GrsAk7?H">qb`cDsD10l1M&3nJ;t>+hBFuR(jBrsdn+gKJT1,g)9;f:?GRWRcR&(6Ma'tjpk"-K_@+s&[*JJ^D[2*2hAEEs3,-aDLpLOnikt8lSh@@RTk0=+tQ9dWI0KWjL@J0`e_HYa.UB]OjY=7(k>[//o0Y`<M^?,VEgZ2@nHlJf8dr>63daB/dk[nN\_Cfh^BO4pfbd#/__h:fRg)lnnBBr@A\(RAb/19DhaTK.(6g0OOa90/@hf%`iP]Aa5BG$P#^>bCR[/L++Iqo,Xf[N#TloSL*^20/[HO9I?_WG]6@8p?D-H`R!9#>".6@c.6E)[G](+TM-PlucS$3<XC!NiF7E)[G]a!q33#m,+G#_Yli3EYTaR8ir6UWYqp^T)'u*#)pB[=jS#C$Ud3Op(Zs0Sn9hP.]>B9qi,5h^0A>R?:4a`k44s0JDus4g\!@_jn0K9Yn9QPpmREm::;@3!@L=N235&EJT\-DpVFMhWN]fhQ[3i8aD*7;ledOVA`fn3Eb7"'%Lj/,0(NbT4+9t7:c_W:Vu??ic.n#6_3k`"hVJM*T_LO],"hLPED`o#NApVG*d*CRgpG^[!q=mMGlUQ[9C5m#hC8.2-/H>G%#)c#WS!GceAGJ?6eg".TE1GJm8\pW'd%?(UZtST^+??P']knb"bSKXCZ`rH`Z=jX]XoHJr-GZ()%FQgG)RA\1]2W>n([-a('*Qg1'Q#QDE3:as%0nU'QYocScEB0L&fbaA%)Y7A8;TU0?%`\p]RRgn?!"*4;dYP-;Gd.+@D%pi=7:N*hZ^1VW6Zbo,E9)@mu-]\N;q?2!u.Dn0KWCsOTWl8Gr]b;s22+/k'AZu$O,34DtOJoTZticNqdX5CS6JuO/5kpX8MHIF))1.Y<>E9+2s'Rl$oGQg=J?g-HVL49p7<C7hGj86=$T>M@p1s<,_d<Q-WdF`TNoug,/82hPMefGjK6n1R5e?gF'Kq38M*\D>/6XEa^4R/,<aoRG!pu-258VHUGpXCC=KpDE#VqK(`!HZt'--95JQ'?"<NO&kV8O>""dt=g!$J"@?+P3><bAj$!Q"=1'JZ^VWAG&$6C.S4J^*;DD-PnuY%f5X9e$@g_U1JAPQ(a0#2;k/M%p]T'l7bRGNjKp"'B_73s42I"lV+rCS#+'N[on"q7HaSa*&`0J<Mjk>A9?NTV,s9GDmmlT+3AClko68><ZafG6InY7cnao'SD1B!_74F7fDUD,p+^.n:%FB*kU1,B5n81-.HCEH\[(E,d[3hZqfk+pd4uWPYVmlPdeoY2QM#XEQ8uiFcrY$&cM6SEo&5JrY&UYA%_&jQ[_pCfK\sKTf:G?eMCWUE=54Vi'nq#/YK1mecr,G[$=/`^KneIA(]C$J~>endstream
+endobj
+36 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2539
+>>
+stream
+Gb"/*h/f&T&:aF]Z/[2XWA&ODkJ8s[jc;<;Rb3Lel1bETB:/mR!m%dImJl#HNY@RA+FJ@dC#b$Vgi@c=EP)+[,m73F+kc>S%,bLrHcH6pL!^>@?.!)&#"PGZD``VN)Q$t)e0/3;Wa_GE_=qnNEHFMu',8J@D,\?Q71J((BY"l8H^YGU9bc?*D!2N?+pL!0ER+33PMjms&r!:&5pjdUX_J>??cpql_9S?=pd4ME==I&U7Pj6KHTlc[UG"<I]gb=^8't=,0.8JV<)#n`7mT0jjcIIAaI=P`(mJ?'1[8F`A8Q$,*J2;=7SWej_>6$]JdCCI9_XS?nr18%(pSP*mMBm#p&,3/Nk@s@pCa?NM-$#9&V$+jL!8B(YTd*9:0!+Ef('GgPJN0U[Q91pmgh3O+VhD:o2#/UbDp%qe.G!OFcC(UagP0d[c.-p#G(_c_C9+jT>N`4/db[Mjl=;n21'l"o*=9ON:QKQie^h[(9ad>cdc%8O6MM#k9eBl`LUC,<BXE)2D4F9\9L@m^FlB"0<"!Aq=)E^PFAl2s10ZQIl.8'jT&.o@,4Cu0Ub0a:lX_Ibj&mNb%uS(OI?$H2[Z=4n/ab]+hWC#^E&gup@[]NXTOGoAK%@mZnh$gBP!:JBZ9.3S30F&eY\f*IA<HD[>fd.Z8i84_C%i>95YTr^\2S%7qinC]CB59J`u2&D%Qh\0[npq/`-o"U(QtP0TWk#nra7QE,cTP^A.6YH2Wc=(!5#&<\!RZ]UR'?0[%p?0'!5=9$ZW\^DB]/D1,Qm?D!h40k?V+-f-^kg,u&:]'=rSRKhf#B`RUZJ^$X%L0VHUMZp$D>g.t=F0V]KRrbi+2/0UGaR6\qb6-+F4,Xok'LnG6.G-m]D4Q9ZoBT#KXNm[P.JOeOX0/nUYFMmY^N.2hk#^5u50g:d:[VOGg8bR/iFm^0Oa_Q.s!@.Vi19'.q3/W@ft0B5'4CQEIkb@bQk,L_a"$7`!F@;<bM\)n9r@(%iAjcmlt)Nse$G6LIIdTRZqi!UTmgK$&TlR&7!cia'38`S5$XR3%+Ek!0asUDb8>lIRoQ<Z[031e/J810:,A88BnmC2)iYM4"2oq>s$\@GUL;iH<ff3e[=[tK=Uhj@gr$JJ4539UNpJ8'D65h"8n!Ho23X/hCs3p*HUN_DXrN/cD7CaK=lajm]a_:3\;"l>QblF0]EZuDUDa"J[+eKZ*I2kXWYB&jD<>_2-INEiEf]#\LeBg0C8"`YbY!b0nlXS,,1l6nEW+n[7kKrUL"UEbIEa*D]6A/R\O#e,\3]?Q],W-)EF=&AIe"X[>#U_;E4g$fq_&7k)F('Td[IO*KX\o3(7q?7]IO2$&%A/+<,/u3RMHJWY=0<iBg<Q),7e@upSPD+ikinCp5[DJd==GfHO6QUi_9O10`4H^n%kPgTRR&8#]\j!>9F_sfNTI79l3?P7-f@+*4'WoWtI9Ib\L7rW0MZ$12*EUpHpRsP&6<h-Z+E>39=)$MrR><mdn!8[Q5&d\:STmIjrSGWJiOBK^<f:VT1o8p\+mZ$c\bi%Y2LN%tBbd_AMDI]4"RDnY"1)d[Q?dSDEpfpH!1".D%1jO]BU`<ft8c%#)mL0mO&[R5Z0\-=Ll;P4>Xj9QLjmCc;%DKYbTbfJrEh=I]o[-://1(gj1>T>_ac@iCM+;3QgHZY`CbE<VCsUUMt;'P<bInqt/lg=.F@V6Dpk6/oHS2EL99Li,LM$F<FH7tn$@1_%n#OFN!"V?bV=Zh"t2"`pI//U)JspaRk*R_mH^UD++"[/gA-:1)_(-ROK!RWXM+;)6CGUi3$C%/_TD^uq=@U8i1_UKG$3]b62e4rYL0%0hS!\7l`:$2VQekO_-,m$j9<Tf-a&Ch[WWe0YH::g7Y.ZlWQTFIF&`U:W76GK#*?![b#q">j0kTXb2Uq?d5PNK0r3XLe\EnaTf4L*c_/e4+SmJUj,!4JZ]r`J#`Y/2GS.L^@&WaLQODUKLD\n$;Q&.1-l"Pe^^\n/h0=]OMKF2+)'a<7.")0[Ns#VqU'*_I:m]'UB5-1I#l<deo0f5S(]]Vd%,3Kdf7goKL5rUO#3,;tYMX@n(Ft9pHPa/L4>nIX(8VS<-Or"#jP9pQ+.6ls]YUmM/`]h&gfc]bLbHaGn6PJ*p&C\Es4&2NcFh6t/5Ea@bB+WS+f<%f$%\Z?uS:*U\q+goF;k0N+Zdb&g_(E;e,ib"?Bb74\rI`>Y7Q98^]gV0'R,ZMGZ/I+)Up9J#&oGnILrkpG-V7BrAKfXHS#HV&W/,35'<O5b2$VN?%Y^92berZZA)i;Dg%:S1MR?]P]n_m;6>OOCSKo3ttMaIP6T5YCe7FEe9S@5N$='Rb4_Eou8I'`U_-B.*KO@X,UaH79:MG;8X)<l.Mon-i3<9CYO"Jt3DI+iuq;gO0p!0&D%pirN'35a`)lDquODIXO[%MNH8GiTsql/qR%9Q9nDS,Pt1M[>jN.&-<6ZiM7M"/r_MMj@aF.6:gp3;;h)F$p>VD0_eZ*,dar@a`^sQ])NlDcYT1L/%8P[L)2eLbn8V()pD&?B`~>endstream
+endobj
+37 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2759
+>>
+stream
+Gb!Sn97P\S'#4<Bb\`p%P5$AHZlH]IXkPhD[O5E1$C6eC[/cRrrU`/o`Ks8\/.5f'rur<`3%k[E1\8'c)ZJsrB+P*Ff!)[55rW3M!kL7u@!rQpl\kdKkf8ss1O#/);?mH)4ibt?4e/)s/R<Q@QnN<sF%lLT%GP%fgKhbg4]_a/e*!=3oO+Q.^^.UNKLFot\]-P>es)E]92@@1LA^`Re#qO_SRK\;EXHC&(o6NO'*p\V+C/3D5hEAt/`Cm$eMVc34'@%Lo^Sd5+Umj\J'a85J.F/S^hm;m3eGO^al*?'^V]iFP9meSb\\:^VHiq]0Yq2H>d!1(97H^D^P;J+[H5fr$jZgCE;EiOd4<6q--sQ$eYIK4l(=cfrX8_T9PT,+nnQ9rGt14']aRag_bd#VL'm($0oA\9f2c]F^^eoCC_`F.aHeMD6EQ+2g1ie4ll\j)=MXO)8/NSVGlH'bVroL*1[p#[fa_dXO]bo1S"(@8iJWYiQ3D>STo9BSYpV:$4Qt>KeWjr&qbDbU*]oKg>Nq2Z_^I!?0SPb=KMcaQ;:;n;./=Q&CkRrb\Xg76@)S+V]V^X,:6QM=?Nb`6;?kq@N0@_'H+rdV>/rr.2WX/#X2#p<m)\K`UJ,4N2The*#cTH[@:p%dr:h5ak"?eRQ$e-0Gp+")g5ea,b0Ui)b2814d6p`8I^<E-,X,D-O"ks3!nBV%hIXdj+ZD-4a+T"XI+sP8+8Hu6+RN\=+8l03@d`J9X+e)sR6(3)giG=l_sl\>(RQBGW&!/,:9NY3KVp<)NK-ZSB3Og.B8S)0Mtu?B3n9u`T8J6OSiC<=nV1qkARZufeAJ0MQsM^Y`aL`Y=`ncmLXd*9cHRdXQ;a/*2eI#.:1.,XR(uQZJ[o`0!_;>Tk.?TZ**)@][L#b&eQUZJmIB;Vk8^6HFS)T[l!.VCDPIimX4h4S2JO?>hm%",&.-gh,4h,mk)N-D0q5Y0DsbK&*A#,ir-35E[+m^fh=oFP@?h*,Fi=dmI_:@qp-P#&AacNGnJP09&25cP_$cAZl5($ej##W/-7<eZXmhc_)-H\S5"AQXI&T5$QUsjnn1hq'&:4ILMQhU#,5C/m"?$DH0#l:^IeN]kVKS:.Hf:Cq$S8to[VD[V/1n6BXBoa+fskIZnKs>;2o*MD!fcO-`mme.,\[;s3jV(^4h"S=hK7pmc/-J(+eq_,KW._TZYZ6"PDEIEjetV3IXb@8g7@>5X(!ofcH:R6'K%peq)2fdZZ7.\Cj;MYI#G;hG#n#uPjQb*^.m;IXPJX[)kH)<S$LUJ]asca]\skndsDt,gtds(;ss(e$rQH\`j@1=pKe%PGB[P#KY)Ra"*D/e0dk"PMC$br@nb(fHRtP`ma&7M0TK6R`k6?V9bIiXAbi-FN+k6Y;Sb5Ida/e`0@gHa,d3+R]L"rj31ga_8ke='^*Sp-.X?^QQ@LAP_90Ri's:L+H3M?Xl=[WIgC_0sGX8(?qWfD$7A&k)@;`WW4/a6]Z->ZK3c.eMXtA.)q^bb>ZefAF(]&MD6M%2C]6Ya/,Rt?P*cZaX%Ob+[^VFeg1q_ZdLQmnfU=b;Wl;*Y=CZ>fq?[U'3O$03\'A+e'@:r8Qlgr$_j9Hc:KSa`VNDMB`D<?U0Sn'CN"$iIn//@QW2cdGKBf%.f:1`<`53Fgs;F)PMET]i_Hp^?Gm#C$)502=2(sOH!mgOM,_rF8>kH)]QYGp`G^"r?8/6\BMoUdPKaj-4ma8!6[<70rVU\.,$]<mJD5N5hY)km+-3DTEY"[?,h!S^k2;*1tn.U$;"D"'OBm6u7:U\mL\g<)W61+PG:$]#2YYfURgPmPiuMIWdFS,6SFq`YLP1(rN/1$;rE%&\M`6!6#7_)IMaGY&_\G:cgGQ*hbV#ieK=.f!"q>uhBUCJ#H##-krPnC]L#fHq.W!l'=\4pEhM/kYp9_jiYW'P0!6LKSJ^&I)*aH.KV1/=RL4A>80,c^2Dg6Z`#:*"H'>\2*plM@t=//n%W6J/`&(,oEVAQYaZ1&s[l2bR'Ia58ZmfhA\&[US2L'Nk-'l+Jqq]TB-?XjP,@>n4C@a[njL2$9mRD&,>tu!V;'J;jufbdTP*IrJHBq]qNsrYSppi--5B=CCk)^EmbJQORh8P5mb2MNKpI[j8)C+eWh5skh]B+0`^-5jm`sSqG,-CTTR"TbnZI.W4ukb4"BYI_,!9aBu1#>,h"7T/BKg6o_Tnr^&G&f;+auS+,2;U]DhBXa='O4;7it6*)-s,*TS;)P>._5b;/9kMB('H0/+07=2]^W=?bqe&#o?9Jq26jPRUTfL7_s,"^bRYnthAOO-pLu,q'B-R17Nu:G<8p%_ZTJG[+6X'MXh<G),S4!a;]BFp"X:65&<l+c/'2$"PljN#HT!pdK6rX.`As;Db93YaTT:d&7pb;g&NfQ,@@ZCn[VE=A9YbHrLTV.BS;cb$bI9H>SVjEuX?-!0Z.E56%C.@`KtD9b%l(K@48T!l_`d<7kFL!ll0\?s6:smdG^j(>RC6g\Hc+k%ZH:OJm1ndOsJJo(MIk,l_"s*/cEo+dPVrF:QV>1:fD'4khJgs7c&41`"R"L2fl#^YVnL_P[]H;A!Ik@BHT/EBf\HQ/i34.e_P-*[K-B,?#b*\6dr9N6G=Jqr#C'>CmeS_9:a*C<6YJQWD4fhN2o78bs4oR+\JN].*DhFXS@+.8V.$f:P5C8.cpt[p&V-TT$gXX"?C.s7Io:Ck+*Tf'5Qq`Hni(j+:;JVff="BHF(p_,5_,9Z+jL!IUb1YQ~>endstream
+endobj
+38 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 536
+>>
+stream
+Gatm79i'e7%)(h*=Q71A0ceS6-CuH<>m./C[:BeeX2:ZsD,P5V'T$23cK(a75b'`5C5r1`rB,'3,TDKqX8ob(@J0d('r3j_&I-ZDHr$M%&U)7J$L<pD8@0.C/M`C9_AU;1JoIt@X4\jM2@ca0<&-*r0SG&!&Y*>4Q&#9rCGsa0[.t-Yf+F%=G,k).FPN&spDF8`3`^Fn/X]1=5Qqka_eqLF%c`,&O;;fHo_%X[b5=1h?Q_M$^^s(NMQ',G>0]W'),P`?r2Q77JU_Z\GQ5/CX.k?H>um#$*H$>iWFU59b4:b3e@1EWpp?a67)s#j7]\M[\nrtkS'%'QOeN\R]O3hLCP1ES4Pt$K&$%1,hX(3mEqOoY>PRk`Pjbr+[sdhtltX;FIX?=L4n0?MAUSX]b09e]?'/LTO(uD#%+&\!jnC&6K["gp+JVf?#"iE""O$+e=8f7.e`*f4I+lGc^S"#bmisRj38OiD;F#[^0gt(^4j`;1>TPj'Le#tN"ZQ891t'EoL_5bF';?K<]"3f-&H)\Hp#oW~>endstream
+endobj
+xref
+0 39
+0000000000 65535 f 
+0000000061 00000 n 
+0000000143 00000 n 
+0000000250 00000 n 
+0000000362 00000 n 
+0000000567 00000 n 
+0000000686 00000 n 
+0000000791 00000 n 
+0000000868 00000 n 
+0000001073 00000 n 
+0000001278 00000 n 
+0000001484 00000 n 
+0000001690 00000 n 
+0000001774 00000 n 
+0000001980 00000 n 
+0000002186 00000 n 
+0000002392 00000 n 
+0000002598 00000 n 
+0000002804 00000 n 
+0000003010 00000 n 
+0000003216 00000 n 
+0000003422 00000 n 
+0000003628 00000 n 
+0000003698 00000 n 
+0000003995 00000 n 
+0000004148 00000 n 
+0000004773 00000 n 
+0000007781 00000 n 
+0000010407 00000 n 
+0000013079 00000 n 
+0000015787 00000 n 
+0000018250 00000 n 
+0000021289 00000 n 
+0000023412 00000 n 
+0000026296 00000 n 
+0000028667 00000 n 
+0000030826 00000 n 
+0000033457 00000 n 
+0000036308 00000 n 
+trailer
+<<
+/ID 
+[<1d8dfea026dff6abcbe13a1e9823e8fd><1d8dfea026dff6abcbe13a1e9823e8fd>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 23 0 R
+/Root 22 0 R
+/Size 39
+>>
+startxref
+36935
+%%EOF

--- a/scripts/generate_reference_pdf.py
+++ b/scripts/generate_reference_pdf.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+"""Generate Core Builds Reference PDF using reportlab."""
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import mm
+from reportlab.lib import colors
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
+    HRFlowable, KeepTogether, PageBreak
+)
+from reportlab.lib.enums import TA_LEFT, TA_CENTER
+import datetime
+
+OUT = "/home/user/Core-Builds/Core-Builds-Reference.pdf"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+BRAND     = colors.HexColor("#1a1a2e")
+ACCENT    = colors.HexColor("#4a90d9")
+LIGHT_BG  = colors.HexColor("#f0f4f8")
+CODE_BG   = colors.HexColor("#1e1e2e")
+CODE_FG   = colors.HexColor("#cdd6f4")
+GRID_COL  = colors.HexColor("#d0d7de")
+H2_COLOR  = colors.HexColor("#0969da")
+H3_COLOR  = colors.HexColor("#1a7f37")
+WARN_BG   = colors.HexColor("#fff8c5")
+WARN_FG   = colors.HexColor("#9a6700")
+
+# ── Styles ────────────────────────────────────────────────────────────────────
+base = getSampleStyleSheet()
+
+def sty(name, parent="Normal", **kw):
+    return ParagraphStyle(name, parent=base[parent], **kw)
+
+H1  = sty("H1", "Title",    fontSize=22, textColor=BRAND,    spaceAfter=6, spaceBefore=0, leading=26)
+H2  = sty("H2", "Heading2", fontSize=14, textColor=H2_COLOR,  spaceAfter=4, spaceBefore=14, leading=18)
+H3  = sty("H3", "Heading3", fontSize=11, textColor=H3_COLOR,  spaceAfter=3, spaceBefore=10, leading=14)
+H4  = sty("H4", "Heading3", fontSize=10, textColor=BRAND,    spaceAfter=2, spaceBefore=8,  leading=13)
+BODY = sty("BODY", fontSize=9,  leading=13, spaceAfter=3)
+SMALL = sty("SMALL", fontSize=8, leading=11, textColor=colors.HexColor("#444444"))
+CODE = sty("CODE", fontName="Courier", fontSize=8, leading=11,
+           backColor=CODE_BG, textColor=CODE_FG,
+           leftIndent=6, rightIndent=6, spaceBefore=2, spaceAfter=2)
+MONO = sty("MONO", fontName="Courier", fontSize=8, leading=11)
+BULLET = sty("BULLET", fontSize=9, leading=13, leftIndent=12, spaceAfter=2,
+             bulletIndent=4, bulletFontName="Helvetica")
+SUBTITLE = sty("SUBTITLE", fontSize=10, textColor=colors.HexColor("#555555"),
+               spaceAfter=2, leading=13)
+NOTE = sty("NOTE", fontSize=8, leading=11, textColor=WARN_FG,
+           backColor=WARN_BG, leftIndent=6, rightIndent=6, spaceBefore=2, spaceAfter=4)
+
+def hr(): return HRFlowable(width="100%", thickness=0.5, color=GRID_COL, spaceAfter=4, spaceBefore=2)
+def sp(h=4): return Spacer(1, h)
+def p(text, style=BODY): return Paragraph(text, style)
+def h2(text): return [sp(6), Paragraph(text, H2), hr()]
+def h3(text): return [Paragraph(text, H3)]
+def h4(text): return [Paragraph(text, H4)]
+def code(text): return Paragraph(text.replace(" ", "&nbsp;").replace("<", "&lt;").replace(">", "&gt;"), CODE)
+def note(text): return Paragraph(f"⚠ {text}", NOTE)
+def bullet(text): return Paragraph(f"• {text}", BULLET)
+
+def mono(text):
+    t = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return f'<font name="Courier">{t}</font>'
+
+def table(data, col_widths=None, header=True):
+    t = Table(data, colWidths=col_widths, repeatRows=1 if header else 0)
+    style = [
+        ("FONTNAME",    (0, 0), (-1, 0 if header else -1), "Helvetica-Bold"),
+        ("FONTSIZE",    (0, 0), (-1, -1), 8),
+        ("LEADING",     (0, 0), (-1, -1), 11),
+        ("BACKGROUND",  (0, 0), (-1, 0),  LIGHT_BG),
+        ("TEXTCOLOR",   (0, 0), (-1, 0),  BRAND),
+        ("GRID",        (0, 0), (-1, -1), 0.4, GRID_COL),
+        ("VALIGN",      (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 5),
+        ("RIGHTPADDING",(0, 0), (-1, -1), 5),
+        ("TOPPADDING",  (0, 0), (-1, -1), 3),
+        ("BOTTOMPADDING",(0,0), (-1, -1), 3),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f8fafc")]),
+    ]
+    t.setStyle(TableStyle(style))
+    return t
+
+def mono_cell(text):
+    return Paragraph(mono(text), SMALL)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Document assembly
+# ─────────────────────────────────────────────────────────────────────────────
+doc = SimpleDocTemplate(
+    OUT, pagesize=A4,
+    leftMargin=20*mm, rightMargin=20*mm,
+    topMargin=18*mm, bottomMargin=18*mm,
+    title="Core Builds — Complete Reference",
+    author="Brevity",
+)
+
+W = A4[0] - 40*mm  # usable width
+
+story = []
+
+# ── Cover ────────────────────────────────────────────────────────────────────
+story += [
+    sp(30),
+    Paragraph("Core Builds", H1),
+    Paragraph("Complete Reference — AIOStreams Templates", SUBTITLE),
+    Paragraph(f"Generated {datetime.date.today().strftime('%B %d, %Y')}", SMALL),
+    sp(6),
+    hr(),
+    p("Authoritative reference for all fields, functions, patterns, and conventions used "
+      "in the Core Builds template collection for AIOStreams. Pull from <b>brevityA/Core-Builds</b>."),
+    PageBreak(),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. TEMPLATE SCHEMA
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("1  Template Schema")
+story += [
+    p("All templates are JSON files with two top-level objects: <b>metadata</b> and <b>config</b>."),
+    sp(4),
+]
+
+story += h3("1.1  metadata")
+story += [
+    table([
+        ["Field", "Type", "Notes"],
+        [mono_cell("id"),                    p("string", SMALL), p("Unique ID — use brevity.core-nexus-* prefix for stable templates", SMALL)],
+        [mono_cell("name"),                  p("string", SMALL), p("Display name shown in AIOStreams UI", SMALL)],
+        [mono_cell("description"),           p("string", SMALL), p("Short summary of the template's purpose", SMALL)],
+        [mono_cell("source"),                p("string", SMALL), p('"external" for all user-imported templates', SMALL)],
+        [mono_cell("author"),                p("string", SMALL), p('"Branding-Brevity"', SMALL)],
+        [mono_cell("version"),               p("string", SMALL), p("SemVer — MAJOR.MINOR.PATCH", SMALL)],
+        [mono_cell("category"),              p("string", SMALL), p('"Debrid" | "Anime" | "Device" | "Nightly"', SMALL)],
+        [mono_cell("serviceRequired"),       p("boolean", SMALL), p("false for most templates", SMALL)],
+        [mono_cell("setToSaveInstallMenu"),  p("boolean", SMALL), p("true — saves to install menu on import", SMALL)],
+        [mono_cell("sourceUrl"),             p("string", SMALL), p("raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/…", SMALL)],
+        [mono_cell("changelogUrl"),          p("string", SMALL), p("Points to CHANGELOG.md raw URL", SMALL)],
+        [mono_cell("changelog"),             p("array", SMALL),  p('[{version, date?, changes:[…]}] — shown in update dialog', SMALL)],
+    ], col_widths=[50*mm, 22*mm, W - 72*mm]),
+    sp(4),
+]
+
+story += h3("1.2  config — top-level fields")
+story += [
+    table([
+        ["Field", "Notes"],
+        [mono_cell("addonName"),        p("Display name of the addon stack", SMALL)],
+        [mono_cell("addonLogo"),        p("Must use /refs/heads/main/ (not /main/) — stale CDN breakage otherwise", SMALL)],
+        [mono_cell("sourceUrl"),        p("Same as metadata.sourceUrl — used for in-app update check", SMALL)],
+        [mono_cell("parentConfig"),     p("Optional — uuid + password + mergeStrategies for parent/child linking", SMALL)],
+        [mono_cell("presets"),          p("Array of addon/service presets", SMALL)],
+        [mono_cell("sortCriteria"),     p("{global:[{key,direction}]} — direction must be 'asc'|'desc', never 'order'", SMALL)],
+        [mono_cell("maxResults"),       p("Max streams returned (default 20)", SMALL)],
+        [mono_cell("maxResultsPerResolution"), p("Cap per resolution bucket (default 8)", SMALL)],
+        [mono_cell("excludedEncodes"),  p("Array of codec strings to hard-exclude", SMALL)],
+        [mono_cell("excludedAudioTags"),p("Array of audio format strings to hard-exclude", SMALL)],
+        [mono_cell("preferredEncodes"), p("Ranked preferred codecs", SMALL)],
+        [mono_cell("preferredVisualTags"),p("Ranked HDR/visual tags", SMALL)],
+        [mono_cell("preferredAudioChannels"), p("e.g. ['7.1','5.1','2.0']", SMALL)],
+        [mono_cell("preferredResolutions"), p("Ordered list — first = most preferred", SMALL)],
+        [mono_cell("preferredRegexPatterns"),  p("Template-specific named regex patterns with score (70–100)", SMALL)],
+        [mono_cell("rankedRegexPatterns"),     p("|score|≥50 subset from shared file (48 × 4K, 45 × 1080p, 0 × Anime)", SMALL)],
+        [mono_cell("streamExpressions"),       p("PSEs — preferred stream expressions (ranking)", SMALL)],
+        [mono_cell("excludedStreamExpressions"), p("ESEs — kill/block expressions", SMALL)],
+        [mono_cell("includedStreamExpressions"), p("ISEs — passthrough / include expressions", SMALL)],
+        [mono_cell("formatter"),        p("Formatter config — references a formatter definition by id", SMALL)],
+    ], col_widths=[55*mm, W - 55*mm]),
+    sp(4),
+]
+
+story += h3("1.3  Preset structure")
+story += [
+    table([
+        ["Field", "Notes"],
+        [mono_cell("id"),       p("UUID for the preset instance", SMALL)],
+        [mono_cell("type"),     p("Preset type string — see Known Preset Types", SMALL)],
+        [mono_cell("enabled"),  p("boolean — false to disable without removing", SMALL)],
+        [mono_cell("options"),  p("Type-specific config object (URLs, API keys, timeouts)", SMALL)],
+    ], col_widths=[30*mm, W - 30*mm]),
+    sp(4),
+]
+
+story += h3("1.4  Template Directives (Nightly Labs only)")
+story += [
+    table([
+        ["Directive", "Effect"],
+        [mono_cell("__if"),     p("Conditional block — evaluates inputs.x, services.x; supports and/or/xor", SMALL)],
+        [mono_cell("__value"),  p("Replaced with a dynamic value at load time", SMALL)],
+        [mono_cell("__switch"), p("Multi-branch conditional", SMALL)],
+        [mono_cell("__remove"), p("Removes the containing key/element from the output", SMALL)],
+    ], col_widths=[35*mm, W - 35*mm]),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. KNOWN VALIDATOR RULES
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("2  Known Validator Rules")
+for item in [
+    "<b>sortCriteria direction</b> — must be <font name='Courier'>\"direction\"</font>, not <font name='Courier'>\"order\"</font> — AIOStreams rejects <font name='Courier'>order</font> on import.",
+    "<b>addonLogo URL</b> — must use <font name='Courier'>/refs/heads/main/</font> not <font name='Courier'>/main/</font> — short form breaks on stale CDN caches.",
+    "<b>stremthruTorz</b> — TorBox-specific; <font name='Courier'>stremthruStore</font> is for other debrid services (AllDebrid, RD).",
+    "<b>torbox-search</b> — valid TorBox-wrapped search addon; keep <font name='Courier'>enabled: false</font> to opt out per-template.",
+    "<b>syncedRankedRegexUrls</b> — blocked on public instances (elfhosted, fortheweak.cloud). Triggers \"Forbidden URL\" error. Embed patterns inline in rankedRegexPatterns instead.",
+    "<b>Regex access</b> — <font name='Courier'>REGEX_FILTER_ACCESS=trusted</font> is the AIOStreams default. Inline rankedRegexPatterns are ALSO blocked for non-trusted users. Self-hosted: set <font name='Courier'>REGEX_FILTER_ACCESS=all</font>.",
+    "<b>SEL hard limits</b> — Max 3,000 chars per expression (MAX_SEL_LENGTH); 50,000 chars total (MAX_STREAM_EXPRESSIONS_TOTAL_CHARACTERS); 200 total expressions max. Current peak: 2,953 chars — do not grow the Final Limit ESE.",
+]:
+    story.append(bullet(item))
+story.append(sp(4))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. KNOWN PRESET TYPES
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("3  Known Preset Types")
+story += [
+    table([
+        ["Category", "type values"],
+        ["Debrid / service", mono_cell("stremthruTorz  stremthruStore  torrent-io  torbox  torbox-search")],
+        ["Scrapers",         mono_cell("comet  mediafusion  mediafusion-public  jackettio  prowlarr  orionoid  annatar  knaben  torrentio  debridio  meteor  torrent-galaxy  zilean  hdhub  eztv")],
+        ["Usenet",           mono_cell("newznab  easynews  easynews-plus")],
+        ["Anime-specific",   mono_cell("seadex  animetosho  neko-bt")],
+        ["Subtitles",        mono_cell("opensubtitles-v3-plus  aiosubtitle")],
+        ["System",          mono_cell("library  custom")],
+    ], col_widths=[35*mm, W - 35*mm]),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. SEL FUNCTION REFERENCE
+# ─────────────────────────────────────────────────────────────────────────────
+story += [PageBreak()]
+story += h2("4  SEL Function Reference")
+story += [p("All functions available in AIOStreams Stream Expression Language "
+            "(<font name='Courier'>packages/core/src/parser/streamExpression.ts</font>)."), sp(3)]
+
+story += h3("4.1  Statistics functions")
+story += [
+    table([
+        ["Function", "Description"],
+        [mono_cell("max(arr)"),          p("Maximum value", SMALL)],
+        [mono_cell("min(arr)"),          p("Minimum value", SMALL)],
+        [mono_cell("avg(arr) / mean(arr)"), p("Arithmetic mean", SMALL)],
+        [mono_cell("sum(arr)"),          p("Sum of values", SMALL)],
+        [mono_cell("percentile(arr,n)"), p("nth percentile", SMALL)],
+        [mono_cell("q1(arr)"),           p("25th percentile", SMALL)],
+        [mono_cell("q2(arr) / median(arr)"), p("50th percentile", SMALL)],
+        [mono_cell("q3(arr)"),           p("75th percentile", SMALL)],
+        [mono_cell("iqr(arr)"),          p("Interquartile range (q3 − q1)", SMALL)],
+        [mono_cell("variance(arr)"),     p("Population variance", SMALL)],
+        [mono_cell("stddev(arr)"),       p("Standard deviation", SMALL)],
+        [mono_cell("range(arr)"),        p("max − min", SMALL)],
+        [mono_cell("mode(arr)"),         p("Most frequent value", SMALL)],
+        [mono_cell("skewness(arr)"),     p("Pearson skewness", SMALL)],
+        [mono_cell("kurtosis(arr)"),     p("Excess kurtosis", SMALL)],
+        [mono_cell("values(streams, field)"), p("Extract field values from a stream array as a numeric array. Common: 'bitrate', 'size', 'seeders'", SMALL)],
+    ], col_widths=[55*mm, W - 55*mm]),
+    sp(4),
+]
+
+story += h3("4.2  Stream filter functions")
+story += [
+    table([
+        ["Function", "Description"],
+        [mono_cell("resolution(streams, ...res)"),    p("Filter by resolution string: '2160p','1080p','720p',…", SMALL)],
+        [mono_cell("quality(streams, ...q)"),         p("Filter by quality: 'Bluray REMUX','WEB-DL','WEBRip',…", SMALL)],
+        [mono_cell("encode(streams, ...enc)"),        p("Filter by codec: 'H.265/HEVC','H.264/AVC','AV1','VC-1',…", SMALL)],
+        [mono_cell("type(streams, ...t)"),            p("Filter by content type: 'movie','series',…", SMALL)],
+        [mono_cell("visualTag(streams, ...t)"),       p("Filter by HDR tag: 'DV','HDR10+','HDR10','HLG','SDR',…", SMALL)],
+        [mono_cell("audioTag(streams, ...t)"),        p("Filter by audio format: 'TrueHD','DTS-HD MA','Atmos',…", SMALL)],
+        [mono_cell("audioChannels(streams, ...ch)"),  p("Filter by channel count: '7.1','5.1','2.0',…", SMALL)],
+        [mono_cell("language(streams, ...l)"),        p("Filter by language code", SMALL)],
+        [mono_cell("subtitle(streams, ...s)"),        p("Filter by subtitle language", SMALL)],
+        [mono_cell("seeders(streams, min, max?)"),    p("Filter by seeder count range", SMALL)],
+        [mono_cell("age(streams, maxDays)"),          p("Filter streams older than maxDays", SMALL)],
+        [mono_cell("size(streams, min, max?)"),       p("Filter by file size — accepts '15GB','1TB', etc.", SMALL)],
+        [mono_cell("bitrate(streams, min, max?)"),    p("Filter by bitrate — accepts '5Mbps','50Mbps', etc.", SMALL)],
+        [mono_cell("service(streams, ...svc)"),       p("Filter by debrid service: 'torbox','realdebrid',…", SMALL)],
+        [mono_cell("cached(streams)"),               p("Keep only cached streams", SMALL)],
+        [mono_cell("uncached(streams)"),             p("Keep only uncached streams", SMALL)],
+        [mono_cell("releaseGroup(streams, ...g)"),   p("Filter by release group name", SMALL)],
+        [mono_cell("seasonPack(streams, mode)"),     p("mode: 'onlySeasons' | 'onlyEpisodes' | 'both'", SMALL)],
+        [mono_cell("multiEpisode(streams)"),         p("Keep only multi-episode files", SMALL)],
+        [mono_cell("addon(streams, ...names)"),      p("Filter by addon name", SMALL)],
+        [mono_cell("library(streams)"),              p("Keep only library/watchlist streams", SMALL)],
+        [mono_cell("seadex(streams)"),               p("Keep only SeaDex-matched streams", SMALL)],
+        [mono_cell("message(streams, msg)"),         p("Attach a custom message to streams", SMALL)],
+        [mono_cell("passthrough(streams)"),          p("Return streams unchanged (identity)", SMALL)],
+        [mono_cell("indexer(streams, ...names)"),    p("Filter by indexer/scraper name", SMALL)],
+        [mono_cell("keyword(streams, attr, ...kw)"), p("Match by keyword in attr ('filename','releaseGroup','all')", SMALL)],
+    ], col_widths=[65*mm, W - 65*mm]),
+    sp(4),
+]
+
+story += h3("4.3  Score / match functions")
+story += [
+    table([
+        ["Function", "Description"],
+        [mono_cell("seScore(streams)"),                    p("Score by stream expression match tier", SMALL)],
+        [mono_cell("streamExpressionScore(streams)"),      p("Alias for seScore", SMALL)],
+        [mono_cell("regexScore(streams)"),                 p("Score by regex pattern match", SMALL)],
+        [mono_cell("regexMatched(streams, ...names)"),     p("Keep streams matched by named regex pattern(s)", SMALL)],
+        [mono_cell("regexMatchedInRange(streams,min,max)"),p("Keep streams whose regex match index is in range", SMALL)],
+        [mono_cell("seMatched(streams, ...names)"),        p("Keep streams whose SE name matches. No args → all SE-matched", SMALL)],
+        [mono_cell("seMatchedInRange(streams, min, max)"), p("Keep streams matched by SE at index in min..max", SMALL)],
+        [mono_cell("rseMatched(streams, ...tiers)"),       p("Keep streams matched by named RSE tier", SMALL)],
+    ], col_widths=[65*mm, W - 65*mm]),
+    sp(4),
+]
+
+story += h3("4.4  Array / control functions")
+story += [
+    table([
+        ["Function", "Signature", "Description"],
+        [mono_cell("count"),      mono_cell("count(streams)"),                  p("Number of streams in array", SMALL)],
+        [mono_cell("negate"),     mono_cell("negate(streams)"),                 p("Invert — exclude these streams from the result set", SMALL)],
+        [mono_cell("merge"),      mono_cell("merge(...arrays)"),                p("Concatenate multiple stream arrays", SMALL)],
+        [mono_cell("slice"),      mono_cell("slice(streams, start, end?)"),     p("Take a sub-slice of a stream array", SMALL)],
+        [mono_cell("perGroup"),   mono_cell("perGroup(streams, key, max)"),     p("Limit to max streams per group key", SMALL)],
+        [mono_cell("pin"),        mono_cell("pin(streams, pos?, returnMatched?)"),
+         p("Register streams for top/bottom pinning. Returns [] (ESE) or matched streams (RSE). pos: 'top'|'bottom'", SMALL)],
+    ], col_widths=[25*mm, 55*mm, W - 80*mm]),
+    sp(4),
+]
+
+story += h3("4.5  Math (expr-eval)")
+for item in [
+    mono("pow(base, exp)") + " — exponentiation. Used in IQR pow()-decay: " + mono("pow(0.95, daysSinceRelease)"),
+    mono("sqrt(x)") + " — square root",
+    mono("random()") + " — random float [0,1)",
+    "All standard arithmetic operators: + − * / % ( )",
+]:
+    story.append(bullet(item))
+story.append(sp(4))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. SEL VARIABLES
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("5  SEL Variables")
+story += [p("Available as bare names in any PSE / ESE / ISE expression."), sp(3)]
+
+story += h3("5.1  Content metadata")
+story += [
+    table([
+        ["Variable", "Type", "Values / Notes"],
+        [mono_cell("queryType"),       p("string",SMALL), p("'movie' | 'series' | 'anime.movie' | 'anime.series'", SMALL)],
+        [mono_cell("isAnime"),         p("boolean",SMALL), p("true when queryType is anime.*", SMALL)],
+        [mono_cell("title"),           p("string",SMALL), p("Content title", SMALL)],
+        [mono_cell("year"),            p("number",SMALL), p("Release year (start year for series)", SMALL)],
+        [mono_cell("yearEnd"),         p("number",SMALL), p("End year for ended series", SMALL)],
+        [mono_cell("season"),          p("number",SMALL), p("Requested season number", SMALL)],
+        [mono_cell("episode"),         p("number",SMALL), p("Requested episode number", SMALL)],
+        [mono_cell("absoluteEpisode"), p("number",SMALL), p("Absolute episode count (anime)", SMALL)],
+        [mono_cell("genres"),          p("string[]",SMALL),p("Genre list e.g. ['Action','Drama']", SMALL)],
+        [mono_cell("runtime"),         p("number",SMALL), p("Runtime in minutes", SMALL)],
+        [mono_cell("originalLanguage"),p("string",SMALL), p("ISO language code e.g. 'en','ja'", SMALL)],
+        [mono_cell("hasSeaDex"),       p("boolean",SMALL), p("true when SeaDex entry exists for this title", SMALL)],
+    ], col_widths=[45*mm, 22*mm, W - 67*mm]),
+    sp(4),
+]
+
+story += h3("5.2  Release timing")
+story += [
+    table([
+        ["Variable", "Type", "Notes"],
+        [mono_cell("daysSinceRelease"),    p("number",SMALL), p("Days since theatrical/streaming release date", SMALL)],
+        [mono_cell("daysSinceFirstAired"), p("number",SMALL), p("Days since series first aired", SMALL)],
+        [mono_cell("daysSinceLastAired"),  p("number",SMALL), p("Days since most recent episode aired", SMALL)],
+        [mono_cell("daysUntilNextEpisode"),p("number",SMALL), p("Days until next episode (negative if in future)", SMALL)],
+        [mono_cell("hasNextEpisode"),      p("boolean",SMALL), p("true if there is a scheduled next episode", SMALL)],
+        [mono_cell("latestSeason"),        p("number",SMALL), p("Highest available season number", SMALL)],
+        [mono_cell("ongoingSeason"),       p("boolean",SMALL), p("true if the requested season is currently airing", SMALL)],
+    ], col_widths=[50*mm, 22*mm, W - 72*mm]),
+    sp(4),
+]
+
+story += h3("5.3  Dynamic addon fetching (exit condition only)")
+story += [
+    table([
+        ["Variable", "Notes"],
+        [mono_cell("totalStreams"),       p("Total streams collected so far across all queried addons", SMALL)],
+        [mono_cell("totalTimeTaken"),     p("Elapsed ms since the query started", SMALL)],
+        [mono_cell("queriedAddons"),      p("Number of addons already queried", SMALL)],
+        [mono_cell("allAddons"),          p("Total number of addons in the stack", SMALL)],
+    ], col_widths=[45*mm, W - 45*mm]),
+    sp(4),
+]
+
+story += h3("5.4  Groups (group condition only)")
+story += [
+    table([
+        ["Variable", "Notes"],
+        [mono_cell("previousStreams"),          p("Streams returned by previous group expressions", SMALL)],
+        [mono_cell("previousGroupTimeTaken"),   p("Time taken by previous group (ms)", SMALL)],
+    ], col_widths=[55*mm, W - 55*mm]),
+    sp(4),
+]
+
+story += [note("hasChapters, editions, regraded, date, dubbed, subbed — formatter DSL only. "
+               "These are stream.X fields in formatter strings, NOT SEL variables.")]
+story.append(sp(4))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. PSE ARCHITECTURE
+# ─────────────────────────────────────────────────────────────────────────────
+story += [PageBreak()]
+story += h2("6  PSE Architecture")
+
+story += h3("6.1  IQR Tukey Fence (4K full templates)")
+story += [
+    p("Three-tier adaptive bitrate selection pattern used in 4K Apex, 4K Hybrid, 4K Essential, 4K AllDebrid:"),
+    sp(2),
+    code("/*LABEL*/\n"
+         "count(PEER_EXPR) >= 4\n"
+         "  ? size(bitrate(STREAMS,\n"
+         "      q1(values(bitrate(STREAMS,'5Mbps'),'bitrate')) - 1.5*iqr(values(...)),\n"
+         "      q3(...) + 1.5*iqr(...)), '15GB')\n"
+         "  : count(PEER_EXPR) > 0\n"
+         "    ? size(bitrate(STREAMS, min(values(...))*0.80, max(values(...))*1.20), '15GB')\n"
+         "    : (count(bitrate(STREAMS, MEDIAN*(1-0.4*pow(0.95,daysSinceRelease)),\n"
+         "                            MEDIAN*(1+0.4*pow(0.95,daysSinceRelease)))) >= 1\n"
+         "        ? bitrate(STREAMS, MEDIAN*(1-0.4*pow(0.95,daysSinceRelease)))\n"
+         "        : [])"),
+    sp(3),
+    table([
+        ["Condition", "Strategy"],
+        ["≥ 4 peers",  p("IQR Tukey fence: q1 − 1.5×IQR … q3 + 1.5×IQR. Statistically sound; outliers clipped.", SMALL)],
+        ["1–3 peers",  p("min × 0.80 … max × 1.20. Thin pool: ±20% tolerance around observed range.", SMALL)],
+        ["0 peers",    p("pow(0.95, daysSinceRelease) exponential decay around median bitrate. "
+                         "±40% day 0 → ±9% day 30 → ±2% day 60 → ~0% day 90+. Replaces hard 60-day cliff.", SMALL)],
+    ], col_widths=[25*mm, W - 25*mm]),
+    sp(4),
+]
+
+story += h3("6.2  Hybrid TorBox-priority pattern")
+story += [
+    p("Each IQR tier is preceded by a TorBox-only twin PSE. Returns [] if no TorBox streams match → falls through:"),
+    code("service(size(bitrate(STREAMS, IQR_LO, IQR_HI), '15GB'), 'torbox')"),
+    sp(4),
+]
+
+story += h3("6.3  ongoingSeason PSE (all active templates)")
+story += [
+    code("/*ongoingSeasonPack*/\n"
+         "((queryType=='series' or queryType=='anime.series') and ongoingSeason\n"
+         "  and (daysSinceLastAired < -1 or daysUntilNextEpisode >= 0))\n"
+         "? seasonPack(streams, 'onlySeasons') : []"),
+    p("Returns season packs only when the queried season is currently airing and "
+      "the latest episode has aired. Prevents partial-pack results for completed seasons."),
+    sp(4),
+]
+
+story += h3("6.4  PSE label convention")
+story += [
+    code("/* TEMPLATE_LABEL Tier Description */"),
+    p("Examples: <font name='Courier'>/* APEX S-Tier 4K Remux — IQR Tukey fence */</font>, "
+      "<font name='Courier'>/* STREAM A-Tier WEB-DL */</font>"),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. REGEX SCORING ARCHITECTURE
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("7  Regex Scoring Architecture")
+story += [
+    p("Two independent regex systems apply simultaneously. Pattern names must not overlap between them — "
+      "duplicates cause double-scoring."),
+    sp(3),
+]
+
+story += h3("7.1  preferredRegexPatterns  (template-specific)")
+story += [
+    table([
+        ["Template type", "Count", "Score", "Example patterns"],
+        ["4K templates",   "7",   "70–100", p("Radarr Remux T1, Sonarr Remux T1, Radarr UHD Bluray T1, FraMeSToR, Anime BD T1", SMALL)],
+        ["1080p templates","8",   "70–100", p("Radarr Web T1, Sonarr Web T1, FLUX, hallowed, BHDStudio, SiC, 126811, Web T1", SMALL)],
+        ["Anime templates","0",   "—",      p("None — SeaDex ISE handles quality selection", SMALL)],
+    ], col_widths=[30*mm, 18*mm, 18*mm, W - 66*mm]),
+    sp(4),
+]
+
+story += h3("7.2  rankedRegexPatterns  (shared high-impact subset)")
+story += [
+    p("Source of truth: <font name='Courier'>Filtering/ranked-regex-patterns.json</font> — 149 patterns, 10 score tiers."),
+    p("Embed only patterns with <b>|score| ≥ 50</b>, minus any names already in preferredRegexPatterns "
+      "(prevents double-scoring). Patterns with |score| &lt; 50 (streaming service tags, edition names, "
+      "low-tier group labels) add file bulk with no meaningful ranking signal."),
+    sp(3),
+    table([
+        ["Template type", "Count", "Score tiers kept"],
+        ["4K templates",   "48", p("S(+100)  A(+80)  B(+60)  Penalised(−50)  Bad(−75)  Blacklist(−200)", SMALL)],
+        ["1080p templates","45", p("Same tiers — 8 more preferredRegexPatterns overlaps removed", SMALL)],
+        ["Anime templates","0",  p("Cleared — live-action group names don't match anime naming", SMALL)],
+    ], col_widths=[35*mm, 20*mm, W - 55*mm]),
+    sp(3),
+    table([
+        ["Score", "Tier", "Meaning"],
+        ["+100", "S",          p("Elite remux groups (FraMeSToR, FLUX, BHDStudio, hallowed, SiC, etc.)", SMALL)],
+        ["+80",  "A",          p("High-quality encode groups", SMALL)],
+        ["+60",  "B",          p("Solid scene groups", SMALL)],
+        ["+40",  "C",          p("Acceptable — included in preferredRegexPatterns only", SMALL)],
+        ["+20",  "D",          p("Marginal — excluded from inline set", SMALL)],
+        ["0",    "Neutral",    p("No signal — excluded", SMALL)],
+        ["−25",  "Meh",        p("Slightly penalised — excluded", SMALL)],
+        ["−50",  "Penalised",  p("Known low-quality encode groups", SMALL)],
+        ["−75",  "Bad",        p("Low-effort or scene-nuked groups", SMALL)],
+        ["−200", "Blacklist",  p("Worst offenders — CAM, TS, scene leaks", SMALL)],
+    ], col_widths=[15*mm, 22*mm, W - 37*mm]),
+    sp(4),
+]
+
+story += h3("7.3  syncedRankedRegexUrls — do not use")
+story += [
+    note("Public AIOStreams instances (elfhosted, fortheweak.cloud) block raw.githubusercontent.com URLs, "
+         "throwing \"Forbidden URL(s) in regex configuration\". Always embed patterns inline. "
+         "The key should be absent or set to []."),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. FORMATTER FIELD REFERENCE
+# ─────────────────────────────────────────────────────────────────────────────
+story += [PageBreak()]
+story += h2("8  Formatter Field Reference")
+story += [p("Used in formatter " + mono("name") + "/" + mono("description") + " strings "
+            "as " + mono("{stream.fieldName::operator[…]}") + "."), sp(3)]
+
+story += [
+    table([
+        ["Field", "Type", "Notes / Example"],
+        [mono_cell("hasChapters"),     p("boolean",SMALL), p('{stream.hasChapters::istrue["📖 "||""]} — REMUX chapter badge', SMALL)],
+        [mono_cell("editions"),        p("string[]",SMALL),p('{stream.editions::join(" · ")} — Director\'s Cut, Extended, IMAX', SMALL)],
+        [mono_cell("edition"),         p("string",SMALL),  p("First edition only", SMALL)],
+        [mono_cell("regraded"),        p("boolean",SMALL), p('{stream.regraded::istrue["🔄 "||""]} — colour regrade flag', SMALL)],
+        [mono_cell("repack"),          p("boolean",SMALL), p('{stream.repack::istrue["🔁 REPACK"||""]} — REPACK/PROPER flag', SMALL)],
+        [mono_cell("date"),            p("string",SMALL),  p("Release date parsed from filename", SMALL)],
+        [mono_cell("dubbed"),          p("boolean",SMALL), p("Audio is dubbed", SMALL)],
+        [mono_cell("subbed"),          p("boolean",SMALL), p("Has subtitles", SMALL)],
+        [mono_cell("uSubtitleEmojis"), p("string[]",SMALL),p("Per-language flag emojis (🇬🇧 🇫🇷 🇩🇪 etc.)", SMALL)],
+        [mono_cell("seMatched"),       p("string",SMALL),  p("Name of the stream expression that matched", SMALL)],
+        [mono_cell("rseMatched"),      p("string[]",SMALL),p("Regex set expression tier(s) matched", SMALL)],
+        [mono_cell("nSeScore"),        p("number",SMALL),  p("Normalised stream expression score (0–1)", SMALL)],
+        [mono_cell("nRegexScore"),     p("number",SMALL),  p("Normalised regex score (0–1)", SMALL)],
+        [mono_cell("folderSeasons"),   p("string[]",SMALL),p("Season folders in multi-season packs", SMALL)],
+        [mono_cell("folderEpisodes"),  p("string[]",SMALL),p("Episode entries in folder-based releases", SMALL)],
+    ], col_widths=[42*mm, 22*mm, W - 64*mm]),
+    sp(4),
+]
+
+story += h3("8.1  Formatter String Modifiers")
+story += [
+    p("Appended after " + mono("::") + " in " + mono("{stream.field::modifier}") + " expressions:"),
+    sp(2),
+    table([
+        ["Modifier", "Effect"],
+        [mono_cell("smallcaps"),        p("Renders text in small capitals", SMALL)],
+        [mono_cell("rsort"),            p("Reverse-sort array before joining", SMALL)],
+        [mono_cell("lsort"),            p("Logical (natural) sort of array", SMALL)],
+        [mono_cell("slice(start,end)"), p("Trim array to index range", SMALL)],
+        [mono_cell("remove(val)"),      p("Remove a value from array / string", SMALL)],
+        [mono_cell("star"),             p("Star rating display (filled stars)", SMALL)],
+        [mono_cell("pstar"),            p("Partial-star rating display", SMALL)],
+        [mono_cell("istrue[a||b]"),     p("If truthy return a else b — used for boolean fields", SMALL)],
+        [mono_cell("join('sep')"),      p("Join array with separator string", SMALL)],
+    ], col_widths=[50*mm, W - 50*mm]),
+    sp(4),
+]
+
+story += h3("8.2  Formatter structure")
+story += [
+    table([
+        ["Field", "Notes"],
+        [mono_cell("id"),           p("All Core Builds formatters use id: \"tamtaro\"", SMALL)],
+        [mono_cell("definitions.overrides['tamtaro']"), p("Override block — name and description template strings", SMALL)],
+    ], col_widths=[60*mm, W - 60*mm]),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. PARENT / CHILD CONFIG LINKING
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("9  Parent / Child Config Linking  (v2.28.0+)")
+story += [
+    code('{\n'
+         '  "parentConfig": {\n'
+         '    "uuid": "parent-config-uuid",\n'
+         '    "password": "parent-config-password",\n'
+         '    "mergeStrategies": {\n'
+         '      "presets":   "inherit" | "extend" | "override",\n'
+         '      "services":  "inherit" | "extend" | "override",\n'
+         '      "filters":   "inherit" | "override",\n'
+         '      "sorting":   "inherit" | "override",\n'
+         '      "formatter": "inherit" | "override",\n'
+         '      "branding":  "inherit" | "override",\n'
+         '      "fieldOverrides": { "addonName": "override" }\n'
+         '    }\n'
+         '  }\n'
+         '}'),
+    sp(3),
+    table([
+        ["Strategy", "Available on", "Effect"],
+        ["inherit",  p("all sections",SMALL),               p("Child uses parent's value entirely", SMALL)],
+        ["extend",   p("presets, services",SMALL),          p("Merge parent + child lists", SMALL)],
+        ["override", p("all sections",SMALL),               p("Child's value takes priority", SMALL)],
+        ["fieldOverrides", p("individual fields",SMALL),    p("Override one field while inheriting the rest of the section", SMALL)],
+    ], col_widths=[28*mm, 32*mm, W - 60*mm]),
+    sp(3),
+    bullet("Runtime resolution — parent fetched and merged on every getUser() call; only child stored."),
+    bullet("Minimum child: just { parentConfig: { uuid, password } } — all sections inherit."),
+    bullet("Graceful fallback: if parent unreachable, child loads unmerged."),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 10. TEMPLATE CONVENTIONS
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("10  Conventions")
+story += [
+    table([
+        ["Rule", "Detail"],
+        ["Version scheme", p("MAJOR.MINOR.PATCH — minor bump for new features/PSE logic, patch for fixes", SMALL)],
+        ["PSE labels",     p("/* TEMPLATE_LABEL Tier Description */ e.g. /* APEX S-Tier 4K Remux — IQR Tukey fence */", SMALL)],
+        ["ESE labels",     p("/* Plain English description */", SMALL)],
+        ["1080p resolution guard", p("MUST have a hard resolution exclusion ESE: resolution(streams,'2160p','1440p') — PSEs rank but do not exclude", SMALL)],
+        ["Samsung templates", p("DV-Only Kill ESE enabled; excludedAudioTags: [TrueHD, DTS-HD MA, DTS:X, FLAC]", SMALL)],
+        ["AllDebrid templates", p("stremthruStore replaces stremthruTorz; no torbox-search", SMALL)],
+        ["Nightly commit", p("Files are gitignored — use git add -f to stage", SMALL)],
+        ["Import URLs",    p("All URLs use brevityA/Core-Builds (not Branding-Brevity)", SMALL)],
+        ["API keys",       p("NEVER commit real keys. Personal templates: Templates/Personal/ — do not document", SMALL)],
+        ["PR workflow",    p("Create a new PR for every task — even small changes", SMALL)],
+    ], col_widths=[40*mm, W - 40*mm]),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 11. TEMPLATE INVENTORY
+# ─────────────────────────────────────────────────────────────────────────────
+story += [PageBreak()]
+story += h2("11  Active Template Inventory  (v2.8.2)")
+
+sections = [
+    ("Single (TorBox Pro)", [
+        ("core-nexus-4k-apex.json",              "v0.4.4", "Flagship 4K — DV/HDR REMUX · IQR Tukey fence PSEs · pow() decay"),
+        ("core-nexus-4k-apex-torbox.json",       "v2.8.2", "TorBox-cached-only 4K Apex variant"),
+        ("core-nexus-stream.json",               "v2.8.2", "1080p streaming quality · strict res guard"),
+        ("core-nexus-stream-lite.json",          "v2.8.2", "Lite variant of Stream"),
+        ("core-nexus-stream-firestick.json",      "v2.8.2", "Fire Stick optimised — SDR-first, SDR audio"),
+        ("core-nexus-stream-firestick-lite.json", "v2.8.2", "Lite Fire Stick variant"),
+    ]),
+    ("Essential (TorBox Essential)", [
+        ("core-nexus-4k-essential.json",         "v2.8.2", "4K Essential with IQR PSEs and pow() decay"),
+        ("core-nexus-4k-essential-lite.json",    "v2.8.2", "4K Essential — CB-style PSEs (simpler)"),
+        ("core-nexus-essential.json",            "v2.8.2", "1080p Essential"),
+        ("core-nexus-essential-lite.json",       "v2.8.2", "1080p Essential lite"),
+    ]),
+    ("Flash (cached-only)", [
+        ("core-nexus-flash-4k.json",             "v2.8.2", "Instant play — cached 4K only"),
+        ("core-nexus-flash.json",                "v2.8.2", "Instant play — cached 1080p only"),
+    ]),
+    ("Speed — TorBox", [
+        ("core-nexus-speed-4k.json",             "v2.8.2", "Fast cached 4K — library + Zilean + TorBox Search, exit at 3 cached or 4s"),
+        ("core-nexus-speed-4k-lite.json",        "v2.8.2", "Speed 4K lite"),
+        ("core-nexus-speed.json",                "v2.8.2", "Fast cached 1080p — same stack"),
+        ("core-nexus-speed-lite.json",           "v2.8.2", "Speed 1080p lite"),
+    ]),
+    ("Speed — EasyNews", [
+        ("core-nexus-speed-4k-plus.json",        "v2.8.2", "EasyNews + TorBox 4K"),
+        ("core-nexus-speed-easynews.json",       "v2.8.2", "EasyNews 1080p"),
+    ]),
+    ("AllDebrid", [
+        ("core-nexus-4k-alldebrid.json",         "v0.1.2", "4K AllDebrid with IQR PSEs — stremthruStore"),
+        ("core-nexus-4k-alldebrid-lite.json",    "v0.1.0", "4K AllDebrid — CB-style PSEs"),
+        ("core-nexus-alldebrid.json",            "v0.1.0", "1080p AllDebrid"),
+        ("core-nexus-alldebrid-lite.json",       "v0.1.0", "1080p AllDebrid lite"),
+    ]),
+    ("Hybrid (TorBox Pro + NZBGeek)", [
+        ("core-nexus-4k-hybrid.json",            "v2.8.2", "4K hybrid — TorBox priority PSEs + IQR"),
+        ("core-nexus-hybrid.json",               "v2.8.2", "1080p hybrid"),
+        ("core-nexus-hybrid-lite.json",          "v2.8.2", "1080p hybrid lite"),
+    ]),
+    ("Device — Samsung TV", [
+        ("core-nexus-samsung-tv.json",           "v0.2.2", "1080p · DV-Only Kill · AV1/VC-1 excluded"),
+        ("core-nexus-samsung-tv-4k.json",        "v0.2.2", "4K · HDR10+/HDR10/HLG priority · DV-Only Kill · AV1/VC-1 excluded"),
+    ]),
+    ("Anime", [
+        ("core-nexus-anime-4k.json",             "v2.8.3", "4K anime — SeaDex + AnimeTosho"),
+        ("core-nexus-anime-4k-lite.json",        "v2.8.3", "4K anime lite"),
+        ("core-nexus-anime.json",                "v2.8.3", "1080p anime"),
+        ("core-nexus-anime-lite.json",           "v2.8.3", "1080p anime lite"),
+        ("core-nexus-anime-dub.json",            "v2.8.3", "Dubbed anime variant"),
+        ("core-nexus-anime-dub-lite.json",       "v2.8.3", "Dubbed lite"),
+    ]),
+    ("Nightly  ⚠ gitignored — git add -f to stage", [
+        ("Nightly/AppleTV/core-nexus-apple-tv-4k.json",  "v0.1.0", "Apple TV 4K — DV Profile 5/8 · AV1 excluded · Atmos preferred"),
+        ("Nightly/Single/core-nexus-4k-apex-labs.json",  "v0.6.0", "Labs — dynamicAddonFetching · template directives · scraper toggles"),
+        ("Nightly/Single/core-nexus-stream-labs.json",   "v0.4.0", "Labs 1080p variant"),
+        ("Nightly/Essential/core-nexus-essential-labs.json",   "v0.1.0", "Labs Essential 1080p — debrid-only · TorBox Search toggle"),
+        ("Nightly/Essential/core-nexus-4k-essential-labs.json","v0.1.0", "Labs Essential 4K — debrid-only"),
+        ("Nightly/Samsung/core-nexus-samsung-tv-4k.json","v0.2.4", "Samsung RU7100 (2019) 4K — FLAC/AAC native · APEX IQR PSEs"),
+    ]),
+]
+
+for section_title, templates in sections:
+    story += h3(section_title)
+    rows = [["File", "Ver", "Description"]]
+    for fname, ver, desc in templates:
+        rows.append([mono_cell(fname.split("/")[-1]), p(ver, SMALL), p(desc, SMALL)])
+    story.append(table(rows, col_widths=[58*mm, 14*mm, W - 72*mm]))
+    story.append(sp(4))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 12. SORT CRITERIA KEYS
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("12  Sort Criteria Keys")
+story += [
+    p("Used in " + mono("config.sortCriteria.global") + " as " + mono('{"key":"…","direction":"asc"|"desc"}') + "."),
+    sp(3),
+    table([
+        ["Key", "Sorts by"],
+        [mono_cell("resolution"),      p("Stream resolution (2160p > 1080p > …)", SMALL)],
+        [mono_cell("quality"),         p("Stream quality tier (Bluray REMUX > WEB-DL > …)", SMALL)],
+        [mono_cell("visualTag"),       p("HDR format (DV > HDR10+ > HDR10 > HLG > SDR)", SMALL)],
+        [mono_cell("audioTag"),        p("Audio format (TrueHD Atmos > TrueHD > DTS:X > …)", SMALL)],
+        [mono_cell("audioChannels"),   p("Channel count (7.1 > 5.1 > 2.0 > …)", SMALL)],
+        [mono_cell("encode"),          p("Video codec (AV1 > H.265 > H.264 > …)", SMALL)],
+        [mono_cell("size"),            p("File size", SMALL)],
+        [mono_cell("bitrate"),         p("Bitrate", SMALL)],
+        [mono_cell("seeders"),         p("Seeder count (torrent)", SMALL)],
+        [mono_cell("cached"),          p("Cached status (cached first when asc)", SMALL)],
+        [mono_cell("service"),         p("Debrid service priority", SMALL)],
+        [mono_cell("seScore"),         p("Stream expression match score (use when streamExpressions present)", SMALL)],
+        [mono_cell("regexScore"),      p("Regex pattern match score (use when rankedRegexPatterns/preferredRegexPatterns present)", SMALL)],
+        [mono_cell("age"),             p("Stream/release age", SMALL)],
+        [mono_cell("languagePreference"), p("Language match preference", SMALL)],
+    ], col_widths=[45*mm, W - 45*mm]),
+    sp(3),
+    note("Both seScore and regexScore must appear in sortCriteria when using both stream expressions "
+         "and regex patterns. Omitting one causes the other's scores to be ignored."),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 13. REPO STRUCTURE
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("13  Repo Structure")
+story += [
+    table([
+        ["Path", "Contents"],
+        [mono_cell("Templates/Torbox/Single/"),       p("TorBox Pro templates (4K Apex, Stream + Lite variants)", SMALL)],
+        [mono_cell("Templates/Torbox/Essential/"),    p("TorBox Essential templates", SMALL)],
+        [mono_cell("Templates/Torbox/Flash/"),        p("Cached-only instant play", SMALL)],
+        [mono_cell("Templates/Torbox/Speed/TorBox/"),p("TorBox-only fast cached play", SMALL)],
+        [mono_cell("Templates/Torbox/Speed/EasyNews/"),p("EasyNews dual-source variants", SMALL)],
+        [mono_cell("Templates/Torbox/Anime/"),        p("Anime-optimised templates", SMALL)],
+        [mono_cell("Templates/Torbox/Hybrid/"),       p("TorBox + RD hybrid templates", SMALL)],
+        [mono_cell("Templates/Torbox/AllDebrid/"),    p("AllDebrid variants", SMALL)],
+        [mono_cell("Templates/Torbox/Device/Samsung/"),p("Samsung TV device templates", SMALL)],
+        [mono_cell("Templates/Torbox/Nightly/"),      p("Pre-release / nightly builds (gitignored)", SMALL)],
+        [mono_cell("Templates/Torbox/Deprecated/"),   p("Retired templates kept for reference", SMALL)],
+        [mono_cell("Templates/Personal/"),            p("Personal/experimental — do not document or expose", SMALL)],
+        [mono_cell("Community-Templates/"),           p("Community-contributed templates (MightyIcyy, RB3)", SMALL)],
+        [mono_cell("Formatters/"),                    p("14 custom stream layout formatters", SMALL)],
+        [mono_cell("Filtering/"),                     p("Shared filter expression files (ESEs, ISEs, PSEs) + ranked-regex-patterns.json", SMALL)],
+        [mono_cell("Regex/"),                         p("Excluded regex pattern lists", SMALL)],
+        [mono_cell("Assets/"),                        p("Banners, icons, formatter preview images", SMALL)],
+        [mono_cell("Guides/"),                        p("Import guide, troubleshooting, device profiles, FAQ", SMALL)],
+        [mono_cell("tests/"),                         p("pytest test suite (template validation, integration)", SMALL)],
+        [mono_cell("scripts/"),                       p("One-off maintenance scripts — not imported by templates", SMALL)],
+    ], col_widths=[58*mm, W - 58*mm]),
+    sp(4),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 14. LINKS
+# ─────────────────────────────────────────────────────────────────────────────
+story += h2("14  Links")
+story += [
+    table([
+        ["Resource", "URL"],
+        ["This repo (mirror)",   p("github.com/brevityA/Core-Builds", SMALL)],
+        ["Main repo",            p("github.com/Branding-Brevity/Core-Builds-By-Brevity", SMALL)],
+        ["AIOStreams",           p("github.com/Viren070/AIOStreams", SMALL)],
+        ["AIOStreams docs",      p("docs.aiostreams.viren070.me", SMALL)],
+        ["Offline archive",      p("mega.nz/folder/DvQGwYYJ#eAnBsID9nc4Nkr8eQfZ2Lg", SMALL)],
+    ], col_widths=[40*mm, W - 40*mm]),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+doc.build(story)
+print(f"PDF written to: {OUT}")


### PR DESCRIPTION
## Summary

- **`Core-Builds-Reference.pdf`** — 14-section reference document covering everything used in the Core Builds template collection.
- **`scripts/generate_reference_pdf.py`** — reportlab generator; run after CLAUDE.md updates to regenerate.

## PDF Contents

| Section | Coverage |
|---|---|
| 1 | Template schema — metadata fields, config fields, preset structure, directives |
| 2 | Known validator rules |
| 3 | Known preset types (all confirmed `type` values) |
| 4 | SEL function reference — stats, stream filters, score/match, array ops, math |
| 5 | SEL variables — content metadata, release timing, DAF exit, group condition |
| 6 | PSE architecture — IQR Tukey fence, pow() decay, Hybrid priority, ongoingSeason |
| 7 | Regex scoring — preferredRegexPatterns vs rankedRegexPatterns, score tiers |
| 8 | Formatter field reference + string modifiers |
| 9 | Parent/child config linking |
| 10 | Conventions |
| 11 | Active template inventory (34 templates) |
| 12 | Sort criteria keys |
| 13 | Repo structure |
| 14 | Links |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_