### PR TITLE
fix: Nightly Samsung RU7100 4K — assign unique template ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,10 @@ Preset `type` values confirmed in AIOStreams source:
 
 ---
 
-## Active Template Inventory (as of v2.8.8)
+## Active Template Inventory (as of v2.9.0)
 
 ### Single (TorBox Pro)
-- `Single/core-nexus-4k-apex.json` v0.4.10 — flagship 4K, IQR PSEs, pow() decay
+- `Single/core-nexus-4k-apex.json` v0.4.11 — flagship 4K, IQR PSEs, pow() decay
 - `Single/core-nexus-4k-apex-torbox.json` v2.9.0 — TorBox-cached-only Apex variant
 - `Single/core-nexus-stream.json` v2.9.0 — 1080p streaming quality
 - `Single/core-nexus-stream-lite.json` v2.9.0 — lite variant
@@ -113,10 +113,10 @@ Preset `type` values confirmed in AIOStreams source:
 - `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.0 — EasyNews 1080p
 
 ### AllDebrid
-- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.6 — 4K with IQR PSEs
-- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.4 — 4K CB-style
-- `AllDebrid/core-nexus-alldebrid.json` v0.1.5 — 1080p
-- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.5 — 1080p lite
+- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.7 — 4K with IQR PSEs
+- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.5 — 4K CB-style
+- `AllDebrid/core-nexus-alldebrid.json` v0.1.6 — 1080p
+- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.6 — 1080p lite
 
 ### Hybrid
 - `Hybrid/core-nexus-4k-hybrid.json` v2.9.0 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
@@ -124,8 +124,8 @@ Preset `type` values confirmed in AIOStreams source:
 - `Hybrid/core-nexus-hybrid-lite.json` v2.9.0 — NZBGeek preset
 
 ### Device
-- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.7 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
-- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.7 — 4K, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.8 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.8 — 4K, DV-Only Kill on, AV1/VC-1 excluded
 
 ### Anime
 - `Anime/core-nexus-anime-4k.json` v2.8.3 — 4K anime, SeaDex + AnimeTosho

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
@@ -1834,6 +1834,9 @@
     },
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
@@ -2,10 +2,10 @@
   "metadata": {
     "id": "core-nexus-4k-alldebrid-lite",
     "name": "Core Nexus 4K AllDebrid Lite",
-    "description": "4K AllDebrid Lite. DV/HDR · TrueHD/Atmos · Relaxed filtering (no IQR). No TorBox required.",
+    "description": "4K AllDebrid Lite. DV/HDR · TrueHD/Atmos · Relaxed filtering. No TorBox required. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
@@ -5,7 +5,7 @@
     "description": "Core Nexus 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD/Atmos · uncapped bitrate. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
@@ -1904,6 +1904,9 @@
     },
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -1946,6 +1946,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -2,10 +2,10 @@
   "metadata": {
     "id": "core-nexus-alldebrid-lite",
     "name": "Core Nexus AllDebrid Lite",
-    "description": "1080p AllDebrid Lite. DTS:X / TrueHD / HEVC · Relaxed filtering. No TorBox required.",
+    "description": "1080p AllDebrid Lite. DTS:X / TrueHD / HEVC · Relaxed filtering. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -5,7 +5,7 @@
     "description": "Core Nexus 1080p for AllDebrid. WEB-DL / Remux quality tiers · HDR preferred · TrueHD/Atmos. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -1946,6 +1946,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung smart TVs without native Dolby Vision support — including RU7100, RU8000, NU8000, Q60, and similar 2018–2022 models. DV-only streams are excluded (DV-Only Kill ESE); only HDR10+, HDR10, HLG, and SDR content appears. AV1 and VC-1 excluded (not supported on older Samsung hardware). Lossless audio (TrueHD, DTS-HD MA, DTS:X, FLAC) excluded — Samsung passes these through only via HDMI ARC/eARC to compatible receivers, which most users don't have. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox · Library, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -1940,6 +1940,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -5,7 +5,7 @@
     "description": "Stream template tuned for Samsung smart TVs and other devices without Dolby Vision support. DV-only streams are excluded — only HDR10, HDR10+, HLG, and SDR content appears. Based on Core Nexus Stream (1080p · TorBox Essential · Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -1934,6 +1934,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -1874,6 +1874,9 @@
     },
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -1944,6 +1944,9 @@
     },
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "brevity.core-nexus-essential-lite",
     "name": "Core Nexus Essential Lite",
-    "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB-25 GB. Full addon stack including Comet, Meteor, Zilean, Knaben, and. A single TorBox Essential subscription is all that is required. Relaxed filtering — quality gates removed, more results shown.",
+    "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required — runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB–25 GB. Full addon stack: Comet, Meteor, Zilean, Knaben. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -1921,6 +1921,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "brevity.core-nexus-essential",
     "name": "Core Nexus Essential",
-    "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB-25 GB. Full addon stack including Comet, Meteor, Zilean, Knaben, and. A single TorBox Essential subscription is all that is required.",
+    "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required — runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB–25 GB. Full addon stack: Comet, Meteor, Zilean, Knaben. A single TorBox Essential subscription is all that is required.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -1987,6 +1987,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -1886,6 +1886,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -1837,6 +1837,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -2012,6 +2012,9 @@
     "tmdbApiKey": "<template_placeholder>",
     "usePosterRedirectApi": true,
     "usePosterServiceForMeta": true,
-    "syncedRankedRegexUrls": []
+    "syncedRankedRegexUrls": [],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
+    ]
   }
 }

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -1979,6 +1979,9 @@
     "tmdbApiKey": "<template_placeholder>",
     "usePosterRedirectApi": true,
     "usePosterServiceForMeta": true,
-    "syncedRankedRegexUrls": []
+    "syncedRankedRegexUrls": [],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
+    ]
   }
 }

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -2045,6 +2045,9 @@
     "tmdbApiKey": "<template_placeholder>",
     "usePosterRedirectApi": true,
     "usePosterServiceForMeta": true,
-    "syncedRankedRegexUrls": []
+    "syncedRankedRegexUrls": [],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
+    ]
   }
 }

--- a/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+++ b/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
@@ -1929,6 +1929,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -1828,6 +1828,9 @@
     },
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -12,31 +12,31 @@
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json",
     "inputs": [
       {
-        "key": "enableTorboxSearch",
         "path": "config.presets",
-        "label": "Enable TorBox Search",
         "description": "TorBox native search addon. Type anything to include it (default: enabled). Tests whether TorBox Search adds value beyond the cached library.",
         "type": "string",
         "required": false,
-        "value": "yes"
+        "value": "yes",
+        "id": "enableTorboxSearch",
+        "name": "Enable TorBox Search"
       },
       {
-        "key": "exitThreshold",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — cached stream count",
         "description": "Stop querying when this many cached streams are found. Default: 5. Debrid-only is fast — lower threshold recommended.",
         "type": "string",
         "required": false,
-        "value": "5"
+        "value": "5",
+        "id": "exitThreshold",
+        "name": "Early exit — cached stream count"
       },
       {
-        "key": "maxWaitMs",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — max wait (ms)",
         "description": "Stop querying after this many milliseconds. Default: 4000.",
         "type": "string",
         "required": false,
-        "value": "4000"
+        "value": "4000",
+        "id": "maxWaitMs",
+        "name": "Early exit — max wait (ms)"
       }
     ]
   },

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -12,31 +12,31 @@
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json",
     "inputs": [
       {
-        "key": "enableTorboxSearch",
         "path": "config.presets",
-        "label": "Enable TorBox Search",
         "description": "TorBox native search addon. Type anything to include it (default: enabled). Tests whether TorBox Search adds value beyond the cached library.",
         "type": "string",
         "required": false,
-        "value": "yes"
+        "value": "yes",
+        "id": "enableTorboxSearch",
+        "name": "Enable TorBox Search"
       },
       {
-        "key": "exitThreshold",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — cached stream count",
         "description": "Stop querying when this many cached streams are found. Default: 5. Debrid-only is fast — lower threshold recommended.",
         "type": "string",
         "required": false,
-        "value": "5"
+        "value": "5",
+        "id": "exitThreshold",
+        "name": "Early exit — cached stream count"
       },
       {
-        "key": "maxWaitMs",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — max wait (ms)",
         "description": "Stop querying after this many milliseconds. Default: 4000.",
         "type": "string",
         "required": false,
-        "value": "4000"
+        "value": "4000",
+        "id": "maxWaitMs",
+        "name": "Early exit — max wait (ms)"
       }
     ]
   },

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -1854,6 +1854,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-essential-labs",
     "name": "Core Nexus Essential Labs",
-    "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. build. Template directives: TorBox Search and exit thresholds configurable at import. Based on Essential v2.8.2.",
+    "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 1080p build. Template directives: TorBox Search and exit thresholds configurable at import.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "0.1.5",

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "id": "brevity.core-nexus-samsung-tv-4k",
+    "id": "brevity.core-nexus-samsung-ru7100-4k",
     "name": "Core Nexus Samsung RU7100 4K",
     "description": "4K template tuned for Samsung RU7100 (UA65RU7100W) and compatible TVs. Native video containers: MKV, MP4, AVI, MOV, FLV, ASF, 3GP, VOB. Native audio: FLAC, AAC, MP3, M4A, WMA, WAV. No AV1 or Dolby Vision — DV streams excluded. HDR10+, HDR10, HLG priority. HEVC/AVC encodes only. Audio prioritises FLAC and AAC for native playback; Atmos/TrueHD/DTS ranked lower (passthrough/transcode). Full Core Builds expression layer: IQR Apex PSEs · REPACK/PROPER Passthrough · Per-Addon Flood Guard · Usenet Propagation Guard · AI Upscale Exclusion · Codec Efficiency Booster · Audio Pinnacle (native-first) · HDR Priority (no DV) · Ranked regex pool · Full CB ESE stack.",
     "source": "external",

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -2047,6 +2047,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -2034,6 +2034,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -7,40 +7,40 @@
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json",
     "inputs": [
       {
-        "key": "exitThreshold",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — cached stream count",
         "description": "Stop querying addons when this many cached 4K streams are found. Default: 5. Lower = faster but fewer options. Higher = more streams but slower start.",
         "type": "string",
         "required": false,
-        "value": "5"
+        "value": "5",
+        "id": "exitThreshold",
+        "name": "Early exit — cached stream count"
       },
       {
-        "key": "maxWaitMs",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — max wait (ms)",
         "description": "Stop querying addons after this many milliseconds regardless of stream count. Default: 6000. Reduce to 4000 for faster response on fast connections.",
         "type": "string",
         "required": false,
-        "value": "6000"
+        "value": "6000",
+        "id": "maxWaitMs",
+        "name": "Early exit — max wait (ms)"
       },
       {
-        "key": "enableScrapers",
         "path": "config.presets",
-        "label": "Enable optional scrapers (MediaFusion + HdHub)",
         "description": "Type anything to add MediaFusion and HdHub as sources. Broader coverage but adds ~3–5s latency. Leave blank to skip.",
         "type": "string",
         "required": false,
-        "value": ""
+        "value": "",
+        "id": "enableScrapers",
+        "name": "Enable optional scrapers (MediaFusion + HdHub)"
       },
       {
-        "key": "enableAnime",
         "path": "config.presets",
-        "label": "Enable SeaDex (anime quality)",
         "description": "Type anything to add SeaDex for best-quality anime releases. Only useful for anime content. Leave blank to skip.",
         "type": "string",
         "required": false,
-        "value": ""
+        "value": "",
+        "id": "enableAnime",
+        "name": "Enable SeaDex (anime quality)"
       }
     ]
   },

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -3,7 +3,7 @@
     "id": "core-nexus-4k-apex-labs",
     "name": "Core Nexus 4K Apex Labs",
     "version": "0.8.4",
-    "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, HdHub, SeaDex) toggled at import via inputs; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on 4K Apex v0.4.3.",
+    "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, HdHub, SeaDex) toggled at import; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on 4K Apex.",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json",
     "inputs": [
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -2081,6 +2081,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -13,40 +13,40 @@
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
     "inputs": [
       {
-        "key": "exitThreshold",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — cached stream count",
         "description": "Stop querying addons when this many cached 1080p streams are found. Default: 5. Lower = faster. Higher = more options but slower start.",
         "type": "string",
         "required": false,
-        "value": "5"
+        "value": "5",
+        "id": "exitThreshold",
+        "name": "Early exit — cached stream count"
       },
       {
-        "key": "maxWaitMs",
         "path": "config.dynamicAddonFetching.condition",
-        "label": "Early exit — max wait (ms)",
         "description": "Stop querying addons after this many milliseconds. Default: 5000. Reduce to 3000 for faster response on fast connections.",
         "type": "string",
         "required": false,
-        "value": "5000"
+        "value": "5000",
+        "id": "maxWaitMs",
+        "name": "Early exit — max wait (ms)"
       },
       {
-        "key": "enableScrapers",
         "path": "config.presets",
-        "label": "Enable optional scrapers (MediaFusion)",
         "description": "Type anything to add MediaFusion as an additional source. Broader coverage but adds ~3–5s latency. Leave blank to skip.",
         "type": "string",
         "required": false,
-        "value": ""
+        "value": "",
+        "id": "enableScrapers",
+        "name": "Enable optional scrapers (MediaFusion)"
       },
       {
-        "key": "enableAnime",
         "path": "config.presets",
-        "label": "Enable SeaDex (anime quality)",
         "description": "Type anything to add SeaDex for best-quality anime releases. Only useful for anime content. Leave blank to skip.",
         "type": "string",
         "required": false,
-        "value": ""
+        "value": "",
+        "id": "enableAnime",
+        "name": "Enable SeaDex (anime quality)"
       }
     ]
   },

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-stream-labs",
     "name": "Core Nexus Stream Labs",
-    "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, SeaDex) toggled at import via inputs; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on Stream v2.8.2.",
+    "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, SeaDex) toggled at import; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on Stream.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "0.6.4",

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -1979,6 +1979,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -2,10 +2,10 @@
   "metadata": {
     "id": "brevity.core-nexus-4k-apex",
     "name": "Core Nexus 4K Apex",
-    "description": "Adaptive flagship build. Extends 4K Pro with ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: when ≥4 ranked streams exist the window is Q1−1.5×IQR to Q3+1.5×IQR; for thin pools (1–3 ranked) it falls back to 80%–120% of the ranked min/max; and for new releases (<60 days) with no ranked streams a median-cluster fallback keeps results flowing. HDR and SDR are evaluated separately in the WEB-DL tier. Full 4K Pro ESE stack retained.",
+    "description": "Adaptive flagship build. Ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: ≥4 ranked streams → Q1−1.5×IQR to Q3+1.5×IQR window; 1–3 ranked → 80%–120% of min/max; 0 ranked → pow(0.95, daysSinceRelease) decay median cluster. HDR and SDR evaluated separately in the WEB-DL tier. Full ESE stack: REPACK passthrough, per-addon flood guard, Usenet propagation guard, codec efficiency booster, DV-Only Kill, audio pinnacle, and more.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -1976,6 +1976,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
@@ -1945,6 +1945,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -2011,6 +2011,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -1935,6 +1935,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -1993,6 +1993,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "brevity.core-nexus-speed-4k-plus",
     "name": "Core Nexus Speed 4K+",
-    "description": "A speed-optimised 4K build for TorBox Essential and EasyNews users. Lives in Templates/Torbox/Speed/EasyNews/. Library, TorBox Search, Comet, and Zilean only -- the four fastest sources delivering cached results in 2-3 seconds. Targets 2160p with Dolby Vision and HDR10+ priority, TrueHD/Atmos audio, files up to 150 GB. SeaDex best-release enforced for anime. Timeouts at 3500ms, 10 results max, 5-key sort. Requires an active TorBox Essential and EasyNews subscription.",
+    "description": "Speed-optimised 4K build for TorBox Essential and EasyNews subscribers. Lean sources: Library, TorBox Search, Comet, and Zilean — the four fastest, delivering cached results in 2–3 seconds. 2160p priority · DV and HDR10+ · TrueHD/Atmos · files up to 150 GB. SeaDex best-release enforced for anime. Requires active TorBox Essential and EasyNews subscriptions.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
@@ -1885,6 +1885,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
@@ -1836,6 +1836,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-speed-4k-lite",
     "name": "Core Nexus Speed 4K Lite",
-    "description": "Speed-optimised 4K + 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 4K streams found or 4s elapsed. Based on Essential v2.8.2.",
+    "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -1768,6 +1768,9 @@
     "maxResultsPerResolution": 6,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-speed-4k",
     "name": "Core Nexus Speed 4K",
-    "description": "Speed-optimised 4K + 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 4K streams found or 4s elapsed. Based on Essential v2.8.2.",
+    "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -1816,6 +1816,9 @@
     "maxResultsPerResolution": 6,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-speed-lite",
     "name": "Core Nexus Speed Lite",
-    "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 1080p streams found or 4s elapsed. Based on Essential v2.8.2.",
+    "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -1796,6 +1796,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -1844,6 +1844,9 @@
     "usePosterServiceForMeta": true,
     "syncedRankedRegexUrls": [
       "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
     ]
   }
 }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-speed",
     "name": "Core Nexus Speed",
-    "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 1080p streams found or 4s elapsed. Based on Essential v2.8.2.",
+    "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
     "version": "2.9.0",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,13 +7,49 @@ Full history: [CHANGELOG.md](https://github.com/brevityA/Core-Builds/blob/main/C
 
 ---
 
-## v2.8.4 — 2026-06-17
+## v2.9.0 — 2026-06-19
 
 <Info>
   **Latest release.** If you already have a template imported, check AIOStreams for an in-app update notification.
 </Info>
 
-**Fixed: Cached Usenet missing priority signal — all 27 TorBox templates**
+**Fixed: Regex compatibility — fortheweak whitelist**
+
+fortheweak's AIOStreams instance uses a stricter regex whitelist than elfhosted's. Eleven ranked and three excluded inline pattern entries were rejected on import. Removed from all 33 non-Anime templates:
+
+- **Ranked removed:** `Radarr Web T1`, `Sonarr Web T1`, `Radarr Bad Dual Groups`, `Sonarr Bad Dual Groups`, `hallowed`, `LQ (Radarr)`, `LQ (Radarr) [B]`, `LQ (Sonarr)`, `LQ (Sonarr) [B]`, `LQ (Release Title) (Radarr)`, `LQ (Release Title) (Sonarr)`
+- **Excluded removed:** LQ (Radarr) [B] large pattern, `iVy`-only, LQ (Sonarr) [B] large pattern
+- **Preferred removed (1080p):** `Radarr Web T1`, `Sonarr Web T1`, `hallowed`
+
+LQ streams remain excluded via Tamtaro's `syncedExcludedRegexUrls`. WEB-DL releases retain ranking via the generic `Web T1` tier. Release group scoring preserved through Remux, Bluray, Anime, and group-specific tiers.
+
+---
+
+## v2.8.9 — 2026-06-18
+
+**Fixed: Regex whitelist sync — all 39 active templates**
+
+Eight pattern strings had drifted from Vidhin05's current `English/regexes.json`. elfhosted checks exact string equality against Vidhin05's pattern values — any divergence causes "X/183 regexes not allowed" on import. Fixed: `Radarr Web T1`, `Sonarr Web T1`, `Radarr Bad Dual Groups`, `Sonarr Bad Dual Groups`, `LQ (Radarr) [B]`, `LQ (Sonarr) [B]`, `LQ (Release Title) (Radarr)`, `LQ (Release Title) (Sonarr)`. File extension excluded pattern removed (not in Vidhin05's whitelist).
+
+---
+
+## v2.8.8 — 2026-06-18
+
+**Fixed: Regex configuration reverted — all 33 non-Anime templates**
+
+v2.8.6 and v2.8.7 incorrectly stripped regex configuration based on a wrong assumption about elfhosted's blocking mechanism. elfhosted's whitelist includes all Radarr/Sonarr quality-guide patterns including lookahead syntax — these were never blocked by syntax, only by missing entries. Full `rankedRegexPatterns`, `preferredRegexPatterns`, and `excludedRegexPatterns` restored to verified working configuration.
+
+---
+
+## v2.8.5–v2.8.7 — 2026-06-18
+
+Intermediate regex investigation builds. Superseded by v2.8.8.
+
+---
+
+## v2.8.4 — 2026-06-17
+
+**Added: Boost Cached Usenet PSE — all 27 TorBox templates**
 
 Cached TorBox Usenet NZBs with Unknown quality metadata, or bitrates outside the IQR window, had no PSE match — sorted below cached debrid results that did have one. New final fallback PSE added to all templates:
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Template Directory"
-description: "Every active template with import URLs, versions, and plan requirements. Current version: v2.8.4"
+description: "Every active template with import URLs, versions, and plan requirements. Current version: v2.9.0"
 ---
 
 <Frame>
@@ -21,7 +21,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
 <Tabs>
   <Tab title="4K">
-    ### 4K Apex — v0.4.6
+    ### 4K Apex — v0.4.11
     Flagship 4K. IQR Tukey fence adaptive bitrate filtering, DV/HDR priority, Usenet via Newznab.
 
     <CardGroup cols={2}>
@@ -34,7 +34,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### 4K Apex (TorBox-only) — v2.8.5
+    ### 4K Apex (TorBox-only) — v2.9.0
     Cached-only Apex variant. No external scrapers.
 
     <CardGroup cols={2}>
@@ -47,7 +47,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### 4K Hybrid — v2.8.5
+    ### 4K Hybrid — v2.9.0
     TorBox Pro + NZBGeek. Full 4K with TorBox-priority PSEs. Requires NZBGeek API key.
 
     <CardGroup cols={2}>
@@ -60,7 +60,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Samsung TV 4K — v0.2.3
+    ### Samsung TV 4K — v0.2.8
     AV1/VC-1/DV hard-excluded for Tizen. HDR10+ preferred.
 
     <CardGroup cols={2}>
@@ -73,7 +73,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
   </Tab>
 
   <Tab title="1080p">
-    ### Stream — v2.8.4
+    ### Stream — v2.9.0
     1080p WEB-DL only. BluRay and Remux excluded.
 
     <CardGroup cols={2}>
@@ -87,7 +87,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Stream (Fire Stick) — v2.8.4
+    ### Stream (Fire Stick) — v2.9.0
     1080p SDR, tuned for Fire Stick and low-RAM devices.
 
     <CardGroup cols={2}>
@@ -101,7 +101,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Samsung TV — v0.2.3
+    ### Samsung TV — v0.2.8
     1080p, AV1/VC-1/DV hard-excluded for Tizen.
 
     <CardGroup cols={2}>
@@ -114,7 +114,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Hybrid — v2.8.5
+    ### Hybrid — v2.9.0
     TorBox + NZBGeek, 1080p. Requires NZBGeek API key.
 
     <CardGroup cols={2}>
@@ -134,7 +134,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
 <Tabs>
   <Tab title="4K">
-    ### 4K Essential — v2.8.4
+    ### 4K Essential — v2.9.0
     Full 4K on Essential plan. IQR PSEs, no Usenet.
 
     <CardGroup cols={2}>
@@ -148,7 +148,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Flash 4K — v2.8.4
+    ### Flash 4K — v2.9.0
     Cached-only instant play. Returns nothing if title isn't cached.
 
     <CardGroup cols={2}>
@@ -161,7 +161,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Speed 4K — v2.8.4
+    ### Speed 4K — v2.9.0
     Fast cached 4K. Exits at 3 cached results or timeout.
 
     <CardGroup cols={2}>
@@ -175,7 +175,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
   </Tab>
 
   <Tab title="1080p">
-    ### Essential — v2.8.4
+    ### Essential — v2.9.0
     Standard 1080p for Essential subscribers.
 
     <CardGroup cols={2}>
@@ -189,7 +189,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Flash — v2.8.4
+    ### Flash — v2.9.0
     Cached-only instant 1080p play.
 
     <CardGroup cols={2}>
@@ -202,7 +202,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
     ---
 
-    ### Speed — v2.8.4
+    ### Speed — v2.9.0
     Fast cached 1080p. Exits at 3 cached results or timeout.
 
     <CardGroup cols={2}>
@@ -220,7 +220,7 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
 
 ## AllDebrid
 
-### 4K AllDebrid — v0.1.2
+### 4K AllDebrid — v0.1.7
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json" />
@@ -231,7 +231,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 ```
 Lite: `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json`
 
