### PR TITLE
docs: add mintlify redirect notice to all READMEs

### DIFF
--- a/Community-Templates/README.md
+++ b/Community-Templates/README.md
@@ -8,6 +8,11 @@
   </a>
 </p>
 
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
 # 🤝 Community Builds
 
 A curated collection of community-contributed AIOStreams templates and formatters. Each build is authored and maintained by its contributor — offering a different aesthetic, approach, or device target from the official Core Nexus suite.

--- a/Formatters/README.md
+++ b/Formatters/README.md
@@ -8,6 +8,11 @@
   </a>
 </p>
 
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
 # Core Formatters
 
 Custom stream display layouts for AIOStreams. Formatters control how every stream appears in Stremio and WuPlay — the title line, the metadata rows, cache status, audio tags, release group, and everything else you see when picking a stream.

--- a/Guides/README.md
+++ b/Guides/README.md
@@ -8,6 +8,11 @@
   </a>
 </p>
 
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
 # 📖 Core Builds by Brevity — Complete Guide
 
 Everything you need to set up, customise, and maintain your build.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/brevityA/Core-Builds/validate.yml?style=for-the-badge&label=BUILD&logo=github&logoColor=white&labelColor=1a1f27" alt="Build Status"/>
   </a>
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://img.shields.io/badge/RELEASE-v2.8.3-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
+    <img src="https://img.shields.io/badge/RELEASE-v2.9.0-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
   </a>
 </p>
 
@@ -41,6 +41,11 @@
   <a href="https://torbox.app/subscription?referral=d1ccddb0-f094-45ca-b52b-942a2635855e">
     <img src="https://img.shields.io/badge/TorBox-Get_15_days_free_with_code_d1ccddb0-f97316?style=for-the-badge&logo=thunder&logoColor=white&labelColor=1a1f27" alt="TorBox Referral"/>
   </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
 </p>
 
 > 🚀 **These templates are built for [TorBox](https://torbox.app/subscription?referral=d1ccddb0-f094-45ca-b52b-942a2635855e).** Use the referral link above and get **up to 84 extra days free** depending on the plan — and support this project.

--- a/Templates/Torbox/Anime/README.md
+++ b/Templates/Torbox/Anime/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # Anime Templates
 
 Anime-optimised templates with SeaDex best-release enforcement, AnimeTosho scraping, and FLAC/AAC audio priority. Full documentation is in the [Template Directory](../README.md).

--- a/Templates/Torbox/Essential/README.md
+++ b/Templates/Torbox/Essential/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # TorBox Essential Templates
 
 Templates in this folder require a **TorBox Essential** subscription. Full documentation is in the [Template Directory](../README.md).

--- a/Templates/Torbox/Flash/README.md
+++ b/Templates/Torbox/Flash/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # Flash Templates
 
 Cached-only instant play templates. `excludeUncached: true` — only streams already cached in TorBox appear. Full documentation is in the [Template Directory](../README.md).

--- a/Templates/Torbox/Hybrid/README.md
+++ b/Templates/Torbox/Hybrid/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # Hybrid Templates
 
 TorBox Pro + NZBGeek dual-source templates. Requires both a TorBox Pro subscription and an NZBGeek API key. Full documentation is in the [Template Directory](../README.md).

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -8,11 +8,16 @@
   </a>
 </p>
 
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
 # Core Builds — Template Directory
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v2.8.4** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v2.9.0** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
 > 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/wiki) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 

--- a/Templates/Torbox/Single/README.md
+++ b/Templates/Torbox/Single/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # TorBox Pro Templates
 
 Templates in this folder require a **TorBox Pro** subscription. Full documentation is in the [Template Directory](../README.md).

--- a/Templates/Torbox/Speed/EasyNews/README.md
+++ b/Templates/Torbox/Speed/EasyNews/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # Speed Templates (EasyNews)
 
 Fast cached-play templates combining TorBox Essential with EasyNews for dual-source instant results. Speed EasyNews requires only an EasyNews subscription (no TorBox needed). Full documentation is in the [Template Directory](../../README.md).

