### PR TITLE
fix: hard resolution kill ESE on remaining 1080p templates + seadexBestOnly labs

### DIFF
--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -258,6 +258,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Part of Tamtaro SEL Setup*/[]",
         "enabled": true
       },

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -257,6 +257,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Part of Tamtaro SEL Setup*/[]",
         "enabled": true
       },

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -249,6 +249,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -1264,6 +1264,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -254,6 +254,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -1923,7 +1923,7 @@
     },
     "mergedCatalogs": [],
     "syncedExcludedRegexUrls": [],
-    "seadexBestOnly": true,
+    "seadexBestOnly": false,
     "rpdbApiKey": "t0-free-rpdb",
     "posterService": "rpdb",
     "enhanceResults": true,

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -261,6 +261,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
@@ -1265,6 +1265,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -249,6 +249,10 @@
     "excludeUncachedFromStreamTypes": [],
     "excludedStreamExpressions": [
       {
+        "expression": "/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')",
+        "enabled": true
+      },
+      {
         "expression": "/*Per-Addon Flood Guard*/ merge(slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Meteor'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Comet RD'),5),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'MediaFusion'),4),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Torrent Galaxy'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'EZTV'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'Knaben'),3),slice(addon(negate(merge(library(streams),seadex(streams)),cached(streams)),'HdHub'),3))",
         "enabled": true
       },


### PR DESCRIPTION
## Summary

Second pass on the full-repo audit — fixes the 8 non-lite 1080p templates and the Nightly Labs template that the first batch (#134) missed.

### Hard resolution kill ESE — 8 templates

These non-lite 1080p templates were missing the standalone `resolution(streams, '2160p', '1440p', ...)` ESE. The conditional ESEs they carry (Bad 4K Anime, Upscaled 4K, Bad 4K Bluray) only exclude 4K under specific quality/count conditions — without the hard kill, raw 4K streams can surface on 1080p-only devices.

| Template | Plan |
|---|---|
| `AllDebrid/core-nexus-alldebrid.json` | AllDebrid |
| `AllDebrid/core-nexus-alldebrid-lite.json` | AllDebrid |
| `Essential/core-nexus-essential.json` | Essential |
| `Flash/core-nexus-flash.json` | Essential |
| `Hybrid/core-nexus-hybrid.json` | Pro + RD |
| `Single/core-nexus-stream-firestick.json` | Pro |
| `Speed/EasyNews/core-nexus-speed-easynews.json` | EasyNews |
| `Speed/TorBox/core-nexus-speed.json` | Essential |

ESE inserted at position 0 (first to fire): `/* Hard Resolution Kill — 1080p-only */ resolution(streams, '2160p', '1440p', '720p', '576p', '480p')`.

The existing "Extra Cached" ESEs that reference 2160p become no-ops for those tiers (harmless — empty slice returns `[]`).

### seadexBestOnly: false — Nightly Apex Labs

`core-nexus-4k-apex-labs.json` still had `seadexBestOnly: true`. Same silent-drop bug as the 4 production templates fixed in #134.

## Test plan

- [x] All 120 pytest tests pass
- [ ] Import `core-nexus-essential.json` on a 1080p device — verify zero 4K streams in results
- [ ] Import `core-nexus-flash.json` — same check
- [ ] Import Apex Labs with an anime query — verify non-SeaDex streams appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_