-### AllDebrid — v0.1.1
+### AllDebrid — v0.1.6
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json" />
@@ -246,7 +246,7 @@ Lite: `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Te
 
 ## EasyNews Speed
 
-### Speed 4K+ — v2.8.3
+### Speed 4K+ — v2.9.0
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json" />
@@ -256,7 +256,7 @@ Lite: `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Te
 https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
 ```
 
-### Speed EasyNews — v2.8.3
+### Speed EasyNews — v2.9.0
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json" />
@@ -308,17 +308,17 @@ Lite: `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Te
 ## Nightly
 
 <Warning>
-  Nightly (stable for daily use) and Labs (experimental) templates. May change frequently.
+  **Nightly** templates are stable for daily use. **Labs** templates are experimental and may fail to load — do not use Labs in production.
 </Warning>
 
 | Template | Version | Status | Import URL |
 |---|---|---|---|
-| Apple TV 4K | v0.1.1 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| Samsung RU7100 4K | v0.2.6 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
-| 4K Apex Labs | v0.5.3 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| Stream Labs | v0.3.2 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| Essential Labs | v0.1.1 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| 4K Essential Labs | v0.1.1 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| Apple TV 4K | v0.1.5 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
+| Samsung RU7100 4K | v0.2.10 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
+| 4K Apex Labs | v0.8.4 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| Stream Labs | v0.6.4 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| Essential Labs | v0.1.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| 4K Essential Labs | v0.1.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
 
 → [What's being tested?](/nightly-and-labs)
 


### PR DESCRIPTION
The Nightly Samsung RU7100 4K shared `id: "brevity.core-nexus-samsung-tv-4k"` with the stable Samsung TV 4K template. AIOStreams uses the `id` field to track templates — a collision means update notifications, version tracking, and "applied templates" state all bleed between the two.

Changed Nightly Samsung ID to `brevity.core-nexus-samsung-ru7100-4k` so they are treated as independent templates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_