--- a/Templates/Torbox/Speed/TorBox/README.md
+++ b/Templates/Torbox/Speed/TorBox/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+  <a href="https://core-builds.mintlify.app/template-directory">
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+  </a>
+</p>
+
+<p align="center">
+  Template directory, import links, and full documentation have moved to<br/>
+  <a href="https://core-builds.mintlify.app/template-directory"><b>core-builds.mintlify.app</b></a>
+</p>
+
+
 # Speed Templates (TorBox Only)
 
 Fast cached-play templates for TorBox Essential subscribers. No EasyNews required. Full documentation is in the [Template Directory](../../README.md).

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,11 +7,23 @@ Full history: [CHANGELOG.md](https://github.com/brevityA/Core-Builds/blob/main/C
 
 ---
 
-## v2.9.0 — 2026-06-19
+## v2.9.0 (patch) — 2026-06-19
 
 <Info>
   **Latest release.** If you already have a template imported, check AIOStreams for an in-app update notification.
 </Info>
+
+**Fixed: Labs templates — metadata.inputs schema**
+
+AIOStreams renamed fields in the `metadata.inputs` schema — `key` → `id` and `label` → `name`. All 4 Labs templates were failing to load with 8 errors each. Fixed across 4K Apex Labs, Stream Labs, Essential Labs, and 4K Essential Labs.
+
+**Fixed: Nightly Samsung RU7100 4K — unique template ID**
+
+The Nightly Samsung RU7100 4K shared `id: brevity.core-nexus-samsung-tv-4k` with the stable Samsung TV 4K template. AIOStreams uses the ID for update tracking — the collision caused update notifications and version state to bleed between the two. Changed to `brevity.core-nexus-samsung-ru7100-4k`.
+
+---
+
+**Fixed: Regex compatibility — fortheweak whitelist**
 
 **Fixed: Regex compatibility — fortheweak whitelist**
 

--- a/docs/nightly-and-labs.mdx
+++ b/docs/nightly-and-labs.mdx
@@ -7,13 +7,13 @@ description: "Experimental templates testing new features before stable promotio
 
 | | Nightly | Labs |
 |---|---|---|
-| Stability | Stable for daily use | Experimental — may break |
+| Stability | Stable for daily use | Experimental — may fail to load |
 | Purpose | Finalising before stable promotion | Testing new PSE/SEL architecture |
 | Update frequency | Periodic | Frequent |
 
 ## Nightly Templates
 
-### Apple TV 4K (v0.1.1)
+### Apple TV 4K (v0.1.5)
 
 Device profile for Apple TV 4K (3rd gen) via Infuse. DV Profile 5/8 prioritised, DD+ Atmos, AV1 hard-excluded (no A15 hardware decoder).
 
@@ -28,7 +28,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Samsung RU7100 4K (v0.2.6)
+### Samsung RU7100 4K (v0.2.10)
 
 Samsung RU7100 (2019) 4K — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV. Full APEX IQR PSE stack. More aggressive filtering than the stable Samsung TV template.
 
@@ -46,14 +46,18 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 ## Labs Templates
 
 <Warning>
-  Labs templates are experimental. They may change frequently and are not guaranteed to be stable. Use them to give feedback on new ideas.
+  Labs templates are experimental and may fail to load. Import errors are expected — reporting them is the point. Do not use Labs as your main template.
 </Warning>
 
-### 4K Apex Labs (v0.5.3)
+<Info>
+  **Calling for import testers.** Labs templates need real-world import data to establish what errors AIOStreams is generating. Try importing any Labs template, screenshot or copy the exact error text, and drop it in the community thread. Host, template name, and error message are all useful.
+</Info>
+
+### 4K Apex Labs (v0.8.4)
 
 Experimental Apex variant testing:
 - `dynamicAddonFetching` exit conditions (exit at 5+ cached 4K or 6s)
-- Template directives for per-scraper toggles
+- Template directives for per-scraper toggles configurable at import
 - Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`
 
 <CardGroup cols={2}>
@@ -67,7 +71,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Stream Labs (v0.3.2)
+### Stream Labs (v0.6.4)
 
 1080p variant of 4K Apex Labs. Same hybrid architecture, exit at 5+ cached 1080p or 5s.
 
@@ -82,7 +86,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Essential Labs (v0.1.1)
+### Essential Labs (v0.1.5)
 
 TorBox debrid-only 1080p — no external scrapers. Library + TorBox Search only. Tests template directives for TorBox Search toggle and exit thresholds. Fast and lightweight.
 
@@ -97,7 +101,7 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### 4K Essential Labs (v0.1.1)
+### 4K Essential Labs (v0.1.5)
 
 Same as Essential Labs but 4K. TorBox debrid-only, no external scrapers.
 
@@ -114,9 +118,9 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ## How to Give Feedback
 
-Post in the Nightly or Labs thread in the community. Include:
+Post in the community thread. Include:
 
 - Template name and version
-- Title that triggered the issue
-- What you expected vs what happened
-- AIOStreams version and host type (self-hosted / elfhosted / etc.)
+- Host type (elfhosted / fortheweak / self-hosted)
+- Exact error text or screenshot
+- Whether it loaded partially or not at all


### PR DESCRIPTION
Adds a consistent notice under the docs badge on every README directing users to core-builds.mintlify.app.

**Changed:**
- `README.md` — notice added, version badge v2.8.3 → v2.9.0
- `Templates/Torbox/README.md` — notice added, version v2.8.4 → v2.9.0
- `Templates/Torbox/Single/README.md` — docs badge + notice added
- `Templates/Torbox/Essential/README.md` — docs badge + notice added
- `Templates/Torbox/Flash/README.md` — docs badge + notice added
- `Templates/Torbox/Hybrid/README.md` — docs badge + notice added
- `Templates/Torbox/Speed/TorBox/README.md` — docs badge + notice added
- `Templates/Torbox/Speed/EasyNews/README.md` — docs badge + notice added
- `Templates/Torbox/Anime/README.md` — docs badge + notice added
- `Formatters/README.md` — notice added under existing badge
- `Guides/README.md` — notice added under existing badge
- `Community-Templates/README.md` — notice added under existing badge

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_