### PR TITLE
docs: fix docs.json schema for Mintlify v2

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,10 +10,7 @@
   "colors": {
     "primary": "#3B82F6",
     "light": "#93C5FD",
-    "dark": "#1D4ED8",
-    "background": {
-      "dark": "#0F1117"
-    }
+    "dark": "#1D4ED8"
   },
   "topbarLinks": [
     {
@@ -29,24 +26,31 @@
     "name": "Template Directory",
     "url": "/template-directory"
   },
-  "navigation": [
-    {
-      "group": "Getting Started",
-      "pages": ["introduction", "which-template", "importing"]
-    },
-    {
-      "group": "Templates",
-      "pages": ["template-directory"]
-    },
-    {
-      "group": "Reference",
-      "pages": ["device-profiles", "formatters", "nightly-and-labs"]
-    },
-    {
-      "group": "Support",
-      "pages": ["troubleshooting", "changelog", "roadmap"]
-    }
-  ],
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": ["introduction", "which-template", "importing"]
+          },
+          {
+            "group": "Templates",
+            "pages": ["template-directory"]
+          },
+          {
+            "group": "Reference",
+            "pages": ["device-profiles", "formatters", "nightly-and-labs"]
+          },
+          {
+            "group": "Support",
+            "pages": ["troubleshooting", "changelog", "roadmap"]
+          }
+        ]
+      }
+    ]
+  },
   "footerSocials": {
     "github": "https://github.com/brevityA/Core-Builds"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
   "name": "Core Builds",
   "logo": {
     "light": "/logo/core_icon.svg",


### PR DESCRIPTION
Fixes two validation errors from the Mintlify deployment log:

- `colors.background` removed — unrecognized key in v2 schema
- `navigation` changed from flat array to `{ tabs: [{ tab, groups }] }` object format required by v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_