### PR TITLE
docs: update nightly-and-labs and changelog for post-v2.9.0 fixes

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,11 +7,23 @@ Full history: [CHANGELOG.md](https://github.com/brevityA/Core-Builds/blob/main/C
 
 ---
 
-## v2.9.0 — 2026-06-19
+## v2.9.0 (patch) — 2026-06-19
 
 <Info>
   **Latest release.** If you already have a template imported, check AIOStreams for an in-app update notification.
 </Info>
+
+**Fixed: Labs templates — metadata.inputs schema**
+
+AIOStreams renamed fields in the `metadata.inputs` schema — `key` → `id` and `label` → `name`. All 4 Labs templates were failing to load with 8 errors each. Fixed across 4K Apex Labs, Stream Labs, Essential Labs, and 4K Essential Labs.
+
+**Fixed: Nightly Samsung RU7100 4K — unique template ID**
+
+The Nightly Samsung RU7100 4K shared `id: brevity.core-nexus-samsung-tv-4k` with the stable Samsung TV 4K template. AIOStreams uses the ID for update tracking — the collision caused update notifications and version state to bleed between the two. Changed to `brevity.core-nexus-samsung-ru7100-4k`.
+
+---
+
+**Fixed: Regex compatibility — fortheweak whitelist**
 
 **Fixed: Regex compatibility — fortheweak whitelist**
 

--- a/docs/nightly-and-labs.mdx
+++ b/docs/nightly-and-labs.mdx
@@ -7,13 +7,13 @@ description: "Experimental templates testing new features before stable promotio
 
 | | Nightly | Labs |
 |---|---|---|
-| Stability | Stable for daily use | Experimental — may break |
+| Stability | Stable for daily use | Experimental — may fail to load |
 | Purpose | Finalising before stable promotion | Testing new PSE/SEL architecture |
 | Update frequency | Periodic | Frequent |
 
 ## Nightly Templates
 
-### Apple TV 4K (v0.1.1)
+### Apple TV 4K (v0.1.5)
 
 Device profile for Apple TV 4K (3rd gen) via Infuse. DV Profile 5/8 prioritised, DD+ Atmos, AV1 hard-excluded (no A15 hardware decoder).
 
@@ -28,7 +28,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Samsung RU7100 4K (v0.2.6)
+### Samsung RU7100 4K (v0.2.10)
 
 Samsung RU7100 (2019) 4K — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV. Full APEX IQR PSE stack. More aggressive filtering than the stable Samsung TV template.
 
@@ -46,14 +46,18 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 ## Labs Templates
 
 <Warning>
-  Labs templates are experimental. They may change frequently and are not guaranteed to be stable. Use them to give feedback on new ideas.
+  Labs templates are experimental and may fail to load. Import errors are expected — reporting them is the point. Do not use Labs as your main template.
 </Warning>
 
-### 4K Apex Labs (v0.5.3)
+<Info>
+  **Calling for import testers.** Labs templates need real-world import data to establish what errors AIOStreams is generating. Try importing any Labs template, screenshot or copy the exact error text, and drop it in the community thread. Host, template name, and error message are all useful.
+</Info>
+
+### 4K Apex Labs (v0.8.4)
 
 Experimental Apex variant testing:
 - `dynamicAddonFetching` exit conditions (exit at 5+ cached 4K or 6s)
-- Template directives for per-scraper toggles
+- Template directives for per-scraper toggles configurable at import
 - Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`
 
 <CardGroup cols={2}>
@@ -67,7 +71,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Stream Labs (v0.3.2)
+### Stream Labs (v0.6.4)
 
 1080p variant of 4K Apex Labs. Same hybrid architecture, exit at 5+ cached 1080p or 5s.
 
@@ -82,7 +86,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Essential Labs (v0.1.1)
+### Essential Labs (v0.1.5)
 
 TorBox debrid-only 1080p — no external scrapers. Library + TorBox Search only. Tests template directives for TorBox Search toggle and exit thresholds. Fast and lightweight.
 
@@ -97,7 +101,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### 4K Essential Labs (v0.1.1)
+### 4K Essential Labs (v0.1.5)
 
 Same as Essential Labs but 4K. TorBox debrid-only, no external scrapers.
 
@@ -114,9 +118,9 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ## How to Give Feedback
 
-Post in the Nightly or Labs thread in the community. Include:
+Post in the community thread. Include:
 
 - Template name and version
-- Title that triggered the issue
-- What you expected vs what happened
-- AIOStreams version and host type (self-hosted / elfhosted / etc.)
+- Host type (elfhosted / fortheweak / self-hosted)
+- Exact error text or screenshot
+- Whether it loaded partially or not at all


### PR DESCRIPTION
**nightly-and-labs.mdx**
- All version numbers updated to current (Apple TV 0.1.1→0.1.5, Samsung 0.2.6→0.2.10, Labs: Apex 0.5.3→0.8.4, Stream 0.3.2→0.6.4, Essential/4K Essential 0.1.1→0.1.5)
- Labs stability note updated: "may fail to load" instead of "may break"
- Labs section: added import tester call to action Info block

**changelog.mdx**
- Added Labs metadata.inputs schema fix entry (key→id, label→name)
- Added Nightly Samsung RU7100 unique ID fix entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_