### PR TITLE
fix: raise stremthruTorz/Store debrid timeout 3000ms → 5000ms (35 templates)

### DIFF
--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
@@ -1640,7 +1640,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru AllDebrid",
-          "timeout": 3000,
+          "timeout": 5000,
           "useMultipleInstances": false
         },
         "resources": [

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
@@ -1708,7 +1708,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru AllDebrid",
-          "timeout": 3000,
+          "timeout": 5000,
           "useMultipleInstances": false
         },
         "resources": [

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -1667,7 +1667,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru AllDebrid",
-          "timeout": 3000,
+          "timeout": 5000,
           "useMultipleInstances": false
         },
         "resources": [

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -1667,7 +1667,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru AllDebrid",
-          "timeout": 3000,
+          "timeout": 5000,
           "useMultipleInstances": false
         },
         "resources": [

--- a/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
@@ -242,7 +242,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Anime/core-nexus-anime-4k.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k.json
@@ -260,7 +260,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
@@ -242,7 +242,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Anime/core-nexus-anime-dub.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub.json
@@ -260,7 +260,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Anime/core-nexus-anime-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-lite.json
@@ -242,7 +242,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Anime/core-nexus-anime.json
+++ b/Templates/Torbox/Anime/core-nexus-anime.json
@@ -260,7 +260,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -1658,7 +1658,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -1652,7 +1652,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -1679,7 +1679,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -1731,7 +1731,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -1642,7 +1642,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -1690,7 +1690,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -1737,7 +1737,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -1656,7 +1656,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -1704,7 +1704,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+++ b/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
@@ -1647,7 +1647,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -1740,7 +1740,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -1683,7 +1683,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -1715,7 +1715,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -1775,7 +1775,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -1780,7 +1780,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -1722,7 +1722,7 @@
         "enabled": false,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -1719,7 +1719,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
@@ -1663,7 +1663,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -1711,7 +1711,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -1653,7 +1653,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -1693,7 +1693,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -1679,7 +1679,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -1727,7 +1727,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -1626,7 +1626,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -1674,7 +1674,7 @@
         "enabled": true,
         "options": {
           "name": "StremThru Torz",
-          "timeout": 3000,
+          "timeout": 5000,
           "includeP2P": false,
           "useMultipleInstances": false
         },


### PR DESCRIPTION
## Summary

Raises the `stremthruTorz` / `stremthruStore` debrid timeout from **3000ms → 5000ms** across 35 active templates.

**Why this causes playback errors:**
`stremthruTorz` and `stremthruStore` are the debrid link resolvers — they convert a cached magnet/NZB into a direct HTTP playback URL on every click. AIOStreams v2.24.0 introduced "throw debrid error on timeouts for cache and play", meaning a 3000ms timeout now propagates as an active **Playback Error** to the client rather than a silent miss.

3000ms is too short — TorBox API link generation can take 3–5 s during peak hours, on first-time cache access, or with host→TorBox network latency. The symptom is a "Playback Error" in Nuvio (surfaces the error immediately) or a silent auto-retry in Stremio.

**What changed:**
- 35 active templates: `stremthruTorz` / `stremthruStore` `timeout` field: `3000` → `5000`
- 35 files changed, exactly 1 line each — only `options.timeout` inside the debrid service preset

**What did NOT change:**
- Flash / Speed EasyNews (3500ms — cached-only speed templates, intentional)
- Dual Core templates (4000ms — already above 3000ms)
- 2 Nightly templates already at 5000ms
- All deprecated templates
- All scraper addon timeouts (Comet, MediaFusion, Meteor, etc.)
- No expressions, regex, versions, or any other fields

## Test plan
- [ ] Re-import any template — confirm no schema errors
- [ ] Play a stream in Nuvio — confirm playback error reduced/eliminated
- [ ] Verify only `timeout` changed: `git diff HEAD~1` shows 35 files × 1 line each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_