### PR TITLE
docs: audit fixes — stale counts, deprecated Speed+, broken anchors

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -25,8 +25,6 @@ The Nightly Samsung RU7100 4K shared `id: brevity.core-nexus-samsung-tv-4k` with
 
 **Fixed: Regex compatibility — fortheweak whitelist**
 
-**Fixed: Regex compatibility — fortheweak whitelist**
-
 fortheweak's AIOStreams instance uses a stricter regex whitelist than elfhosted's. Eleven ranked and three excluded inline pattern entries were rejected on import. Removed from all 33 non-Anime templates:
 
 - **Ranked removed:** `Radarr Web T1`, `Sonarr Web T1`, `Radarr Bad Dual Groups`, `Sonarr Bad Dual Groups`, `hallowed`, `LQ (Radarr)`, `LQ (Radarr) [B]`, `LQ (Sonarr)`, `LQ (Sonarr) [B]`, `LQ (Release Title) (Radarr)`, `LQ (Release Title) (Sonarr)`

--- a/docs/easynews-setup.mdx
+++ b/docs/easynews-setup.mdx
@@ -3,15 +3,14 @@ title: "EasyNews Setup"
 description: "Setting up EasyNews with Core Builds — standalone and TorBox+ variants."
 ---
 
-EasyNews is a Usenet provider with its own search interface — no separate indexer (like NZBGeek) required. Core Builds supports two EasyNews use cases: **standalone** (EasyNews only, no TorBox) and **Speed+** (TorBox Essential + EasyNews combined).
+EasyNews is a Usenet provider with its own search interface — no separate indexer (like NZBGeek) required. Core Builds supports two EasyNews use cases: **standalone** (EasyNews only, no TorBox) and **Speed 4K+** (TorBox Essential + EasyNews combined).
 
 ## Which Template?
 
 | Template | Services needed | Best for |
 |---|---|---|
 | **Speed EasyNews** | EasyNews only | EasyNews subscribers without TorBox |
-| **Speed 4K+** | TorBox Essential + EasyNews | Essential subscribers who want EasyNews as a second source |
-| **Speed+** | TorBox Essential + EasyNews | Same as 4K+ but 1080p |
+| **Speed 4K+** | TorBox Essential + EasyNews | Essential subscribers who want a second EasyNews 4K source |
 
 ---
 
@@ -29,8 +28,8 @@ EasyNews is a Usenet provider with its own search interface — no separate inde
   <Step title="Enter EasyNews credentials">
     In AIOStreams → **Add-ons**, find the **EasyNews** addon and enter your EasyNews **username** and **password**.
   </Step>
-  <Step title="(Speed+ only) Add TorBox API key">
-    If using Speed 4K+ or Speed+, also add your TorBox API key in **Services → StremThru TorBox**.
+  <Step title="(Speed 4K+ only) Add TorBox API key">
+    If using Speed 4K+, also add your TorBox API key in **Services → StremThru TorBox**.
   </Step>
   <Step title="Save and install">
     Click **Save** → copy the manifest URL → install in Stremio or WuPlay.
@@ -55,8 +54,8 @@ Speed EasyNews is a cached-only EasyNews template with an exit condition: it sto
 |---|---|---|
 | Access | Username + password | API key |
 | Indexer | Built-in (EasyNews catalogue) | Third-party (NZBGeek database) |
-| Templates | Speed EasyNews, Speed 4K+, Speed+ | 4K Hybrid, Hybrid, Hybrid Lite |
-| TorBox required | No (standalone) or Yes (Speed+) | Yes |
+| Templates | Speed EasyNews, Speed 4K+ | 4K Hybrid, Hybrid, Hybrid Lite |
+| TorBox required | No (standalone) or Yes (Speed 4K+) | Yes |
 | Coverage | EasyNews retention (3,000+ days) | NZBGeek index |
 
 ---
@@ -69,7 +68,7 @@ Speed EasyNews is a cached-only EasyNews template with an exit condition: it sto
     - Confirm your EasyNews subscription is active at easynews.com
     - Speed templates exit early — test with a very popular title (e.g. Inception) to confirm EasyNews is working
   </Accordion>
-  <Accordion title="Speed+ returning only TorBox results">
+  <Accordion title="Speed 4K+ returning only TorBox results">
     EasyNews may be timing out. Check AIOStreams logs for EasyNews addon timeout errors. The EasyNews addon timeout is set to 8,000ms — increase to 12,000ms in Add-ons if your EasyNews connection is slow.
   </Accordion>
 </AccordionGroup>

