### PR TITLE
docs: rename mint.json to docs.json for Mintlify v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ---
 
+## 2.8.4 (2026-06-17)
+
+### Added
+- **Boost Cached Usenet PSE — all 27 TorBox templates** — Appended as the final PSE in every non-AllDebrid, non-Anime, non-EasyNews template:
+  ```
+  /*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))
+  ```
+  Cached TorBox Usenet streams that don't fit inside the quality-window PSEs (e.g. `Unknown` quality NZBs, bitrate outliers) previously fell through all PSEs and appeared after the `streamExpressionMatched: desc` sort as unmatched — below cached debrid with a PSE hit. This PSE catches any remaining cached usenet and gives it a PSE match, so it ranks above uncached/unmatched streams. Enabled by default. Templates affected: all Single, Essential, Flash, Speed/TorBox, Hybrid, Device/Samsung, and Nightly TorBox/Samsung/AppleTV templates.
+
+---
+
 ## 2.8.3 (2026-06-17)
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,31 +84,31 @@ Preset `type` values confirmed in AIOStreams source:
 
 ---
 
-## Active Template Inventory (as of v2.8.3)
+## Active Template Inventory (as of v2.8.4)
 
 ### Single (TorBox Pro)
-- `Single/core-nexus-4k-apex.json` v0.4.4 — flagship 4K, IQR PSEs, pow() decay, 48 ranked patterns inline (|score| ≥ 50)
-- `Single/core-nexus-4k-apex-torbox.json` v2.8.3 — TorBox-cached-only Apex variant
-- `Single/core-nexus-stream.json` v2.8.3 — 1080p streaming quality
-- `Single/core-nexus-stream-lite.json` v2.8.3 — lite variant
-- `Single/core-nexus-stream-firestick.json` v2.8.3 — Fire Stick optimised
-- `Single/core-nexus-stream-firestick-lite.json` v2.8.3
+- `Single/core-nexus-4k-apex.json` v0.4.6 — flagship 4K, IQR PSEs, pow() decay, 48 ranked patterns inline (|score| ≥ 50)
+- `Single/core-nexus-4k-apex-torbox.json` v2.8.5 — TorBox-cached-only Apex variant
+- `Single/core-nexus-stream.json` v2.8.4 — 1080p streaming quality
+- `Single/core-nexus-stream-lite.json` v2.8.4 — lite variant
+- `Single/core-nexus-stream-firestick.json` v2.8.4 — Fire Stick optimised
+- `Single/core-nexus-stream-firestick-lite.json` v2.8.4
 
 ### Essential (TorBox Essential)
-- `Essential/core-nexus-4k-essential.json` v2.8.3 — 4K with IQR PSEs, pow() decay
-- `Essential/core-nexus-4k-essential-lite.json` v2.8.3 — CB-style PSEs
-- `Essential/core-nexus-essential.json` v2.8.3 — 1080p
-- `Essential/core-nexus-essential-lite.json` v2.8.3
+- `Essential/core-nexus-4k-essential.json` v2.8.4 — 4K with IQR PSEs, pow() decay
+- `Essential/core-nexus-4k-essential-lite.json` v2.8.4 — CB-style PSEs
+- `Essential/core-nexus-essential.json` v2.8.4 — 1080p
+- `Essential/core-nexus-essential-lite.json` v2.8.4
 
 ### Flash
-- `Flash/core-nexus-flash-4k.json` v2.8.3 — cached-only 4K instant play
-- `Flash/core-nexus-flash.json` v2.8.3 — cached-only 1080p instant play
+- `Flash/core-nexus-flash-4k.json` v2.8.4 — cached-only 4K instant play
+- `Flash/core-nexus-flash.json` v2.8.4 — cached-only 1080p instant play
 
 ### Speed (TorBox)
-- `Speed/TorBox/core-nexus-speed-4k.json` v2.8.3 — TorBox-only 4K, library + Zilean + TorBox Search, exit at 3 cached 4K or 4s
-- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.8.3 — lite variant
-- `Speed/TorBox/core-nexus-speed.json` v2.8.3 — TorBox-only 1080p, library + Zilean + TorBox Search, exit at 3 cached or 4s
-- `Speed/TorBox/core-nexus-speed-lite.json` v2.8.3 — lite variant
+- `Speed/TorBox/core-nexus-speed-4k.json` v2.8.4 — TorBox-only 4K, library + Zilean + TorBox Search, exit at 3 cached 4K or 4s
+- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.8.4 — lite variant
+- `Speed/TorBox/core-nexus-speed.json` v2.8.4 — TorBox-only 1080p, library + Zilean + TorBox Search, exit at 3 cached or 4s
+- `Speed/TorBox/core-nexus-speed-lite.json` v2.8.4 — lite variant
 
 ### Speed (EasyNews)
 - `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.8.3 — EasyNews 4K
@@ -121,13 +121,13 @@ Preset `type` values confirmed in AIOStreams source:
 - `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.1 — 1080p lite
 
 ### Hybrid
-- `Hybrid/core-nexus-4k-hybrid.json` v2.8.3 — TorBox + RD, service() priority PSEs, IQR
-- `Hybrid/core-nexus-hybrid.json` v2.8.3 — 1080p hybrid
-- `Hybrid/core-nexus-hybrid-lite.json` v2.8.3
+- `Hybrid/core-nexus-4k-hybrid.json` v2.8.5 — TorBox + RD, service() priority PSEs, IQR
+- `Hybrid/core-nexus-hybrid.json` v2.8.5 — 1080p hybrid
+- `Hybrid/core-nexus-hybrid-lite.json` v2.8.5
 
 ### Device
-- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.2 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
-- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.2 — 4K, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.3 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.3 — 4K, DV-Only Kill on, AV1/VC-1 excluded
 
 ### Anime
 - `Anime/core-nexus-anime-4k.json` v2.8.3 — 4K anime, SeaDex + AnimeTosho
@@ -138,12 +138,12 @@ Preset `type` values confirmed in AIOStreams source:
 - `Anime/core-nexus-anime-dub-lite.json` v2.8.3
 
 ### Nightly (gitignored — force-add to commit)
-- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.0 — DV Profile 5/8, AV1 excluded
-- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.5.1 — experimental Apex variant (dynamicAddonFetching, template directives: scraper toggles + exit thresholds)
-- `Nightly/Single/core-nexus-stream-labs.json` v0.3.1 — experimental 1080p variant (dynamicAddonFetching, template directives: scraper toggles + exit thresholds)
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.0 — TorBox debrid-only 1080p (no external scrapers, TorBox Search toggle + exit thresholds)
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.0 — TorBox debrid-only 4K (no external scrapers, TorBox Search toggle + exit thresholds)
-- `Nightly/Samsung/core-nexus-samsung-tv-4k.json` v0.2.4 — Samsung RU7100 (2019) 4K: FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV, APEX IQR PSEs, full ESE stack
+- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.1 — DV Profile 5/8, AV1 excluded
+- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.5.3 — experimental Apex variant (dynamicAddonFetching, template directives: scraper toggles + exit thresholds)
+- `Nightly/Single/core-nexus-stream-labs.json` v0.3.2 — experimental 1080p variant (dynamicAddonFetching, template directives: scraper toggles + exit thresholds)
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.1 — TorBox debrid-only 1080p (no external scrapers, TorBox Search toggle + exit thresholds)
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.1 — TorBox debrid-only 4K (no external scrapers, TorBox Search toggle + exit thresholds)
+- `Nightly/Samsung/core-nexus-samsung-tv-4k.json` v0.2.6 — Samsung RU7100 (2019) 4K: FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV, APEX IQR PSEs, full ESE stack
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,15 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 ---
 
-## 📖 Guides
+## 📖 Wiki
 
 | Guide | Link |
 |---|---|
