### PR TITLE
fix(newznab): checkOwned, searchMode auto, 5s timeout on all Pro templates

### DIFF
--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -5,7 +5,7 @@
     "description": "4K flagship for TorBox users who also run a Usenet indexer. Pairs TorBox debrid with NZBGeek for maximum source diversity across debrid, torrent, and Usenet streams. Prioritises 2160p with 1080p fallback. Full HDR and lossless audio. Adaptive IQR bitrate PSEs — Tukey fence (≥4 ranked) with min/max and new-release median cluster fallbacks. NZBGeek API key required — enter your key in the Usenet preset before saving.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1825,15 +1825,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"
@@ -1849,13 +1849,13 @@
           "newznabUrl": "https://api.nzbgeek.info",
           "apiPath": "/api",
           "apiKey": "<template_placeholder>",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
           "checkOwned": false,
           "useMultipleInstances": false

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1724,15 +1724,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"
@@ -1748,13 +1748,13 @@
           "newznabUrl": "https://api.nzbgeek.info",
           "apiPath": "/api",
           "apiKey": "<template_placeholder>",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
           "checkOwned": false,
           "useMultipleInstances": false

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1790,15 +1790,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"
@@ -1814,13 +1814,13 @@
           "newznabUrl": "https://api.nzbgeek.info",
           "apiPath": "/api",
           "apiKey": "<template_placeholder>",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
           "checkOwned": false,
           "useMultipleInstances": false

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung RU7100 (UA65RU7100W) and compatible TVs. Native video containers: MKV, MP4, AVI, MOV, FLV, ASF, 3GP, VOB. Native audio: FLAC, AAC, MP3, M4A, WMA, WAV. No AV1 or Dolby Vision — DV streams excluded. HDR10+, HDR10, HLG priority. HEVC/AVC encodes only. Audio prioritises FLAC and AAC for native playback; Atmos/TrueHD/DTS ranked lower (passthrough/transcode). Full Core Builds expression layer: IQR Apex PSEs · REPACK/PROPER Passthrough · Per-Addon Flood Guard · Usenet Propagation Guard · AI Upscale Exclusion · Codec Efficiency Booster · Audio Pinnacle (native-first) · HDR Priority (no DV) · Ranked regex pool · Full CB ESE stack.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1785,15 +1785,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: hybrid regex+SEL architecture — elite groups via releaseGroup() pin() PSEs, x264/IMAX via native encode()/visualTag(), bad dual audio groups via releaseGroup() ESE. Simple group-name regex patterns removed from rankedRegexPatterns. Added dynamicAddonFetching (exit at 5+ cached 4K or 6s). Based on 4K Apex v0.4.3.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json"
   },
   "config": {
@@ -1806,15 +1806,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -5,7 +5,7 @@
     "description": "TorBox-native build of Core Nexus 4K Apex. Uses only TorBox's own search and Usenet — no third-party indexers. Identical adaptive ranked-pool bitrate PSEs and full ESE stack. Simpler, faster to load, fewer moving parts.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1810,15 +1810,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -5,7 +5,7 @@
     "description": "Adaptive flagship build. Extends 4K Pro with ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: when ≥4 ranked streams exist the window is Q1−1.5×IQR to Q3+1.5×IQR; for thin pools (1–3 ranked) it falls back to 80%–120% of the ranked min/max; and for new releases (<60 days) with no ranked streams a median-cluster fallback keeps results flowing. HDR and SDR are evaluated separately in the WEB-DL tier. Full 4K Pro ESE stack retained.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1807,15 +1807,15 @@
           "name": "Searchⁿᶻᵇ",
           "newznabUrl": "https://search-api.torbox.app/newznab",
           "apiPath": "/api",
-          "timeout": 10000,
+          "timeout": 5000,
           "mediaTypes": [
             "movie",
             "series",
             "anime"
           ],
-          "searchMode": "both",
+          "searchMode": "auto",
           "paginate": true,
-          "checkOwned": false,
+          "checkOwned": true,
           "useMultipleInstances": false,
           "services": [
             "torbox"


### PR DESCRIPTION
## Summary

The TorBox `newznab` preset on all active Pro templates had three suboptimal settings that were already corrected in the Deprecated templates and in RB3's community template — they just weren't carried forward.

### Changes

| Setting | Before | After | Why |
|---|---|---|---|
| `checkOwned` | `false` | `true` (TorBox only) | Prevents AIOStreams from offering to re-download NZBs already in your TorBox queue or completed library |
| `searchMode` | `"both"` | `"auto"` | `"both"` fires title + query search simultaneously on every call; `"auto"` picks the appropriate mode per query |
| `timeout` | `10000` ms | `5000` ms | 10s is far longer than any other preset; aligns with Zilean (4s), Comet (7s), Knaben (6s) |

`checkOwned` is set to `true` only on TorBox's own newznab (`services: ["torbox"]`). The NZBGeek newznab in Hybrid templates is left at `false` since ownership checking doesn't apply to a third-party indexer.

### Templates affected

- `core-nexus-4k-apex.json` → v0.4.5
- `core-nexus-4k-apex-torbox.json` → v2.8.4
- `core-nexus-4k-hybrid.json` → v2.8.4
- `core-nexus-hybrid.json` → v2.8.4
- `core-nexus-hybrid-lite.json` → v2.8.4
- `Nightly/Samsung/core-nexus-samsung-tv-4k.json` → v0.2.5
- `Nightly/Single/core-nexus-4k-apex-labs.json` → v0.5.2

## Test plan
- [x] `python3 -m pytest tests/ -q` — 120 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_