--- a/docs/expression-layer.mdx
+++ b/docs/expression-layer.mdx
@@ -148,11 +148,11 @@ Template-specific patterns embedded per category. Score range: 70–100.
 | Template type | Count | Patterns |
 |---|---|---|
 | 4K | 7 | Radarr Remux T1, Sonarr Remux T1, Radarr UHD Bluray T1, FraMeSToR, Anime BD T1 |
-| 1080p | 8 | Radarr Web T1, Sonarr Web T1, FLUX, hallowed, BHDStudio, SiC, 126811, Web T1 |
+| 1080p | 5 | Web T1, 126811, FLUX, SiC, BHDStudio |
 | Anime | 0 | SeaDex/AnimeTosho handle quality |
 
 ### `rankedRegexPatterns`
-53 patterns from the shared database (`Filtering/ranked-regex-patterns.json`) where `|score| ≥ 50`, minus names already in `preferredRegexPatterns`.
+37 inline entries per template (embedded directly — not from an external file). Score range: −200 to +100.
 
 | Tier | Score | Examples |
 |---|---|---|

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -35,7 +35,7 @@ description: "Key terms used across Core Builds and AIOStreams."
     A file that has already been downloaded to a debrid service's servers. Clicking a cached stream starts playing instantly — no torrent download wait. Core Builds ISEs boost cached streams above uncached results.
   </Accordion>
   <Accordion title="Core Builds Expression Layer">
-    The set of seven Stream Expressions deployed in all active Core Builds templates. Covers: REPACK/PROPER passthrough, season pack gating, resolution kill, library boost, Usenet boost, cached-first sorting, and format exclusions. See [Expression Layer](/expression-layer).
+    The full set of Stream Expressions deployed in all active Core Builds templates: 24 ESEs (hard kills + quality gates), 3 ISEs (library / cached / language boosts), and the IQR Tukey fence PSEs. See [Expression Layer](/expression-layer).
   </Accordion>
 </AccordionGroup>
 
@@ -60,7 +60,7 @@ description: "Key terms used across Core Builds and AIOStreams."
     A filter that removes streams from results entirely. ESEs run before PSEs — anything matched by an ESE is gone before ranking starts. Examples: CAM kill, YouTube rip kill, 3D kill, low-resolution kill. Standard templates run 24 ESEs; Lite templates run 12 (hard kills only).
   </Accordion>
   <Accordion title="EasyNews">
-    A Usenet provider with a web-based search interface. Supported in AIOStreams as a scraper addon. Used in Speed+ and Speed EasyNews templates — no TorBox required for the standalone EasyNews template.
+    A Usenet provider with a web-based search interface. Supported in AIOStreams as a scraper addon. Used in Speed 4K+ and Speed EasyNews templates — no TorBox required for the standalone EasyNews template.
   </Accordion>
 </AccordionGroup>
 
@@ -68,7 +68,7 @@ description: "Key terms used across Core Builds and AIOStreams."
 
 <AccordionGroup>
   <Accordion title="Formatter">
-    Controls the text displayed for each stream in Stremio — the title line, metadata rows, codec, HDR tag, audio, file size, seeders, etc. Core Builds ships 14 formatters. The default is Core Syntax; others (Apex v2, Elite, Nexus Prime) can be swapped via the Formatter tab.
+    Controls the text displayed for each stream in Stremio — the title line, metadata rows, codec, HDR tag, audio, file size, seeders, etc. Core Builds ships 14 official formatters plus 2 community formatters. All templates default to Core Nexus Elite; others can be swapped via the Formatter tab. See [Formatters](/formatters).
   </Accordion>
 </AccordionGroup>
 
@@ -123,7 +123,7 @@ description: "Key terms used across Core Builds and AIOStreams."
 
 <AccordionGroup>
   <Accordion title="Release group">
-    The team that produced a release (e.g. FraMeSToR, FLUX, BHDStudio). Some groups are consistently high quality; others are known for bad encodes. Core Builds `rankedRegexPatterns` scores 149 release groups across 10 tiers (S/A/B tier down to blacklist).
+    The team that produced a release (e.g. FraMeSToR, FLUX, BHDStudio). Some groups are consistently high quality; others are known for bad encodes. Core Builds embeds 37 inline `rankedRegexPatterns` per template (score range −200 to +100), supplemented by Vidhin05's 174-pattern set via `syncedRankedRegexUrls`. Elite groups surface above generic encodes automatically.
   </Accordion>
   <Accordion title="REMUX">
     See BluRay REMUX.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -13,7 +13,7 @@ mode: "wide"
   <div style={{ display: 'flex', justifyContent: 'center', marginTop: '24px', marginBottom: '12px' }}>
     <div style={{ display: 'flex', background: '#0f172a', borderRadius: '10px', border: '1px solid #1e3a5f', overflow: 'hidden', width: '100%', maxWidth: '480px' }}>
       <div style={{ flex: 1, textAlign: 'center', padding: '18px 0', borderRight: '1px solid #1e3a5f' }}>
