### PR TITLE
docs: add Choosing a Host section to importing guide

### DIFF
--- a/docs/importing.mdx
+++ b/docs/importing.mdx
@@ -68,13 +68,39 @@ Re-import the same URL. AIOStreams will load the latest version and merge it ove
   </Accordion>
 </AccordionGroup>
 
-## Hosted vs Self-Hosted
+## Choosing a Host
+
+<CardGroup cols={2}>
+  <Card title="elfhosted (paid private)" icon="server" href="https://store.elfhosted.com/product/aiostreams">
+    **$9/month** — dedicated instance, no rate limits, Torrentio enabled. Best for serious daily use.
+  </Card>
+  <Card title="fortheweak.cloud" icon="users" href="https://aiostreams.fortheweak.cloud">
+    **Free** — community-run by nhyyeb, stable and nightly builds. Core Builds verified against their allowlist. Best free option.
+  </Card>
+</CardGroup>
+
+<Tip>
+  Not sure? Start with **fortheweak** (free, no signup) to test your template. Upgrade to elfhosted private if you need Torrentio or want a dedicated instance with no shared load.
+</Tip>
+
+| | elfhosted private | fortheweak | elfhosted free | Self-hosted |
+|---|---|---|---|---|
+| Cost | $9/month | Free | Free | Free (server cost) |
+| Rate limits | None | Shared | Shared + Torrentio disabled | None |
+| Torrentio | Enabled | Enabled | Disabled | Enabled |
+| Core Builds verified | ✓ | ✓ | ✓ | ✓ |
+| Nightly builds | — | ✓ | — | ✓ |
+
+For the full list of public instances, see the [AIOStreams public instances page](https://docs.aiostreams.viren070.me/getting-started/public-instances/).
+
+### Regex and allowlists
+
+Hosted instances validate inline regex patterns against an allowlist. v2.9.0 templates are verified against both elfhosted and fortheweak allowlists — import errors from regex patterns indicate an outdated template.
 
 | | Hosted (elfhosted, fortheweak.cloud) | Self-hosted |
 |---|---|---|
 | Inline regex | Validated against host allowlist | Works — all patterns allowed |
 | Synced regex URLs | Whitelisted URLs only | All URLs allowed |
-| Performance | Shared resources | Dedicated |
 
 <Info>
   As of v2.9.0, all Core Builds templates are verified against both elfhosted and fortheweak allowlists. If you see a "regex not allowed" error after importing, re-import the latest template version — older templates may contain pattern strings that predate the v2.9.0 allowlist sync.

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -17,6 +17,12 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
   **Quick import:** click an Import button to open the template directly in your AIOStreams instance. Or copy the raw URL to paste manually into any host.
 </Note>
 
+<Warning>
+  **A TMDB Read Access Token is required for templates to work correctly.** Without it, title matching falls back to AIOStreams defaults — foreign titles, anime, and anything with multiple versions will match poorly or return no results.
+
+  Get yours free at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api) → **Read Access Token** → paste into AIOStreams → **Settings → TMDB Access Token**.
+</Warning>
+
 ## TorBox Pro
 
 <Tabs>


### PR DESCRIPTION
## Summary

- Replaces the bare "Hosted vs Self-Hosted" table with a full **Choosing a Host** section
- `CardGroup` with direct links to elfhosted private ($9/month) and fortheweak (free) — the two recommended options
- Cost/feature comparison table covering elfhosted private, fortheweak, elfhosted free public, and self-hosted (rate limits, Torrentio availability, nightly build access)
- Tip callout: start with fortheweak, upgrade to elfhosted if you need Torrentio or dedicated resources
- Link to the official AIOStreams public instances list for the full directory
- Regex allowlist info preserved as a `### Regex and allowlists` subsection

## Test plan

- [ ] Verify CardGroup links resolve correctly (elfhosted store, fortheweak.cloud)
- [ ] Check comparison table renders cleanly on mobile/narrow viewports
- [ ] Confirm public instances link is correct (`docs.aiostreams.viren070.me/getting-started/public-instances/`)
- [ ] Verify the Info block and Tip callout render without errors in Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_