### PR TITLE
docs: expand formatters (3→16), device profiles, fix importing.mdx advice

### DIFF
--- a/docs/device-profiles.mdx
+++ b/docs/device-profiles.mdx
@@ -1,13 +1,17 @@
 ---
 title: "Device Profiles"
-description: "Template recommendations and codec constraints for Samsung TV, Apple TV, Fire Stick, and low-RAM devices."
+description: "Template recommendations and codec constraints for Samsung TV, Apple TV, Fire Stick, Android TV, and Chromecast."
+---
+
+Device profiles document which codecs and HDR formats each platform can decode, and which Core Builds templates are tuned for them. Using the wrong template on a device that lacks hardware decoders causes silent playback failures — the stream loads but transcodes, stutters, or refuses to play.
+
 ---
 
 ## Samsung TV (Tizen 2018–2022)
 
-**Models:** RU7100, RU8000, NU8000, Q60 and similar
+**Models:** RU7100, RU8000, NU8000, Q60, and similar Tizen models from that period
 
-**Recommended templates:** [Samsung TV](/template-directory#torbox-pro) (1080p) or [Samsung TV 4K](/template-directory#torbox-pro)
+**Recommended templates:** [Samsung TV](/template-directory#device) (1080p) or [Samsung TV 4K](/template-directory#device)
 
 | Feature | Support |
 |---|---|
@@ -19,59 +23,112 @@ description: "Template recommendations and codec constraints for Samsung TV, App
 | HDR10+ | Supported (preferred) |
 | HDR10 | Supported |
 | HLG | Supported |
-| TrueHD / DTS:X / DTS-HD MA / FLAC | Hard-excluded — Tizen cannot pass these through |
-| DD+ Atmos | Top preferred audio |
+| TrueHD / DTS:X / DTS-HD MA / FLAC | Hard-excluded — Tizen cannot pass these through without an AVR |
+| DD+ Atmos | Preferred — native decode |
 | AAC | Native |
 
+<Warning>
+  Samsung Tizen TVs do not have a hardware AV1 decoder. Streams encoded in AV1 will either refuse to play or trigger software transcoding. Both Samsung templates hard-exclude AV1.
+</Warning>
+
 <Info>
-  **Nightly option:** Samsung RU7100 4K (Nightly) — full APEX IQR PSE stack, FLAC/AAC native audio, tuned specifically for the RU7100 (2019).
+  **Nightly option:** [Samsung RU7100 4K (Nightly)](/nightly-and-labs#nightly-samsung-ru7100-4k) — full APEX IQR PSE stack, FLAC/AAC native audio, tuned specifically for the RU7100 (2019) and compatible models. Imports a pre-release template with more aggressive quality filtering.
 </Info>
+
+### Audio passthrough
+
+Samsung templates exclude lossless audio (`TrueHD`, `DTS-HD MA`, `DTS:X`, `FLAC`) by default because Tizen TVs cannot decode them natively — they require HDMI ARC/eARC passthrough to a compatible AV receiver. If you have an AVR and want lossless audio, remove those tags from `excludedAudioTags` in AIOStreams settings after importing.
+
+### Dolby Vision
+
+The DV-Only Kill ESE is enabled by default on Samsung templates. It removes streams where DV is the only signal layer (no HDR10 fallback), which would display as SDR on non-DV screens. Dual-layer streams (DV + HDR10 base) are kept.
 
 ---
 
-## Apple TV 4K (3rd gen, A15/A17)
+## Apple TV 4K (A15 / A17)
 
-**Recommended template:** [Apple TV 4K (Nightly)](/nightly-and-labs) via Infuse
+**Models:** Apple TV 4K 3rd generation (2022) and later
+
+**Recommended template:** [Apple TV 4K (Nightly)](/nightly-and-labs#nightly-apple-tv-4k) via Infuse
 
 | Feature | Support |
 |---|---|
-| Dolby Vision | Profile 5 and 8 — prioritised |
+| Dolby Vision | Profile 5 and 8 — natively supported, prioritised |
+| Dolby Vision Profile 7 | Not supported on A15 |
 | AV1 | No hardware decoder on A15 — hard-excluded |
 | HEVC (H.265) | Hardware decode |
 | AVC (H.264) | Hardware decode |
 | HDR10+ | 3rd gen exclusive |
 | HDR10 / HLG | Supported |
 | DD+ Atmos | Native preferred audio |
-| TrueHD | Passthrough only (requires AVR) |
+| TrueHD | Passthrough only — requires an AVR via eARC |
+
+<Info>
+  The Apple TV 4K Nightly template prioritises DV Profile 5/8 — the profiles natively decoded by the A15 chip. Use Infuse for the best DV playback experience; the native Apple TV app handles DV differently depending on the content source.
+</Info>
+
+<Warning>
+  The A15 chip has no hardware AV1 decoder. Keep AV1 in `excludedEncodes` for Apple TV. If you switch to a generic template, add AV1 to the exclusions manually.
+</Warning>
 
 ---
 
-## Fire Stick (4K / 4K Max)
+## Fire Stick
+
+**Models:** Fire Stick 4K, Fire Stick 4K Max, Fire Stick (standard HD)
 
 **Recommended template:** [Stream (Fire Stick)](/template-directory#torbox-pro) or Stream (Fire Stick) Lite
 
-| Feature | Support |
-|---|---|
-| 4K | Fire Stick 4K / 4K Max only |
-| Dolby Vision | Fire Stick 4K Max only |
-| HEVC | Supported |
-| AV1 | Fire Stick 4K Max only |
-| RAM | Low — Lite variant recommended if buffering |
+| Feature | Fire Stick (HD) | Fire Stick 4K | Fire Stick 4K Max |
+|---|---|---|---|
+| 4K | No | Yes | Yes |
+| AV1 | No | No | Yes |
+| Dolby Vision | No | No | Yes |
+| HDR10+ | No | Yes | Yes |
+| HEVC | Yes | Yes | Yes |
+| AVC | Yes | Yes | Yes |
+| RAM | 1 GB | 1.5 GB | 2 GB |
 
 <Tip>
-  Fire Stick 4K Max supports AV1; Fire Stick 4K does not. Use SDR or HDR10 priority if buffering is an issue.
+  Fire Stick 4K Max supports AV1 and Dolby Vision. Fire Stick 4K supports neither. The Stream (Fire Stick) template hard-excludes both for broadest compatibility — if you have a 4K Max and want AV1/DV, use a standard Stream template and add DV/AV1 to your preferred encodes manually.
 </Tip>
+
+The Fire Stick template also hard-excludes HDR10+, lossless audio, and high-bitrate REMUX streams — all formats that can exceed the Fire Stick's RAM ceiling and cause buffering on shared connections.
+
+### Buffering and RAM
+
+On Fire Stick (HD) or older 4K units, use the **Lite variant** if buffering occurs — it removes quality gates to allow more results through and lets the device pick from a wider bitrate range. Setting a max file size in AIOStreams can also help (e.g. 20 GB cap).
+
+---
+
+## Android TV / Google TV
+
+No dedicated Core Builds template — Android TV (Shield, Chromecast with Google TV, Sony/Philips/TCL running Google TV) typically supports the full codec stack:
+
+| Feature | Support |
+|---|---|
+| AV1 | Yes (Nvidia Shield, modern Google TV devices) |
+| Dolby Vision | Device-dependent (Shield does not; Chromecast w/Google TV does) |
+| HDR10+ | Most recent devices |
+| HEVC / AVC | Universal |
+| TrueHD / DTS-HD MA | Passthrough via HDMI ARC/eARC |
+
+**Recommended:** Use the standard **4K Apex** or **Stream** template (no device restrictions). If you have an older Shield Pro (2017) without DV, enable the DV-Only Kill ESE in AIOStreams settings.
+
+<Info>
+  Chromecast with Google TV (4K) supports Dolby Vision natively. The standard 4K Apex template will serve DV streams correctly on this device without any changes.
+</Info>
 
 ---
 
 ## Low-RAM / Budget Devices
 
-Any device with 2 GB RAM or less (older Fire Sticks, budget Android TV boxes):
+Any device with 2 GB RAM or less (older Fire Sticks, budget Android TV boxes, entry-level smart TVs):
 
 - Use the **Lite variant** of any template — removes quality gates to maximise result count
 - Enable **Flash** if you only need instant cached results
-- Disable HDR to reduce stream sizes
-- Set a bitrate cap via AIOStreams settings if buffering persists
+- Avoid REMUX — set `maxResultsPerQuality` or a file size cap in AIOStreams to prevent 60+ GB BluRay REMUXes from appearing
+- Use **Stream (Fire Stick)** for constrained Fire Stick hardware
 
 ---
 
@@ -79,12 +136,18 @@ Any device with 2 GB RAM or less (older Fire Sticks, budget Android TV boxes):
 
 <AccordionGroup>
   <Accordion title="DV-Only Kill ESE">
-    Enabled by default on Samsung templates. Removes streams where Dolby Vision is the only signal layer (no HDR10 fallback). Safe to disable if your device supports DV natively.
+    Enabled by default on Samsung templates. Removes streams where Dolby Vision is the only signal layer (no HDR10 fallback). Safe to disable if your device supports DV natively (Fire Stick 4K Max, Chromecast with Google TV, Apple TV).
   </Accordion>
   <Accordion title="Audio exclusions on Samsung">
-    Samsung templates hard-exclude TrueHD / DTS:X / DTS-HD MA / FLAC. Remove these exclusions if your device passes audio through to an AVR that supports them.
+    Samsung templates hard-exclude TrueHD, DTS:X, DTS-HD MA, and FLAC. Remove these from `excludedAudioTags` if your TV connects to an AVR via eARC and you want lossless passthrough.
   </Accordion>
-  <Accordion title="AV1 on Samsung and Apple TV">
-    Excluded on both. Keep AV1 in `excludedEncodes` for these devices. Enable it for Fire Stick 4K Max or modern Android TV.
+  <Accordion title="AV1 across devices">
+    Excluded on Samsung and Apple TV (A15). Keep excluded. Enable on: Nvidia Shield (2019+), Chromecast with Google TV (2023 4K), Fire Stick 4K Max, modern Android TV boxes.
+  </Accordion>
+  <Accordion title="Checking what codec a stream uses">
+    Your formatter's description lines show the codec (HEVC, AVC, AV1) and visual tag (DV, HDR10+). If a stream fails to play, check the codec shown in the formatter — if it's AV1 on a Samsung or Apple TV, that stream shouldn't have passed through and suggests you're on a non-device template.
+  </Accordion>
+  <Accordion title="Switching from a generic to a device template">
+    Re-import the device-specific template URL. AIOStreams will merge the new template over your existing API keys and addon config. The key changes are in `excludedEncodes`, `excludedVisualTags`, and `excludedAudioTags` — the device templates add hard exclusions that the generic templates leave open.
   </Accordion>
 </AccordionGroup>

--- a/docs/formatters.mdx
+++ b/docs/formatters.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Formatters"
-description: "Stream display layouts — how to install and customise them."
+description: "Stream display layouts — all 16 formatters with import URLs and comparisons."
 ---
 
 <Frame>
@@ -11,7 +11,7 @@ description: "Stream display layouts — how to install and customise them."
   />
 </Frame>
 
-Formatters control how streams are displayed in Stremio — the text shown for each result (title, quality, size, audio, etc.). All Core Builds templates ship with the **Core Syntax** formatter pre-loaded.
+Formatters control how streams are displayed in Stremio — the text shown for each result (title, quality, size, audio, cache status, etc.). All Core Builds templates ship with **Core Nexus Elite** pre-loaded.
 
 ## How to Import a Formatter
 
@@ -20,13 +20,13 @@ Formatters control how streams are displayed in Stremio — the text shown for e
     In AIOStreams, go to the **Formatter** tab.
   </Step>
   <Step title="Click Import">
-    Click the **Import** icon in the top right corner.
+    Click the **Import** icon in the top-right corner.
   </Step>
   <Step title="Paste the URL">
-    Copy the formatter URL below, paste it into the import dialog, and click **Load**.
+    Copy a formatter URL from below, paste it into the import dialog, and click **Load**.
   </Step>
   <Step title="Save">
-    Click **Save** to apply.
+    Click **Save** to apply. No Stremio reinstall needed.
   </Step>
 </Steps>
 
@@ -36,9 +36,34 @@ Formatters control how streams are displayed in Stremio — the text shown for e
 
 ---
 
-## Apex v2
+## Quick Comparison
 
-4K-focused layout. Visual tags (DV, HDR10+, Atmos) front and centre. Designed for the 4K Apex template but works with any.
+| Formatter | Style | Key feature |
+|---|---|---|
+| **Core Nexus Apex v2** ⭐ | Emoji circles | Score number, bitrate-first layout, per-language subtitle flags |
+| **Core Nexus Apex** | Emoji circles | Audio codec in name, two-tier score badge (ELITE / QUALITY) |
+| **Core Nexus Elite** | Emoji circles | 🟣/🔵/🟢/⚫ resolution circles · INSTANT/UNCACHED · PREMIER |
+| **Core Nexus Sigma** | `「 」` brackets | Title-first name, smallcaps, premium editorial feel |
+| **Core Nexus Minimal** | ⚡/⏳ indicator | 3-line description, TV/Apple TV optimised |
+| **Core Nexus TV** | UPPER CASE | 10-foot UI — 🔴/🔵/🟢 circles, projector and smart TV |
+| **Core Nexus Uniform** | Emoji circles | Legacy — replaced by Elite |
+| **Core Syntax** | `「 」` brackets | Original formatter, ✦/✧ cache indicator, ◈ ELITE badge |
+| **Core Syntax V3** | `「 」` brackets | JBL Spatial, ★ Premium badge, IMAX/edition flags |
+| **Omni Diamond v2.2.0** | Dense emoji | Two-line name, maximum metadata density |
+| **Core Zenith Diamond** | 🔹/🔸 dots | Encode + audio + PREMIER in name line |
+| **Core Zenith Auburn Tiger** | 🔸 orange | Warm orange/navy, 🐅 release prefix |
+| **Midnight Slate** | ASCII symbols | No emoji — for clients that render emoji poorly |
+| **Nexus Prime** | Emoji | SeaDex/BEST detection, 📅 age format, subtitle listing |
+| **RB3 Clean v4** | Bold unicode | Three-line name with bold resolution + italic quality source |
+| **RB3 Formatter** | 🔸/🔹 smallcaps | Auburn Tiger paired, JBL Spatial, PREMIER tagging |
+
+---
+
+## Official Formatters
+
+### Core Nexus Apex v2 ⭐ Recommended
+
+Score number in the name line (💎 ELITE ✦ 94 instead of a label), bitrate before visual tags in line 2, per-language subtitle flags (📝 🇬🇧 🇫🇷) replacing the binary SUB badge. Best pick for 4K Apex users.
 
 ```
 https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-apex-v2-formatter.json
@@ -46,9 +71,19 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatter
 
 ---
 
-## Elite
+### Core Nexus Apex
 
-Minimal and quality-first. Clean one-liner per stream with the essentials only.
+Adds audio codec to the name line, two-tier score badge (💎 ELITE ≥75 · ✦ QUALITY ≥50), and season pack flag before size.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-apex-formatter.json
+```
+
+---
+
+### Core Nexus Elite (bundled in all templates)
+
+High-contrast. Colour-coded resolution circles (🟣 4K · 🔵 1080P · 🟢 720P · ⚫ 480P), HDR/DV in the name line, INSTANT/UNCACHED badge, PREMIER release group detection. Ships pre-loaded in every Core Builds template.
 
 ```
 https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-elite-formatter.json
@@ -56,12 +91,134 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatter
 
 ---
 
-## Nexus Prime
+### Core Nexus Sigma
 
-Full detail — codec, HDR, audio, size, seeders, and stream expression match score. Best for power users who want to see everything.
+Typographic `「 」` / `『 』` bracket system. Title-first name line, smallcaps throughout — premium editorial feel for users who prefer a clean typographic layout over emoji.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-sigma-formatter.json
+```
+
+---
+
+### Core Nexus Minimal
+
+3-line description, ⚡/⏳ cache indicator in name, first audio codec only. Built for TV, Apple TV, and small screens where horizontal space is limited.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-minimal-formatter.json
+```
+
+---
+
+### Core Nexus TV
+
+10-foot UI optimised. UPPER CASE throughout (readable across the room), coloured resolution circles (🔴 4K · 🔵 1080P · 🟢 720P), 4-line description with clear section icons (🎬 video · 🔊 audio · 🔌 type/meta). Designed for projectors, smart TVs, and large-screen setups.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-tv-formatter.json
+```
+
+---
+
+### Core Nexus Uniform
+
+Legacy formatter — replaced by Core Nexus Elite. Kept for users who prefer the older layout.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-nexus-uniform-formatter.json
+```
+
+---
+
+### Core Syntax
+
+Original Core Builds formatter. `✦`/`✧` cache indicator in name, `「 」` bracket metadata system, ◈ ELITE score badge, full release group and edition tagging.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-syntax-formatter.json
+```
+
+---
+
+### Core Syntax V3
+
+Personal build variant with extra features: JBL Spatial audio detection (`🔊 JBL Sᴘᴀᴛɪᴀʟ` for DD+/EAC3), ★ Premium release group badge, IMAX/Hybrid/edition flags, indexer in release line.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-syntax-v3.json
+```
+
+---
+
+### Omni Diamond v2.2.0
+
+Maximum metadata density. Two-line name (visual tags on the second line), edition/network/remastered flags, JBL Spatial detection, full language + release group + indexer in description. Best for users who want to see everything at a glance.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/omni-diamond-v2.2.0.json
+```
+
+---
+
+### Core Zenith Diamond
+
+🔹/🔸 dot separator style. Info-dense name line with encode, audio, channels, and PREMIER flag. 4-line description with bitrate, seeders, video, language, and release group.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-zenith-diamond.json
+```
+
+---
+
+### Core Zenith Auburn Tiger Edition
+
+Auburn Tiger edition of Core Zenith Diamond. Orange 🟠 4K badge, 🐅 release line prefix, amber colour palette — designed to pair with the RB3 Auburn Tiger template.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/core-zenith-auburn-tiger-edition.json
+```
+
+---
+
+### Midnight Slate
+
+Dark minimal. `◼`/`⬤`/`▶`/`◆` ASCII symbols instead of emoji. Clean typographic lines — best for clients that render emoji poorly or for a no-clutter look.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/midnight-slate.json
+```
+
+---
+
+### Nexus Prime
+
+SeaDex/BEST detection, 📅 age format, subtitle emoji track listing, and folder size support. An early Core Builds formatter — similar layout to Uniform with additional metadata fields.
 
 ```
 https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/nexus-prime-formatter.json
+```
+
+---
+
+## Community Formatters
+
+### RB3 Clean v4
+
+Service-first layout by **RB3**. Three name lines — service + ⚡/⏳ cache status · bold unicode resolution (`𝟰𝗞 𝗨𝗛𝗗` · `𝟭𝟬𝟴𝟬𝗽`) · italic unicode source (`𝘉𝘭𝘶-𝘳𝘢𝘺 𝘙𝘦𝘮𝘶𝘹`). Up to 6 structured `⁞`-separated description rows. Highest metadata density of any formatter.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/rb3-clean-v4-formatter.json
+```
+
+---
+
+### RB3 Formatter
+
+Original RB3 community formatter. Pairs with the Auburn Tiger template — orange/navy resolution badges, JBL Spatial audio detection, PREMIER release group tagging.
+
+```
+https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatters/rb3-formatter.json
 ```
 
 ---
@@ -85,13 +242,14 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Formatter
 | `stream.seMatched` | Name of the stream expression that matched |
 | `stream.nSeScore` | Normalised SEL score (0–1) |
 | `stream.nRegexScore` | Normalised regex score (0–1) |
+| `stream.dubbed` | Dubbed audio flag |
+| `stream.subbed` | Subtitles present |
+| `stream.uSubtitleEmojis` | Per-language subtitle flag emojis |
 
-## Customising a Formatter
+## Notes
 
-Formatters are JSON files. To customise:
-
-1. Download the formatter JSON from GitHub
-2. Edit the `name` and `description` template strings
-3. Re-import via the Formatter import button
-
-See the [Formatter Guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/FORMATTER_GUIDE.md) in the repo for the full field and modifier reference.
+- Formatters are display-only — they don't affect which streams appear, filtering, or sorting
+- All formatters use `id: "tamtaro"` — this is the correct formatter type for AIOStreams
+- Score badges (ELITE / QUALITY) only appear when a stream has a ranked regex or stream expression score
+- `{tools.newLine}` must be used for line breaks in the description — literal newlines cause the formatter to be silently discarded on import
+- Compatible with AIOStreams v2.4.6+

--- a/docs/importing.mdx
+++ b/docs/importing.mdx
@@ -72,13 +72,13 @@ Re-import the same URL. AIOStreams will load the latest version and merge it ove
 
 | | Hosted (elfhosted, fortheweak.cloud) | Self-hosted |
 |---|---|---|
-| Inline regex | Blocked unless trusted user | Works — set `REGEX_FILTER_ACCESS=all` |
-| Synced regex URLs | Blocked (GitHub raw URLs forbidden) | Works |
+| Inline regex | Validated against host allowlist | Works — all patterns allowed |
+| Synced regex URLs | Whitelisted URLs only | All URLs allowed |
 | Performance | Shared resources | Dedicated |
 
-<Warning>
-  If you see a "Forbidden URL" or "regex blocked" error on import, you're on a public instance that blocks raw GitHub URLs. Contact your host to add your UUID to `TRUSTED_UUIDS`, or self-host AIOStreams with `REGEX_FILTER_ACCESS=all`.
-</Warning>
+<Info>
+  As of v2.9.0, all Core Builds templates are verified against both elfhosted and fortheweak allowlists. If you see a "regex not allowed" error after importing, re-import the latest template version — older templates may contain pattern strings that predate the v2.9.0 allowlist sync.
+</Info>
 
 ## Stremio vs WuPlay
 


### PR DESCRIPTION
## Summary

- **formatters.mdx** — expanded from 3 formatters to all 16, with import URLs, descriptions, and a quick comparison table. Added community formatter section (RB3 Clean v4, RB3 Formatter).
- **device-profiles.mdx** — major expansion: added Android TV/Google TV section, Fire Stick HD/4K/4K Max model matrix, Apple TV DV Profile 5/8 detail, Samsung audio passthrough explanation, new accordion tips (codec checking, template switching).
- **importing.mdx** — fixed the Hosted vs Self-Hosted section. The Warning block incorrectly told users to request TRUSTED_UUIDS or set REGEX_FILTER_ACCESS=all. Replaced with correct advice: re-import v2.9.0, which is verified against both elfhosted and fortheweak allowlists.

## Test plan

- [ ] All 16 formatter URLs resolve to valid JSON files in the repo
- [ ] Device profiles covers Samsung, Apple TV, Fire Stick, Android TV, low-RAM
- [ ] importing.mdx no longer mentions TRUSTED_UUIDS or REGEX_FILTER_ACCESS as user-facing fixes
- [ ] No broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_