-        <div style={{ fontSize: '26px', fontWeight: '800', color: '#60a5fa' }}>30+</div>
+        <div style={{ fontSize: '26px', fontWeight: '800', color: '#60a5fa' }}>40+</div>
         <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>TEMPLATES</div>
       </div>
       <div style={{ flex: 1, textAlign: 'center', padding: '18px 0', borderRight: '1px solid #1e3a5f' }}>

--- a/docs/nightly-and-labs.mdx
+++ b/docs/nightly-and-labs.mdx
@@ -13,9 +13,9 @@ description: "Experimental templates testing new features before stable promotio
 
 ## Nightly Templates
 
-### Apple TV 4K (v0.1.5)
+### Nightly Apple TV 4K
 
-Device profile for Apple TV 4K (3rd gen) via Infuse. DV Profile 5/8 prioritised, DD+ Atmos, AV1 hard-excluded (no A15 hardware decoder).
+v0.1.5 — Device profile for Apple TV 4K (3rd gen) via Infuse. DV Profile 5/8 prioritised, DD+ Atmos, AV1 hard-excluded (no A15 hardware decoder).
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json" />
@@ -28,9 +28,9 @@ https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates
 
 ---
 
-### Samsung RU7100 4K (v0.2.10)
+### Nightly Samsung RU7100 4K
 
-Samsung RU7100 (2019) 4K — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV. Full APEX IQR PSE stack. More aggressive filtering than the stable Samsung TV template.
+v0.2.10 — Samsung RU7100 (2019) 4K — FLAC/AAC native audio, HDR10+/HDR10/HLG, HEVC/AVC, no AV1/DV. Full APEX IQR PSE stack. More aggressive filtering than the stable Samsung TV template.
 
 <CardGroup cols={2}>
   <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json" />

--- a/docs/which-template.mdx
+++ b/docs/which-template.mdx
@@ -61,9 +61,9 @@ Every template has a **Lite variant** (`-lite` suffix). Use Lite if you get too 
         Fast cached play, exits at 3 cached results or timeout.
         **Best for:** fast results without EasyNews.
       </Card>
-      <Card title="Speed 4K+ / Speed+" icon="gauge" href="/template-directory">
-        Speed with EasyNews dual-source. Requires EasyNews credentials.
-        **Best for:** Essential + EasyNews subscribers.
+      <Card title="Speed 4K+" icon="gauge" href="/template-directory">
+        Speed 4K with EasyNews dual-source. Requires EasyNews credentials.
+        **Best for:** Essential + EasyNews subscribers who want 4K.
       </Card>
     </CardGroup>
 


### PR DESCRIPTION
## Summary

Full docs audit pass fixing 11 issues across 7 files.

**High priority:**
- `expression-layer.mdx` — 1080p preferred patterns count corrected 8→5 (Radarr Web T1, Sonarr Web T1, hallowed removed in v2.9.0); rankedRegexPatterns corrected from "53 from shared database" to "37 inline per template"
- `easynews-setup.mdx` — Removed "Speed+" (deprecated 1080p EasyNews template) from Which Template table, steps, comparison table, and troubleshooting
- `which-template.mdx` — "Speed 4K+ / Speed+" card → "Speed 4K+"

**Medium priority:**
- `changelog.mdx` — Removed duplicate `**Fixed: Regex compatibility — fortheweak whitelist**` heading
- `glossary.mdx` — Fixed "149 release groups" (→ 37 inline + Vidhin05's 174); fixed default formatter "Core Syntax" → "Core Nexus Elite"; fixed "14 formatters" → "14 official + 2 community"; fixed EasyNews "Speed+" → "Speed 4K+"
- `nightly-and-labs.mdx` — Renamed headings to "Nightly Apple TV 4K" / "Nightly Samsung RU7100 4K" so anchor links from device-profiles.mdx resolve correctly

**Low priority:**
- `introduction.mdx` — Template count: "30+" → "40+"

## Test plan

- [ ] expression-layer.mdx 1080p preferred table shows 5 entries
- [ ] easynews-setup.mdx has no "Speed+" references
- [ ] nightly-and-labs.mdx headings match anchors in device-profiles.mdx links
- [ ] glossary.mdx formatter entry says "Core Nexus Elite" as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_