### PR TITLE
fix: nav logo — wide banner at 55px for readable sidebar branding

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "Core Builds",
   "logo": {
-    "light": "/logo/banner_square.png",
-    "dark": "/logo/banner_square.png",
-    "height": 70
+    "light": "/logo/core_builds_banner.png",
+    "dark": "/logo/core_builds_banner.png",
+    "height": 55
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,8 @@
   "name": "Core Builds",
   "logo": {
     "light": "/logo/banner_square.png",
-    "dark": "/logo/banner_square.png"
+    "dark": "/logo/banner_square.png",
+    "height": 70
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -5,7 +5,7 @@ mode: "wide"
 
 <div style={{ textAlign: 'center', paddingTop: '24px', paddingBottom: '20px' }}>
   <img
-    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/banner_square.svg"
+    src="/logo/banner_square.png"
     alt="Core Builds"
     style={{ width: '320px', display: 'inline-block' }}
   />


### PR DESCRIPTION
## Summary

- Switches nav logo from square PNG (hex icon with unreadably small text) to wide banner PNG (`core_builds_banner.png`, 1200×340 RGBA)
- Sets `height: 55` so the banner renders at a proportional width (~193px) that fits cleanly in the Mintlify sidebar

## Why

The square logo at any nav height had the "CORE BUILDS" text crammed below the icon at ~8px — unreadable. The wide banner has large bold "CORE BUILDS" text that's clear at 55px height.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_