### PR TITLE
docs: add TMDB required warning to template directory

### DIFF
--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -17,6 +17,12 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
   **Quick import:** click an Import button to open the template directly in your AIOStreams instance. Or copy the raw URL to paste manually into any host.
 </Note>
 
+<Warning>
+  **A TMDB Read Access Token is required for templates to work correctly.** Without it, title matching falls back to AIOStreams defaults — foreign titles, anime, and anything with multiple versions will match poorly or return no results.
+
+  Get yours free at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api) → **Read Access Token** → paste into AIOStreams → **Settings → TMDB Access Token**.
+</Warning>
+
 ## TorBox Pro
 
 <Tabs>


### PR DESCRIPTION
## Summary

Added a prominent `<Warning>` block at the top of the template directory — the first thing users see before picking a template.

**Before:** No TMDB mention anywhere on the page.
**After:** Warning explaining TMDB Read Access Token is required for correct title matching, with a direct link to `themoviedb.org/settings/api` and the exact setting path in AIOStreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_