-| Import a template | [Guides → Import](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#1--importing-a-template) |
-| Formatters | [Guides → Formatters](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#2--formatters) |
-| Filtering | [Guides → Filtering](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#3--filtering) |
-| Device profiles | [Guides → Device Profiles](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#4--device-profiles) |
-| Troubleshooting | [Guides → Troubleshooting](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md#6--troubleshooting) |
+| Import a template | [Wiki → Importing a Template](https://github.com/brevityA/Core-Builds/wiki/Importing-a-Template) |
+| Formatters | [Wiki → Formatters](https://github.com/brevityA/Core-Builds/wiki/Formatters) |
+| Filtering | [Wiki → Expression Rules](https://github.com/brevityA/Core-Builds/blob/main/Guides/EXPRESSION_RULES.md) |
+| Device profiles | [Wiki → Device Profiles](https://github.com/brevityA/Core-Builds/wiki/Device-Profiles) |
+| Troubleshooting | [Wiki → Troubleshooting and FAQ](https://github.com/brevityA/Core-Builds/wiki/Troubleshooting-and-FAQ) |
 
 ---
 

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung smart TVs without native Dolby Vision support — including RU7100, RU8000, NU8000, Q60, and similar 2018–2022 models. DV-only streams are excluded (DV-Only Kill ESE); only HDR10+, HDR10, HLG, and SDR content appears. AV1 and VC-1 excluded (not supported on older Samsung hardware). Lossless audio (TrueHD, DTS-HD MA, DTS:X, FLAC) excluded — Samsung passes these through only via HDMI ARC/eARC to compatible receivers, which most users don't have. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox · Library, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -357,6 +357,10 @@
       },
       {
         "expression": "/* CB 1080p Fallback | Any */ resolution(streams, '1080p')",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -5,7 +5,7 @@
     "description": "Stream template tuned for Samsung smart TVs and other devices without Dolby Vision support. DV-only streams are excluded — only HDR10, HDR10+, HLG, and SDR content appears. Based on Core Nexus Stream (1080p · TorBox Essential · Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -359,6 +359,10 @@
       },
       {
         "expression": "/* CB 720p Fallback | Any */ resolution(streams, '720p')",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 4K build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -341,6 +341,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 4K build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -393,6 +393,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB-25 GB. Full addon stack including Comet, Meteor, Zilean, Knaben, and. A single TorBox Essential subscription is all that is required. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -340,6 +340,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB-25 GB. Full addon stack including Comet, Meteor, Zilean, Knaben, and. A single TorBox Essential subscription is all that is required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -388,6 +388,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -5,7 +5,7 @@
     "description": "Single-click instant play — 4K. Only cached streams appear — zero uncached results. Derived from Speed 4K but with excludeUncached:true, a 2-stream dynamic stop condition, and pre-resolved top stream. Resolution order: 2160p → 1080p fallback. DV → HDR10+ → HDR priority. If content has no cached streams, the 0Cached ISE shows a title passthrough rather than a blank screen. 4K · TorBox Essential · Library, TorBox Search, Comet, Zilean.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1440,6 +1440,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -5,7 +5,7 @@
     "description": "Single-click instant play. Only cached streams appear — zero uncached results. Derived from Speed but with excludeUncached:true, a 2-stream dynamic stop condition, and pre-resolved top stream. If content has no cached streams, the 0Cached ISE shows a title passthrough rather than a blank screen. 1080p · TorBox Essential · Library, TorBox Search, Comet, Zilean.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1408,6 +1408,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -5,7 +5,7 @@
     "description": "4K flagship for TorBox users who also run a Usenet indexer. Pairs TorBox debrid with NZBGeek for maximum source diversity across debrid, torrent, and Usenet streams. Prioritises 2160p with 1080p fallback. Full HDR and lossless audio. Adaptive IQR bitrate PSEs — Tukey fence (≥4 ranked) with min/max and new-release median cluster fallbacks. NZBGeek API key required — enter your key in the Usenet preset before saving.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -413,6 +413,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -345,6 +345,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -393,6 +393,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+++ b/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Apple TV 4K (3rd gen) and Infuse. Dolby Vision Profile 5/8 is natively supported — DV streams are prioritised. HDR10+ (3rd gen exclusive), HDR10, HLG, and SDR are also shown. AV1 hard-excluded (no hardware decoder on the A15 chip — severe performance hit). DD+ Atmos is the native top audio format. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox · Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -350,6 +350,10 @@
       },
       {
         "expression": "/* CB 1080p Fallback | Any */ resolution(streams, '1080p')",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 4K build. Template directives: TorBox Search and exit thresholds configurable at import. Based on 4K Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -433,6 +433,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. build. Template directives: TorBox Search and exit thresholds configurable at import. Based on Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -412,6 +412,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung RU7100 (UA65RU7100W) and compatible TVs. Native video containers: MKV, MP4, AVI, MOV, FLV, ASF, 3GP, VOB. Native audio: FLAC, AAC, MP3, M4A, WMA, WAV. No AV1 or Dolby Vision — DV streams excluded. HDR10+, HDR10, HLG priority. HEVC/AVC encodes only. Audio prioritises FLAC and AAC for native playback; Atmos/TrueHD/DTS ranked lower (passthrough/transcode). Full Core Builds expression layer: IQR Apex PSEs · REPACK/PROPER Passthrough · Per-Addon Flood Guard · Usenet Propagation Guard · AI Upscale Exclusion · Codec Efficiency Booster · Audio Pinnacle (native-first) · HDR Priority (no DV) · Ranked regex pool · Full CB ESE stack.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -390,6 +390,10 @@
       },
       {
         "expression": "/*HDR Priority (no DV — Samsung RU7100)*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10+','HDR10'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR','HLG'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: hybrid regex+SEL architecture — elite groups via releaseGroup() pin() PSEs, x264/IMAX via native encode()/visualTag(), bad dual audio groups via releaseGroup() ESE. Simple group-name regex patterns removed from rankedRegexPatterns. Added dynamicAddonFetching (exit at 5+ cached 4K or 6s). Based on 4K Apex v0.4.3.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json"
   },
   "config": {
@@ -393,6 +393,10 @@
       },
       {
         "expression": "/* B-Tier 1080p any */ resolution(streams,'1080p')",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: hybrid regex+SEL architecture — elite groups via releaseGroup() pin() PSEs, x264/IMAX via native encode()/visualTag(), bad dual audio groups via releaseGroup() ESE. Simple group-name regex patterns removed from rankedRegexPatterns. Added dynamicAddonFetching (exit at 5+ cached 1080p or 5s). Based on Stream v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -394,6 +394,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -6,9 +6,9 @@
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v2.8.3** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v2.8.4** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
-> 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
+> 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/wiki) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 
 ---
 
@@ -20,14 +20,14 @@ Nightly templates test new optimisations before they're promoted to stable. They
 
 | Template | Version | Testing | Import URL |
 |---|---|---|---|
-| **4K Apex Labs** | v0.5.1 | Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`. `dynamicAddonFetching`: exit at 5+ cached 4K or 6s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Stream Labs** | v0.3.1 | Same hybrid regex+SEL as 4K Apex Labs — 1080p variant. `dynamicAddonFetching`: exit at 5+ cached 1080p or 5s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| **Apple TV 4K** | v0.1.0 | Device profile — DV Profile 5/8, AV1 excluded, Atmos preferred | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| **Samsung RU7100 4K** | v0.2.4 | Samsung RU7100 (2019) device profile — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV, IQR PSEs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
-| **Essential Labs** | v0.1.0 | TorBox debrid-only 1080p — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| **4K Essential Labs** | v0.1.0 | TorBox debrid-only 4K — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **4K Apex Labs** | v0.5.3 | Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`. `dynamicAddonFetching`: exit at 5+ cached 4K or 6s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Stream Labs** | v0.3.2 | Same hybrid regex+SEL as 4K Apex Labs — 1080p variant. `dynamicAddonFetching`: exit at 5+ cached 1080p or 5s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **Apple TV 4K** | v0.1.1 | Device profile — DV Profile 5/8, AV1 excluded, Atmos preferred | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
+| **Samsung RU7100 4K** | v0.2.6 | Samsung RU7100 (2019) device profile — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV, IQR PSEs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
+| **Essential Labs** | v0.1.1 | TorBox debrid-only 1080p — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **4K Essential Labs** | v0.1.1 | TorBox debrid-only 4K — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
 
-> **[What's being tested? → Full Labs changelog & testing guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md)**
+> **[What's being tested? → Full Labs changelog & testing guide](https://github.com/brevityA/Core-Builds/wiki/Nightly-and-Labs)**
 
 ### 🗂️ Stable Templates
 
@@ -167,7 +167,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-4k-apex.json` |
-| **Version** | v0.4.4 |
+| **Version** | v0.4.6 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-apex.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ✅ cacheAndPlay + nzbFailover |
@@ -181,7 +181,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.4 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ via Newznab (opt-in) |
@@ -195,7 +195,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream-firestick.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.4 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick.json` |
 | **Resolution** | 1080p · SDR |
 | **Usenet** | ❌ |
@@ -209,7 +209,7 @@ Stream-based 1080p template for Samsung TVs and devices without Dolby Vision sup
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json` |
-| **Version** | v0.2.2 |
+| **Version** | v0.2.3 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ❌ |
@@ -223,7 +223,7 @@ Stream-based 1080p template for Samsung TVs and devices without Dolby Vision sup
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json` |
-| **Version** | v0.2.2 |
+| **Version** | v0.2.3 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -237,7 +237,7 @@ Stream-based 1080p template for Samsung TVs and devices without Dolby Vision sup
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.1.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -255,10 +255,10 @@ Experimental builds testing new PSE architectures and addon configurations befor
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Version** | v0.5.1 |
+| **Version** | v0.5.3 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
 | **Resolution** | 2160p · 1080p fallback |
-| **Base** | 4K Apex v0.4.4 |
+| **Base** | 4K Apex v0.4.6 |
 | **Usenet** | ❌ |
 
 #### Core Nexus Stream Labs
@@ -266,10 +266,10 @@ Experimental builds testing new PSE architectures and addon configurations befor
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| **Version** | v0.3.1 |
+| **Version** | v0.3.2 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
 | **Resolution** | 1080p |
-| **Base** | Stream v2.8.3 |
+| **Base** | Stream v2.8.4 |
 | **Usenet** | ❌ |
 
 #### Core Nexus Essential Labs
@@ -279,7 +279,7 @@ TorBox debrid-only 1080p — no external scrapers. Tests template directives for
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.1.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
 | **Resolution** | 1080p |
 | **Usenet** | ❌ |
@@ -291,7 +291,7 @@ TorBox debrid-only 4K — no external scrapers. Tests template directives for To
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.1.1 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -305,7 +305,7 @@ TorBox Pro + NZBGeek. Full 4K with maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.5 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **HDR** | ✅ Full HDR — DV, HDR10+, HDR10 |
@@ -323,7 +323,7 @@ TorBox Pro + NZBGeek. Maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.5 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ NZBGeek API key required |
@@ -341,7 +341,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-4k-essential.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.4 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ❌ |
@@ -355,7 +355,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-essential.json` |
-| **Version** | v2.8.3 |
+| **Version** | v2.8.4 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ❌ |
@@ -495,7 +495,7 @@ Every standard template has a `-lite` variant. Lite removes 12 quality-gate ESEs
 
 ---
 
-## 🛠️ Common to All Templates (v2.8.3)
+## 🛠️ Common to All Templates (v2.8.4)
 
 | Feature | Detail |
 |---|---|
@@ -531,4 +531,4 @@ Core Builds is an independent community project and is not affiliated with, endo
 
 ---
 
-*Part of [Core Builds by Brevity](https://github.com/brevityA/Core-Builds) · [Complete Setup Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md) · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)*
+*Part of [Core Builds by Brevity](https://github.com/brevityA/Core-Builds) · [Wiki](https://github.com/brevityA/Core-Builds/wiki) · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)*

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -5,7 +5,7 @@
     "description": "TorBox-native build of Core Nexus 4K Apex. Uses only TorBox's own search and Usenet — no third-party indexers. Identical adaptive ranked-pool bitrate PSEs and full ESE stack. Simpler, faster to load, fewer moving parts.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -397,6 +397,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -5,7 +5,7 @@
     "description": "Adaptive flagship build. Extends 4K Pro with ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: when ≥4 ranked streams exist the window is Q1−1.5×IQR to Q3+1.5×IQR; for thin pools (1–3 ranked) it falls back to 80%–120% of the ranked min/max; and for new releases (<60 days) with no ranked streams a median-cluster fallback keeps results flowing. HDR and SDR are evaluated separately in the WEB-DL tier. Full 4K Pro ESE stack retained.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -394,6 +394,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
@@ -5,7 +5,7 @@
     "description": "Firestick and budget Android TV optimised build. Hard SDR-only enforcement — excludes Dolby Vision, HDR10+, HDR10, HLG, and 10-bit content. AV1 excluded. TrueHD/Atmos/lossless audio excluded. 1080p + 720p · WEB-DL/WEBRip · TorBox Essential. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -352,6 +352,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -5,7 +5,7 @@
     "description": "Firestick and budget Android TV optimised build. Hard SDR-only enforcement — excludes Dolby Vision, HDR10+, HDR10, HLG, and 10-bit content that causes playback failures or tone-mapping artifacts on Fire TV hardware. AV1 excluded. TrueHD/Atmos/lossless audio excluded. 1080p + 720p · WEB-DL/WEBRip · TorBox Essential. Single TorBox subscription required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -400,6 +400,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -5,7 +5,7 @@
     "description": "A frictionless 1080p SDR build running exclusively on TorBox, with RPDB poster database integration for enhanced metadata visuals in Stremio. Targets 1080p and 720p WEB-DL and WEBRip sources. Blocks BluRay, Remux, 4K, and HDR content for reliable playback on any hardware. File range 1 GB–60 GB, 1080p capped at 25 GB. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. No secondary debrid service required — a single TorBox subscription is sufficient. Designed for phones, tablets, budget Android TV boxes, and Fire TV Sticks. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -342,6 +342,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -5,7 +5,7 @@
     "description": "A frictionless 1080p SDR build running exclusively on TorBox, with RPDB poster database integration for enhanced metadata visuals in Stremio. Targets 1080p and 720p WEB-DL and WEBRip sources. Blocks BluRay, Remux, 4K, and HDR content for reliable playback on any hardware. File range 1 GB–60 GB, 1080p capped at 25 GB. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. No secondary debrid service required — a single TorBox subscription is sufficient. Designed for phones, tablets, budget Android TV boxes, and Fire TV Sticks.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -382,6 +382,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K + 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 4K streams found or 4s elapsed. Based on Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -357,6 +357,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K + 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 4K streams found or 4s elapsed. Based on Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -405,6 +405,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 1080p streams found or 4s elapsed. Based on Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -340,6 +340,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 1080p streams found or 4s elapsed. Based on Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -388,6 +388,10 @@
       },
       {
         "expression": "/*HDR/DV Priority*/ merge(visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'DV','HDR10+','HDR10+/DV'),visualTag(resolution(cached(negate(merge(library(streams),seadex(streams)),streams)),'2160p'),'HDR10','HDR'))",
+        "enabled": true
+      },
+      {
+        "expression": "/*Boost Cached Usenet*/ merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))",
         "enabled": true
       }
     ],

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,57 @@
+---
+title: "Changelog"
+description: "Release history for Core Builds."
+---
+
+Full history: [CHANGELOG.md](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+
+---
+
+## v2.8.4 — 2026-06-17
+
+**Fixed: Cached Usenet missing priority signal — all 27 TorBox templates**
+
+Cached TorBox Usenet NZBs with Unknown quality metadata, or bitrates outside the IQR window, had no PSE match — sorted below cached debrid results that did have one. New final fallback PSE added to all templates:
+
+```
+/*Boost Cached Usenet*/
+merge(cached(merge(library(streams),seadex(streams),type(streams,'debrid','usenet','stremio-usenet'))))
+```
+
+---
+
+## v2.8.3 — 2026-06-17
+
+- `seadexBestOnly: false` — fixed on 5 non-Anime templates that were silently dropping all non-SeaDex streams
+- Hard resolution kill ESE added to all 13 x 1080p templates — prevents 4K streams leaking into 1080p-only results
+- Usenet preset config aligned across Pro templates: `checkOwned: true`, `searchMode: auto`, `timeout: 5000ms`
+- Vidhin05 stale RSE URL removed from Speed/TorBox templates
+
+---
+
+## v2.8.2 — 2026-06-15
+
+- Regex scoring changed from synced URLs to inline embedded patterns (53 patterns, |score| >= 50) — fixes "Forbidden URL" errors on public instances
+- `rseMatched` removed from PSEs and ESEs — was causing "Invalid stream expression" on instances where the Vidhin05 RSE URL is blocked
+- Samsung TV and Samsung TV 4K — AV1/VC-1 hard-excluded; DV and AI upscale removed from preferred visual tags
+- 4K Apex — stereo (2.0) added to ranked audio; AI upscale and low resolutions removed; seadexBestOnly fixed
+
+---
+
+## v2.8.1 — 2026-06-14
+
+- Core Nexus Stream — hard resolution kill ESE added; PSEs no longer allow 4K/1440p/720p to surface on the 1080p-only template
+- 720p fallback PSE tiers removed from Stream
+
+---
+
+## v2.8.0 — 2026-06-14
+
+- AllDebrid template family added (4K AllDebrid, AllDebrid, 4K AllDebrid Lite, AllDebrid Lite)
+- Apple TV 4K (Nightly) added — DV Profile 5/8, AV1 excluded, Atmos preferred
+- Samsung TV promoted from Nightly to stable Device category
+- Hybrid TorBox-priority PSEs added to 4K Hybrid — TorBox-cached twins for each IQR tier
+- `pow()` exponential age-decay window replaces hard 60-day cliff in 5 templates
+- Core Builds Expression Layer — all 7 expressions deployed to all active templates
+
+→ [Full history on GitHub](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)

--- a/docs/device-profiles.mdx
+++ b/docs/device-profiles.mdx
@@ -1,0 +1,90 @@
+---
+title: "Device Profiles"
+description: "Template recommendations and codec constraints for Samsung TV, Apple TV, Fire Stick, and low-RAM devices."
+---
+
+## Samsung TV (Tizen 2018–2022)
+
+**Models:** RU7100, RU8000, NU8000, Q60 and similar
+
+**Recommended templates:** [Samsung TV](/template-directory#torbox-pro) (1080p) or [Samsung TV 4K](/template-directory#torbox-pro)
+
+| Feature | Support |
+|---|---|
+| Dolby Vision | No hardware DV decoder — DV-Only streams excluded by default |
+| AV1 | No hardware decoder — hard-excluded |
+| VC-1 | Not supported — hard-excluded |
+| HEVC (H.265) | Hardware decode |
+| AVC (H.264) | Hardware decode |
+| HDR10+ | Supported (preferred) |
+| HDR10 | Supported |
+| HLG | Supported |
+| TrueHD / DTS:X / DTS-HD MA / FLAC | Hard-excluded — Tizen cannot pass these through |
+| DD+ Atmos | Top preferred audio |
+| AAC | Native |
+
+<Info>
+  **Nightly option:** Samsung RU7100 4K (Nightly) — full APEX IQR PSE stack, FLAC/AAC native audio, tuned specifically for the RU7100 (2019).
+</Info>
+
+---
+
+## Apple TV 4K (3rd gen, A15/A17)
+
+**Recommended template:** [Apple TV 4K (Nightly)](/nightly-and-labs) via Infuse
+
+| Feature | Support |
+|---|---|
+| Dolby Vision | Profile 5 and 8 — prioritised |
+| AV1 | No hardware decoder on A15 — hard-excluded |
+| HEVC (H.265) | Hardware decode |
+| AVC (H.264) | Hardware decode |
+| HDR10+ | 3rd gen exclusive |
+| HDR10 / HLG | Supported |
+| DD+ Atmos | Native preferred audio |
+| TrueHD | Passthrough only (requires AVR) |
+
+---
+
+## Fire Stick (4K / 4K Max)
+
+**Recommended template:** [Stream (Fire Stick)](/template-directory#torbox-pro) or Stream (Fire Stick) Lite
+
+| Feature | Support |
+|---|---|
+| 4K | Fire Stick 4K / 4K Max only |
+| Dolby Vision | Fire Stick 4K Max only |
+| HEVC | Supported |
+| AV1 | Fire Stick 4K Max only |
+| RAM | Low — Lite variant recommended if buffering |
+
+<Tip>
+  Fire Stick 4K Max supports AV1; Fire Stick 4K does not. Use SDR or HDR10 priority if buffering is an issue.
+</Tip>
+
+---
+
+## Low-RAM / Budget Devices
+
+Any device with 2 GB RAM or less (older Fire Sticks, budget Android TV boxes):
+
+- Use the **Lite variant** of any template — removes quality gates to maximise result count
+- Enable **Flash** if you only need instant cached results
+- Disable HDR to reduce stream sizes
+- Set a bitrate cap via AIOStreams settings if buffering persists
+
+---
+
+## General Tips
+
+<AccordionGroup>
+  <Accordion title="DV-Only Kill ESE">
+    Enabled by default on Samsung templates. Removes streams where Dolby Vision is the only signal layer (no HDR10 fallback). Safe to disable if your device supports DV natively.
+  </Accordion>
+  <Accordion title="Audio exclusions on Samsung">
+    Samsung templates hard-exclude TrueHD / DTS:X / DTS-HD MA / FLAC. Remove these exclusions if your device passes audio through to an AVR that supports them.
+  </Accordion>
+  <Accordion title="AV1 on Samsung and Apple TV">
+    Excluded on both. Keep AV1 in `excludedEncodes` for these devices. Enable it for Fire Stick 4K Max or modern Android TV.
+  </Accordion>
+</AccordionGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,55 @@
+{
+  "name": "Core Builds",
+  "logo": {
+    "light": "/logo/core_icon.svg",
+    "dark": "/logo/core_icon.svg"
+  },
+  "favicon": "/logo/core_icon.svg",
+  "colors": {
+    "primary": "#3B82F6",
+    "light": "#93C5FD",
+    "dark": "#1D4ED8",
+    "background": {
+      "dark": "#0F1117"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "GitHub",
+      "url": "https://github.com/brevityA/Core-Builds"
+    },
+    {
+      "name": "AIOStreams",
+      "url": "https://github.com/Viren070/AIOStreams"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "Template Directory",
+    "url": "/template-directory"
+  },
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": ["introduction", "which-template", "importing"]
+    },
+    {
+      "group": "Templates",
+      "pages": ["template-directory"]
+    },
+    {
+      "group": "Reference",
+      "pages": ["device-profiles", "formatters", "nightly-and-labs"]
+    },
+    {
+      "group": "Support",
+      "pages": ["troubleshooting", "changelog", "roadmap"]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/brevityA/Core-Builds"
+  },
+  "feedback": {
+    "thumbsRating": true,
+    "suggestEdit": true
+  }
+}

--- a/docs/formatters.mdx
+++ b/docs/formatters.mdx
@@ -1,0 +1,78 @@
+---
+title: "Formatters"
+description: "Stream display layouts — how to install and customise them."
+---
+
+Formatters control how streams are displayed in Stremio — the text shown for each result (title, quality, size, audio, etc.). All Core Builds templates ship with the **Core Syntax** formatter pre-loaded.
+
+## How to Import a Formatter
+
+<Steps>
+  <Step title="Open the Formatter tab">
+    In AIOStreams, go to the **Formatter** tab.
+  </Step>
+  <Step title="Click Import">
+    Click the **Import** icon in the top right corner.
+  </Step>
+  <Step title="Paste the URL">
+    Paste the formatter's raw GitHub URL and click **Load**.
+  </Step>
+  <Step title="Save">
+    Click **Save** to apply.
+  </Step>
+</Steps>
+
+## Available Formatters
+
+<CardGroup cols={2}>
+  <Card title="Core Syntax" icon="code">
+    Clean, information-dense. Default in all templates — no import needed.
+  </Card>
+  <Card title="Apex v2" icon="crown" href="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-apex-v2-formatter.json">
+    4K-focused, visual tags prominent. Copy URL to import.
+  </Card>
+  <Card title="Elite" icon="star" href="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-elite-formatter.json">
+    Minimal, quality-first. Copy URL to import.
+  </Card>
+  <Card title="Nexus Prime" icon="list" href="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/nexus-prime-formatter.json">
+    Full detail — codec, HDR, audio, size, seeders. Copy URL to import.
+  </Card>
+</CardGroup>
+
+## Formatter URLs
+
+| Formatter | Import URL |
+|---|---|
+| Apex v2 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-apex-v2-formatter.json` |
+| Elite | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-elite-formatter.json` |
+| Nexus Prime | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/nexus-prime-formatter.json` |
+
+## Field Reference
+
+| Field | What it shows |
+|---|---|
+| `stream.resolution` | 2160p, 1080p, 720p, etc. |
+| `stream.quality` | BluRay REMUX, WEB-DL, WEBRip, etc. |
+| `stream.encode` | HEVC, AVC, AV1 |
+| `stream.visualTag` | DV, HDR10+, HDR10, HLG, SDR |
+| `stream.audioTag` | Atmos, TrueHD, DTS:X, DD+, AAC |
+| `stream.size` | File size |
+| `stream.bitrate` | Bitrate in Mbps |
+| `stream.seeders` | P2P seeders (torrent only) |
+| `stream.hasChapters` | Chapter badge for BluRay REMUXes with chapter markers |
+| `stream.editions` | Director's Cut, Extended, IMAX, etc. |
+| `stream.regraded` | Colour regrade flag |
+| `stream.repack` | REPACK/PROPER flag |
+| `stream.seMatched` | Name of the stream expression that matched |
+| `stream.nSeScore` | Normalised SEL score (0–1) |
+| `stream.nRegexScore` | Normalised regex score (0–1) |
+
+## Customising a Formatter
+
+Formatters are JSON files. To customise:
+
+1. Download the formatter JSON from GitHub
+2. Edit the `name` and `description` template strings
+3. Re-import via the Formatter import button
+
+See the [Formatter Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/FORMATTER_GUIDE.md) in the repo for the full field and modifier reference.

--- a/docs/importing.mdx
+++ b/docs/importing.mdx
@@ -1,0 +1,81 @@
+---
+title: "Importing a Template"
+description: "Step-by-step guide to importing, configuring API keys, and updating templates."
+---
+
+## Steps
+
+<Steps>
+  <Step title="Pick your template">
+    Use [Which Template?](/which-template) or browse the [Template Directory](/template-directory).
+  </Step>
+  <Step title="Copy the import URL">
+    Each template has a raw GitHub URL in the Template Directory. Copy it.
+  </Step>
+  <Step title="Load in AIOStreams">
+    Open your AIOStreams instance → **About → Get Started → Load Template** → paste the URL → click **Load**.
+  </Step>
+  <Step title="Enter your API keys">
+    Fill in **Services**:
+    - **TorBox API key** — [torbox.app/dashboard](https://torbox.app/dashboard) → API Keys
+    - **TMDB Access Token** (recommended) — [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api) → Read Access Token
+  </Step>
+  <Step title="Save and install">
+    Click **Save** → copy the manifest URL → install in Stremio or WuPlay.
+  </Step>
+</Steps>
+
+## API Keys
+
+| Key | Where to get it | Required for |
+|---|---|---|
+| TorBox API key | torbox.app → Dashboard → API Keys | All TorBox templates |
+| TMDB Access Token | themoviedb.org → Settings → API → Read Access Token | Better title matching (recommended) |
+| NZBGeek API key | nzbgeek.info → My Profile → API | Hybrid templates only |
+| AllDebrid API key | alldebrid.com → My Account → API | AllDebrid templates only |
+| EasyNews credentials | easynews.com | Speed EasyNews templates |
+
+## Updating a Template
+
+Re-import the same URL. AIOStreams will load the latest version and merge it over your existing config. Your API keys are preserved.
+
+<Tip>
+  Already imported? Check AIOStreams for an in-app update notification — it will prompt you to pull the latest version automatically.
+</Tip>
+
+## After Importing
+
+<AccordionGroup>
+  <Accordion title="Hybrid templates (4K Hybrid, Hybrid, Hybrid Lite)">
+    Go to **Add-ons → Newznab** and enter your NZBGeek API key.
+  </Accordion>
+  <Accordion title="AllDebrid templates">
+    Go to **Add-ons → StremThru AllDebrid** and enter your AllDebrid API key.
+  </Accordion>
+  <Accordion title="Speed templates">
+    These exit after 3 cached results or a timeout. Test with a popular title first (e.g. Breaking Bad S01E01).
+  </Accordion>
+  <Accordion title="Flash templates">
+    Cached-only. If a title isn't in TorBox's cache you'll get no results. Use Speed or Essential as a fallback for new releases.
+  </Accordion>
+</AccordionGroup>
+
+## Hosted vs Self-Hosted
+
+| | Hosted (elfhosted, fortheweak.cloud) | Self-hosted |
+|---|---|---|
+| Inline regex | Blocked unless trusted user | Works — set `REGEX_FILTER_ACCESS=all` |
+| Synced regex URLs | Blocked (GitHub raw URLs forbidden) | Works |
+| Performance | Shared resources | Dedicated |
+
+<Warning>
+  If you see a "Forbidden URL" or "regex blocked" error on import, you're on a public instance that blocks raw GitHub URLs. Contact your host to add your UUID to `TRUSTED_UUIDS`, or self-host AIOStreams with `REGEX_FILTER_ACCESS=all`.
+</Warning>
+
+## Stremio vs WuPlay
+
+| | Stremio | WuPlay |
+|---|---|---|
+| Platform | Desktop + mobile | Web + Chromecast |
+| Installation | Add-on URL in Stremio | Direct stream URL |
+| Best for | Standard setup | Casting / TV without an app |

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,58 @@
+---
+title: "Core Builds"
+description: "Optimised AIOStreams templates for TorBox, AllDebrid, and EasyNews."
+---
+
+<img
+  src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/templates_banner.svg"
+  alt="Core Builds"
+  style={{ borderRadius: '8px' }}
+/>
+
+## What is Core Builds?
+
+Core Builds is a collection of optimised [AIOStreams](https://github.com/Viren070/AIOStreams) templates for TorBox subscribers. Templates control how streams are filtered, sorted, deduplicated, and displayed inside AIOStreams.
+
+**Current version: v2.8.4** — [Changelog](/changelog)
+
+<CardGroup cols={2}>
+  <Card title="Which Template?" icon="map" href="/which-template">
+    Find the right template in 30 seconds with the decision tree.
+  </Card>
+  <Card title="Template Directory" icon="list" href="/template-directory">
+    Every template with import URLs, versions, and plan requirements.
+  </Card>
+  <Card title="Import a Template" icon="download" href="/importing">
+    Step-by-step guide — API keys, first-run setup, and updating.
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/troubleshooting">
+    Common problems and fixes.
+  </Card>
+</CardGroup>
+
+## Quick Start
+
+<Steps>
+  <Step title="Pick a template">
+    Not sure which? Start with [Which Template?](/which-template)
+  </Step>
+  <Step title="Copy the import URL">
+    Find your template in the [Template Directory](/template-directory) and copy the URL.
+  </Step>
+  <Step title="Load in AIOStreams">
+    Open your AIOStreams instance → **About → Get Started → Load Template** → paste the URL.
+  </Step>
+  <Step title="Enter your API keys">
+    Add your TorBox API key in **Services** and your TMDB Access Token in **Settings**.
+  </Step>
+  <Step title="Install in Stremio">
+    Click **Save** → copy the manifest URL → install in Stremio or WuPlay.
+  </Step>
+</Steps>
+
+## Links
+
+- [GitHub Repository](https://github.com/brevityA/Core-Builds)
+- [AIOStreams](https://github.com/Viren070/AIOStreams)
+- [AIOStreams Docs](https://docs.aiostreams.viren070.me)
+- [TorBox](https://torbox.app)

--- a/docs/logo/core_icon.svg
+++ b/docs/logo/core_icon.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
+    </linearGradient>
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
+    </linearGradient>
+    <filter id="hexGlow">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="diamGlow">
+      <feGaussianBlur stdDeviation="14" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="24"/>
+    </filter>
+  </defs>
+
+  <circle cx="256" cy="256" r="248" fill="#0d1117"/>
+
+  <!-- Ambient glow -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="#00e5ff" opacity="0.04" filter="url(#softGlow)"/>
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="#c060c0" opacity="0.08" filter="url(#softGlow)"/>
+
+  <!-- Hex glow layer -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round"
+    opacity="0.3" filter="url(#hexGlow)"/>
+
+  <!-- Hex outline -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="none" stroke="url(#hexGrad)" stroke-width="22" stroke-linejoin="round"/>
+
+  <!-- Diamond glow -->
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+
+  <!-- Diamond -->
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="url(#diamGrad)" opacity="0.95"/>
+</svg>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,0 +1,55 @@
+{
+  "name": "Core Builds",
+  "logo": {
+    "light": "/logo/core_icon.svg",
+    "dark": "/logo/core_icon.svg"
+  },
+  "favicon": "/logo/core_icon.svg",
+  "colors": {
+    "primary": "#3B82F6",
+    "light": "#93C5FD",
+    "dark": "#1D4ED8",
+    "background": {
+      "dark": "#0F1117"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "GitHub",
+      "url": "https://github.com/brevityA/Core-Builds"
+    },
+    {
+      "name": "AIOStreams",
+      "url": "https://github.com/Viren070/AIOStreams"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "Template Directory",
+    "url": "/template-directory"
+  },
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": ["introduction", "which-template", "importing"]
+    },
+    {
+      "group": "Templates",
+      "pages": ["template-directory"]
+    },
+    {
+      "group": "Reference",
+      "pages": ["device-profiles", "formatters", "nightly-and-labs"]
+    },
+    {
+      "group": "Support",
+      "pages": ["troubleshooting", "changelog", "roadmap"]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/brevityA/Core-Builds"
+  },
+  "feedback": {
+    "thumbsRating": true,
+    "suggestEdit": true
+  }
+}

--- a/docs/nightly-and-labs.mdx
+++ b/docs/nightly-and-labs.mdx
@@ -1,0 +1,80 @@
+---
+title: "Nightly and Labs"
+description: "Experimental templates testing new features before stable promotion."
+---
+
+## Nightly vs Labs
+
+| | Nightly | Labs |
+|---|---|---|
+| Stability | Stable for daily use | Experimental — may break |
+| Purpose | Finalising before stable promotion | Testing new PSE/SEL architecture |
+| Update frequency | Periodic | Frequent |
+
+## Nightly Templates
+
+### Apple TV 4K (v0.1.1)
+
+Device profile for Apple TV 4K (3rd gen) via Infuse. DV Profile 5/8 prioritised, DD+ Atmos, AV1 hard-excluded (no A15 hardware decoder).
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+```
+
+### Samsung RU7100 4K (v0.2.6)
+
+Samsung RU7100 (2019) 4K — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV. Full APEX IQR PSE stack. More aggressive than the stable Samsung TV template.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+```
+
+## Labs Templates
+
+<Warning>
+  Labs templates are experimental. They may change frequently and are not guaranteed to be stable. Use them to give feedback on new ideas.
+</Warning>
+
+### 4K Apex Labs (v0.5.3)
+
+Experimental Apex variant testing:
+- `dynamicAddonFetching` exit conditions (exit at 5+ cached 4K or 6s)
+- Template directives for per-scraper toggles
+- Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+```
+
+### Stream Labs (v0.3.2)
+
+1080p variant of 4K Apex Labs. Same hybrid architecture, exit at 5+ cached 1080p or 5s.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+```
+
+### Essential Labs (v0.1.1)
+
+TorBox debrid-only 1080p — no external scrapers. Library + TorBox Search only. Tests template directives for TorBox Search toggle and exit thresholds. Fast and lightweight.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+```
+
+### 4K Essential Labs (v0.1.1)
+
+Same as Essential Labs but 4K. TorBox debrid-only, no external scrapers.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+```
+
+## How to Give Feedback
+
+Post in the Nightly or Labs thread in the community. Include:
+
+- Template name and version
+- Title that triggered the issue
+- What you expected vs what happened
+- AIOStreams version and host type (self-hosted / elfhosted / etc.)

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,0 +1,97 @@
+---
+title: "Roadmap"
+description: "Planned work, active development, and recently completed milestones."
+---
+
+## Recently Completed
+
+| Version | Item |
+|---|---|
+| v2.8.4 | Boost Cached Usenet PSE restored — all 27 TorBox templates |
+| v2.8.3 | seadexBestOnly fixed on 5 general-purpose 4K templates |
+| v2.8.3 | Hard resolution kill ESE added to all 13 x 1080p templates |
+| v2.8.2 | Samsung TV codec fixes — AV1/VC-1 hard-excluded, DV/AI upscale removed |
+| v2.8.2 | Regex patterns embedded inline — fixes public instance "Forbidden URL" errors |
+| v2.8.0 | AllDebrid template family (4 templates) |
+| v2.8.0 | Apple TV 4K (Nightly) |
+| v2.8.0 | Samsung TV promoted to stable |
+| v2.8.0 | pow() exponential age-decay replaces hard 60-day cliff |
+| v2.8.0 | Core Builds Expression Layer — all 7 expressions deployed |
+| v2.7.5 | Addon timeout tuning — fixes silent Usenet result drops |
+| v2.7.5 | Dedup tiebreakers — torrent_seeders + usenet_age |
+| v2.7.0 | Core Nexus 4K Hybrid — TorBox + NZBGeek Usenet |
+| v2.7.0 | IQR Tukey fence PSEs |
+
+---
+
+## In Progress
+
+| Item | Notes |
+|---|---|
+| `hasSeaDex` + `seMatched()` anime gating | Adaptive anime quality gate — if SeaDex data exists, require SeaDex-matched stream in top tier; else fall through to standard sort |
+| Hybrid TorBox-priority PSEs — 1080p | TorBox-cached twins already in 4K Hybrid; carry over to Hybrid and Hybrid Lite |
+
+---
+
+## Planned
+
+### Expression Layer
+
+<AccordionGroup>
+  <Accordion title="REPACK/PROPER Passthrough ISE">
+    Pins REPACK/PROPER releases ahead of limit/excluded filters. Ensures patched releases always surface. Critical for Anime (fansub REPACKs), Hybrid, and Stream.
+  </Accordion>
+  <Accordion title="Per-Addon Flood Guard ESE">
+    Per-addon result cap (Meteor ≤5, Comet ≤5, MediaFusion ≤4, Torrent Galaxy/EZTV/Knaben/HdHub ≤3) on cached non-library streams. Most impactful on Stream, Essential, and Apex where Meteor can return 15–20+ results.
+  </Accordion>
+  <Accordion title="Usenet Propagation Guard ESE">
+    Holds back NZBs younger than 2 hours when propagated alternatives exist. Eliminates corrupt early-propagation grabs. All Usenet-enabled templates.
+  </Accordion>
+  <Accordion title="Codec Efficiency Booster PSE">
+    Surfaces HEVC/AV1 encodes ahead of AVC equivalents. Stream, Essential, Anime primarily.
+  </Accordion>
+  <Accordion title="Audio Pinnacle PSE">
+    Promotes lossless/object-based audio: Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3/DD+. Critical for Apex, 4K Hybrid, 4K Essential.
+  </Accordion>
+  <Accordion title="HDR / DV Priority PSE">
+    Within 4K results, surfaces DV/HDR10+/HDR10 ahead of SDR. Critical for Apex, 4K Essential, 4K Hybrid, Flash 4K.
+  </Accordion>
+  <Accordion title="pin() top result">
+    Pin the #1 PSE-matched stream to position 1 regardless of sort order.
+  </Accordion>
+</AccordionGroup>
+
+### Templates
+
+- **Mobile / Bandwidth template** — 25 Mbps bitrate ceiling, SDR-preferred, no REMUX. Covers mobile, travel, data-capped users
+- **Anime Dub 4K variant** — English-dub priority at 4K
+- **Flash suite review** — Flash 4K and Flash under evaluation; `excludeUncached: true` behaviour is genuinely distinct from Speed/Essential
+
+### Infrastructure
+
+- **GitHub Sponsors setup** — Ko-fi is live; exploring GitHub-native sponsorship
+- **Automated live AIOStreams testing** — Docker-based end-to-end validation against a real AIOStreams instance
+
+### Documentation
+
+- **Video walkthrough** — Import flow and template selection for new users
+- **AllDebrid setup guide** — Mirror of the TorBox import guide scoped to AllDebrid
+
+---
+
+## Ideas / Under Consideration
+
+| Idea | Status |
+|---|---|
+| New unified template suite | Under consideration — tighter 6-template lineup built around the Core Builds expression layer |
+| Debrid-Link template | Under research — supported in AIOStreams |
+| Premiumize template | Under research — natively supported |
+| RealDebrid support revival | Monitoring — server-side filter policy (May 2026) blocks most torrent results |
+| stddev() / variance() PSE variants | Exploratory — z-score gating as IQR alternative for large pools |
+| Community formatter gallery | Under consideration — Formatters/Community/ with user-submitted layouts |
+
+---
+
+## Want to Contribute?
+
+Feature suggestions belong in [Discussions](https://github.com/brevityA/Core-Builds/discussions) rather than issues — roadmap items that gain community traction get prioritised.

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -1,0 +1,111 @@
+---
+title: "Template Directory"
+description: "Every active template with import URLs, versions, and plan requirements. Current version: v2.8.4"
+---
+
+All templates require **AIOStreams v2.30+**. Every standard template has a **Lite variant** (`-lite` suffix) for shared hosts or thin libraries.
+
+<Note>
+  To import: copy the URL → AIOStreams → **About → Get Started → Load Template** → paste → Load.
+</Note>
+
+## TorBox Pro
+
+<Tabs>
+  <Tab title="4K">
+    | Template | Version | Import URL |
+    |---|---|---|
+    | **4K Apex** | v0.4.6 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-apex.json` |
+    | **4K Apex (TorBox-only)** | v2.8.5 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json` |
+    | **4K Hybrid** | v2.8.5 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
+    | **Samsung TV 4K** | v0.2.3 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json` |
+  </Tab>
+  <Tab title="1080p">
+    | Template | Version | Import URL |
+    |---|---|---|
+    | **Stream** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json` |
+    | **Stream Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-lite.json` |
+    | **Stream (Fire Stick)** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick.json` |
+    | **Stream (Fire Stick) Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json` |
+    | **Samsung TV** | v0.2.3 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json` |
+    | **Hybrid** | v2.8.5 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
+    | **Hybrid Lite** | v2.8.5 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json` |
+  </Tab>
+</Tabs>
+
+## TorBox Essential
+
+<Tabs>
+  <Tab title="4K Essential">
+    | Template | Version | Import URL |
+    |---|---|---|
+    | **4K Essential** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
+    | **4K Essential Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json` |
+    | **Flash 4K** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Flash/core-nexus-flash-4k.json` |
+    | **Speed 4K** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json` |
+    | **Speed 4K Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json` |
+  </Tab>
+  <Tab title="1080p Essential">
+    | Template | Version | Import URL |
+    |---|---|---|
+    | **Essential** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential.json` |
+    | **Essential Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential-lite.json` |
+    | **Flash** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Flash/core-nexus-flash.json` |
+    | **Speed** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed.json` |
+    | **Speed Lite** | v2.8.4 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json` |
+  </Tab>
+</Tabs>
+
+## AllDebrid
+
+| Template | Version | Resolution | Import URL |
+|---|---|---|---|
+| **4K AllDebrid** | v0.1.2 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json` |
+| **4K AllDebrid Lite** | v0.1.0 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json` |
+| **AllDebrid** | v0.1.1 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json` |
+| **AllDebrid Lite** | v0.1.1 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json` |
+
+## EasyNews Speed
+
+| Template | Version | Resolution | Import URL |
+|---|---|---|---|
+| **Speed 4K+** | v2.8.3 | 4K | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json` |
+| **Speed EasyNews** | v2.8.3 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json` |
+
+## Anime
+
+| Template | Version | Resolution | Import URL |
+|---|---|---|---|
+| **Anime** | v2.8.3 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json` |
+| **Anime Lite** | v2.8.3 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-lite.json` |
+| **Anime 4K** | v2.8.3 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json` |
+| **Anime 4K Lite** | v2.8.3 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json` |
+| **Anime Dub** | v2.8.3 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub.json` |
+| **Anime Dub Lite** | v2.8.3 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json` |
+
+## Nightly
+
+<Warning>
+  Nightly (🌙) = stable enough for daily use, gathering feedback. Labs (🧪) = experimental, may change frequently.
+</Warning>
+
+| Template | Version | Status | Import URL |
+|---|---|---|---|
+| **Apple TV 4K** | v0.1.1 | 🌙 Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
+| **Samsung RU7100 4K** | v0.2.6 | 🌙 Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
+| **4K Apex Labs** | v0.5.3 | 🧪 Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Stream Labs** | v0.3.2 | 🧪 Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **Essential Labs** | v0.1.1 | 🧪 Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **4K Essential Labs** | v0.1.1 | 🧪 Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+
+→ [What's being tested in Labs?](/nightly-and-labs)
+
+## Community Templates
+
+| Template | Author | Import URL |
+|---|---|---|
+| **Auburn Tiger Edition** | RB3 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/RB3/auburn-tiger-rb3.json` |
+| **RB3 TorBox Pro + RD Hybrid** | RB3 | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/RB3/rb3-hybrid/rb3-torbox-pro-rd-hybrid.json` |
+| **Prism TorBox Essential 1080p** | MightyIcyy | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Community-Templates/Templates/MightyIcyy/prism-torbox-essential-1080p.json` |
+
+Want your template listed? Open a PR to `Community-Templates/` in the [GitHub repository](https://github.com/brevityA/Core-Builds).

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,0 +1,88 @@
+---
+title: "Troubleshooting and FAQ"
+description: "Common problems and fixes."
+---
+
+## Common Issues
+
+<AccordionGroup>
+  <Accordion title="No results / very few results">
+    **Check first:**
+    - Is the title in TorBox's cache? Search at [torbox.app](https://torbox.app)
+    - Are your scrapers enabled? Open AIOStreams → Add-ons — confirm Comet, Mediafusion, etc. are enabled
+    - Are your API keys entered? TorBox key in Services, TMDB in Settings
+
+    **If you're on a Flash or Speed template:**
+    These templates exit as soon as they find cached results. If TorBox doesn't have the title cached, Flash returns nothing. Switch to Core Nexus Essential for full coverage with uncached fallback.
+
+    **Try the Lite variant:**
+    The standard template runs 24 ESEs (quality gates). Lite runs 12 — hard kills stay but quality gates are removed. If Lite returns results, one of the quality gates is filtering your content.
+  </Accordion>
+
+  <Accordion title='"Forbidden URL" or "regex blocked" error on import'>
+    You're on a public AIOStreams instance (elfhosted, fortheweak.cloud). These block raw GitHub URLs by default.
+
+    **Solutions:**
+    - Contact your host and ask them to add your UUID to `TRUSTED_UUIDS`
+    - Self-host AIOStreams and set `REGEX_FILTER_ACCESS=all`
+    - Use the Lite variant (fewer SEL expressions, same hard kills)
+  </Accordion>
+
+  <Accordion title="Cached Usenet NZBs appearing below debrid results">
+    Fixed in v2.8.4. Re-import your template. The Boost Cached Usenet PSE now catches any cached NZBs that fall outside the quality-window PSEs and ensures they rank above uncached streams.
+  </Accordion>
+
+  <Accordion title="Samsung TV — audio not playing / stuttering">
+    Check that your template has `excludedAudioTags: ["TrueHD","DTS-HD MA","DTS:X","FLAC"]`. The Samsung TV and Samsung TV 4K stable templates have these excluded by default. If you imported an older version, re-import to pick up the fix.
+  </Accordion>
+
+  <Accordion title="Samsung TV — Dolby Vision content I can't play">
+    The DV-Only Kill ESE is enabled by default on Samsung templates. If you're still seeing DV streams, check:
+    - Your template version is v0.2.2 or later (re-import if not)
+    - You haven't disabled the `No DV-Only` ESE in the AIOStreams editor
+  </Accordion>
+
+  <Accordion title="4K streams showing on a 1080p template">
+    Fixed in v2.8.3. All 1080p templates now have a hard resolution kill ESE as their first filter. Re-import your template.
+  </Accordion>
+
+  <Accordion title="SeaDex filtering out all results for anime">
+    Fixed in v2.8.3. `seadexBestOnly: true` was dropping all non-SeaDex streams on several non-Anime templates. Re-import to pick up the fix.
+  </Accordion>
+
+  <Accordion title="Usenet results slow or not appearing">
+    Fixed in v2.7.5. The newznab timeout was 3000ms — too short for TorBox Usenet. Updated to 10,000ms. Additionally `searchMode: auto` and `checkOwned: true` are now set. Re-import your template.
+  </Accordion>
+</AccordionGroup>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Do I need a TorBox subscription?">
+    Yes for all TorBox templates. AllDebrid and EasyNews templates work without TorBox.
+  </Accordion>
+
+  <Accordion title="Can I use these on a free/public AIOStreams instance?">
+    Yes, but inline regex scoring may be blocked on public instances. See the "Forbidden URL" section above.
+  </Accordion>
+
+  <Accordion title="How do I update a template?">
+    Re-import the same URL. Your API keys are preserved. Check AIOStreams for an in-app update notification first — it will prompt you automatically.
+  </Accordion>
+
+  <Accordion title="What's the difference between Standard and Lite?">
+    Standard runs 24 ESEs including quality gates (low bitrate, low seeders, upscaled 4K, bad Bluray). Lite runs 12 — hard kills only (CAM, YouTube, 3D, bad NZBs). See [Which Template?](/which-template#lite-vs-standard) for full comparison.
+  </Accordion>
+
+  <Accordion title="Can I submit my own template?">
+    Yes — open a PR to `Community-Templates/` in the [repository](https://github.com/brevityA/Core-Builds). Include a README with what your template does and what service/plan it requires.
+  </Accordion>
+
+  <Accordion title="Do I need a TMDB API token?">
+    It's optional but recommended. Without it, title matching falls back to AIOStreams defaults, which is less accurate for foreign titles and anime.
+  </Accordion>
+
+  <Accordion title="What is seadexBestOnly?">
+    SeaDex is an anime release quality database. When `seadexBestOnly: true`, only streams flagged as SeaDex best releases are shown for anime queries. This was incorrectly enabled on several non-Anime templates and fixed in v2.8.3.
+  </Accordion>
+</AccordionGroup>

--- a/docs/which-template.mdx
+++ b/docs/which-template.mdx
@@ -1,0 +1,98 @@
+---
+title: "Which Template?"
+description: "Find the right template in 30 seconds."
+---
+
+Every template also has a **Lite variant** (`-lite` suffix). Use Lite if you get too few results or are on a low-overhead shared host.
+
+## Decision Tree
+
+```
+TorBox Pro?
+├── Got NZBGeek/Usenet indexer?
+│   ├── Want 4K? → 4K Hybrid
+│   └── 1080p only? → Hybrid
+├── Want 4K? → 4K Apex
+├── Samsung TV / no Dolby Vision? → Samsung TV · Samsung TV 4K
+├── Apple TV 4K (Infuse)? → Apple TV 4K (Nightly)
+├── Fire Stick / low-RAM? → Stream (Fire Stick)
+└── 1080p only? → Stream
+
+TorBox Essential?
+├── Single-click instant play (cached only)?
+│   ├── 4K? → Flash 4K
+│   └── 1080p? → Flash
+├── Fast cached play, no EasyNews?
+│   ├── 4K? → Speed 4K
+│   └── 1080p? → Speed
+├── Fast cached play + EasyNews?
+│   ├── 4K? → Speed 4K+
+│   └── 1080p? → Speed+
+├── Want 4K? → 4K Essential
+└── 1080p standard? → Essential
+
+EasyNews only (no TorBox)? → Speed EasyNews
+
+AllDebrid (no TorBox)?
+├── Want 4K?
+│   ├── Full IQR filtering → 4K AllDebrid
+│   └── Simpler filtering → 4K AllDebrid Lite
+└── 1080p only?
+    ├── Full → AllDebrid
+    └── Lite → AllDebrid Lite
+
+Anime?
+├── Want 4K HDR? → Anime 4K
+├── Standard 1080p? → Anime
+└── Prefer English dubs? → Anime Dub
+```
+
+## Lite vs Standard
+
+<Tabs>
+  <Tab title="Standard">
+    - 24 ESEs (full quality gate stack)
+    - Includes low-bitrate, low-seeder, upscaled 4K, and bad Bluray quality gates
+    - Recommended for most users on self-hosted or dedicated instances
+  </Tab>
+  <Tab title="Lite">
+    - 12 ESEs (hard kills only — CAM, YouTube, 3D, bad NZBs)
+    - Quality gates removed for maximum result count
+    - Recommended for shared hosts, thin libraries, or debugging
+  </Tab>
+</Tabs>
+
+<Tip>
+  If the standard template returns very few results, switch to the Lite variant. If Lite returns results, one of the quality gates is filtering your content — you can enable/disable individual ESEs in AIOStreams.
+</Tip>
+
+## Template Comparison
+
+<CardGroup cols={2}>
+  <Card title="4K Apex" icon="crown">
+    Flagship 4K. IQR Tukey fence adaptive bitrate filtering, DV/HDR priority, Usenet via Newznab. TorBox Pro.
+  </Card>
+  <Card title="4K Hybrid" icon="shuffle">
+    TorBox Pro + NZBGeek. Dual-source: debrid + Usenet. Full 4K, TorBox-priority PSEs.
+  </Card>
+  <Card title="Stream" icon="play">
+    1080p WEB-DL only. BluRay and Remux excluded. Best for budget hardware. TorBox Pro.
+  </Card>
+  <Card title="4K Essential" icon="star">
+    Full 4K on TorBox Essential plan. IQR PSEs, no Usenet.
+  </Card>
+  <Card title="Flash" icon="bolt">
+    Cached-only instant play. Returns immediately if cached, nothing if not. TorBox Essential.
+  </Card>
+  <Card title="Speed" icon="gauge">
+    Fast cached play. Exits at 3 cached results or timeout. TorBox Essential.
+  </Card>
+  <Card title="Anime" icon="tv">
+    SeaDex best-release enforcement, AnimeTosho + NekoBT scrapers. TorBox Essential.
+  </Card>
+  <Card title="Samsung TV" icon="monitor">
+    AV1/VC-1/DV hard-excluded for Tizen compatibility. 1080p and 4K variants.
+  </Card>
+</CardGroup>
+
+→ [Full import URLs and versions](/template-directory)


### PR DESCRIPTION
Mintlify v2 uses `docs.json` as the config filename instead of `mint.json`. Adds `docs/docs.json` (same content) so Mintlify can find the config when the subdirectory toggle is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_