### PR TITLE
docs: fix docs.json — add required theme field for Mintlify v2

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
   "name": "Core Builds",
   "logo": {
     "light": "/logo/core_icon.svg",


### PR DESCRIPTION
Fixes the Mintlify deployment error: `Invalid docs.json: #.theme: Invalid discriminator value`. Mintlify v2 requires a `theme` field. Added `"theme": "mint"` and the `$schema` reference to `docs.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_