### PR TITLE
docs: fix how-it-works counts, roadmap staleness, add Nuvio, bigger logo

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,12 @@ Full history: [CHANGELOG.md](https://github.com/brevityA/Core-Builds/blob/main/C
   **Latest release.** If you already have a template imported, check AIOStreams for an in-app update notification.
 </Info>
 
+**Fixed: Debrid timeout raised — 35 templates**
+
+`stremthruTorz` and `stremthruStore` timeout increased from 3000ms to 5000ms across all 35 active templates (excludes Flash and Speed EasyNews which were already at 3500ms+). AIOStreams v2.24.0 changed debrid timeout behaviour — timeouts now propagate as active Playback Errors to the client rather than failing silently. On Nuvio and similar clients, this surfaced as a visible error on every slow debrid link resolution. The 5000ms budget gives TorBox's link resolver enough headroom to handle congested periods without triggering the error.
+
+---
+
 **Fixed: Labs templates — metadata.inputs schema**
 
 AIOStreams renamed fields in the `metadata.inputs` schema — `key` → `id` and `label` → `name`. All 4 Labs templates were failing to load with 8 errors each. Fixed across 4K Apex Labs, Stream Labs, Essential Labs, and 4K Essential Labs.

--- a/docs/device-profiles.mdx
+++ b/docs/device-profiles.mdx
@@ -132,6 +132,28 @@ Any device with 2 GB RAM or less (older Fire Sticks, budget Android TV boxes, en
 
 ---
 
+## Streaming Clients
+
+### Nuvio
+
+[Nuvio](https://nuvio.app) is a Stremio-compatible streaming client (by Tapframe) available on Android, iOS, Apple TV, Android TV, and web. It works with all Stremio addons including AIOStreams — no configuration changes are needed.
+
+**One key difference from Stremio:** Nuvio surfaces debrid errors immediately rather than retrying silently. If a stream fails to resolve, you'll see a **Playback Error** message instead of a buffering spinner. This makes debrid timeouts visible — which is useful for diagnosing problems, but can appear alarming on the first encounter.
+
+<Info>
+  If you see Playback Error on Nuvio but the same stream works in Stremio, the most likely cause is a debrid link resolution timeout. Core Builds templates run `stremthruTorz`/`stremthruStore` at a 5000ms timeout (raised in v2.9.0) to reduce this. If errors persist, check TorBox's status page for outages or try a different stream from the list.
+</Info>
+
+### Stremio
+
+Standard setup — install AIOStreams as an add-on via manifest URL. Stremio auto-retries failed stream requests without surfacing the error to the user. Compatible on Windows, macOS, Linux, Android, iOS, and smart TVs with the Stremio app.
+
+### WuPlay
+
+Web-based streaming client. Use it for Chromecast or any device without a native Stremio app. Copy the manifest URL from AIOStreams → paste into WuPlay → stream directly in browser.
+
+---
+
 ## General Tips
 
 <AccordionGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5,7 +5,7 @@
   "logo": {
     "light": "/logo/core_builds_banner.png",
     "dark": "/logo/core_builds_banner.png",
-    "height": 55
+    "height": 75
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {

--- a/docs/expression-layer.mdx
+++ b/docs/expression-layer.mdx
@@ -147,7 +147,7 @@ Template-specific patterns embedded per category. Score range: 70–100.
 
 | Template type | Count | Patterns |
 |---|---|---|
-| 4K | 7 | Radarr Remux T1, Sonarr Remux T1, Radarr UHD Bluray T1, FraMeSToR, Anime BD T1 |
+| 4K | 7 | Radarr Remux T1, Sonarr Remux T1, Radarr UHD Bluray T1, Radarr UHD Bluray T1 — DON, Anime BD T1, Anime BD T1 [sam], FraMeSToR |
 | 1080p | 5 | Web T1, 126811, FLUX, SiC, BHDStudio |
 | Anime | 0 | SeaDex/AnimeTosho handle quality |
 

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -151,7 +151,7 @@ description: "Key terms used across Core Builds and AIOStreams."
 
 <AccordionGroup>
   <Accordion title="Template">
-    A JSON configuration file that defines every aspect of an AIOStreams setup — addons, filters, sorting, formatter, deduplication, and branding. Core Builds provides 30+ templates for different services, resolutions, and devices.
+    A JSON configuration file that defines every aspect of an AIOStreams setup — addons, filters, sorting, formatter, deduplication, and branding. Core Builds provides 40+ templates for different services, resolutions, and devices.
   </Accordion>
   <Accordion title="TorBox">
     A debrid service with both torrent and Usenet support. Core Builds is primarily built for TorBox subscribers. Plans: Essential (basic cached-only) and Pro (full Usenet + uncached support).

--- a/docs/how-it-works.mdx
+++ b/docs/how-it-works.mdx
@@ -51,10 +51,10 @@ Vanilla AIOStreams with default settings returns raw, unsorted results. Core Bui
     Bitrate-based ranking using real statistics across all streams for a title — not hardcoded cutoffs. Adapts to thin libraries and new releases via the pow() decay window.
   </Card>
   <Card title="Core Builds Expression Layer" icon="filter">
-    Seven stream expressions deployed across all templates: REPACK passthrough, season pack gating, resolution kill, library boost, Usenet boost, cached-first sort, and format exclusions.
+    24 ESEs remove junk before ranking ever starts. 3 ISEs pin library, cached, and English streams to the top. IQR Tukey fence PSEs score everything else by bitrate percentile against real peers.
   </Card>
   <Card title="Release Group Scoring" icon="star">
-    149 release groups scored across 10 tiers (+100 to -200). Elite groups (FraMeSToR, FLUX, BHDStudio) surface above generic encodes automatically.
+    37 inline ranked patterns per template (score range −200 to +100) plus 174 additional patterns synced from Vidhin05's release database. Elite groups (FraMeSToR, FLUX, BHDStudio) surface above generic encodes automatically.
   </Card>
   <Card title="Device Profiles" icon="tv">
     Samsung TV, Apple TV, Fire Stick templates hard-exclude codecs and HDR formats the device can't play — no more silent playback failures from AV1 or DV on unsupported hardware.
@@ -75,7 +75,7 @@ Vanilla AIOStreams with default settings returns raw, unsorted results. Core Bui
 |---|---|---|---|
 | ESE | Remove — stream is excluded from results | 24 | 12 |
 | ISE | Boost — stream jumps to top regardless of score | 3 | 3 |
-| PSE | Rank — stream gets a quality score | 7–12 | 7–12 |
+| PSE | Rank — stream gets a quality score | varies by template | varies by template |
 
 ESEs run first, then ISEs, then PSEs. A stream matched by an ESE never reaches PSE scoring.
 

--- a/docs/importing.mdx
+++ b/docs/importing.mdx
@@ -68,13 +68,39 @@ Re-import the same URL. AIOStreams will load the latest version and merge it ove
   </Accordion>
 </AccordionGroup>
 
-## Hosted vs Self-Hosted
+## Choosing a Host
+
+<CardGroup cols={2}>
+  <Card title="elfhosted (paid private)" icon="server" href="https://store.elfhosted.com/product/aiostreams">
+    **$9/month** — dedicated instance, no rate limits, Torrentio enabled. Best for serious daily use.
+  </Card>
+  <Card title="fortheweak.cloud" icon="users" href="https://aiostreams.fortheweak.cloud">
+    **Free** — community-run by nhyyeb, stable and nightly builds. Core Builds verified against their allowlist. Best free option.
+  </Card>
+</CardGroup>
+
+<Tip>
+  Not sure? Start with **fortheweak** (free, no signup) to test your template. Upgrade to elfhosted private if you need Torrentio or want a dedicated instance with no shared load.
+</Tip>
+
+| | elfhosted private | fortheweak | elfhosted free | Self-hosted |
+|---|---|---|---|---|
+| Cost | $9/month | Free | Free | Free (server cost) |
+| Rate limits | None | Shared | Shared + Torrentio disabled | None |
+| Torrentio | Enabled | Enabled | Disabled | Enabled |
+| Core Builds verified | ✓ | ✓ | ✓ | ✓ |
+| Nightly builds | — | ✓ | — | ✓ |
+
+For the full list of public instances, see the [AIOStreams public instances page](https://docs.aiostreams.viren070.me/getting-started/public-instances/).
+
+### Regex and allowlists
+
+Hosted instances validate inline regex patterns against an allowlist. v2.9.0 templates are verified against both elfhosted and fortheweak allowlists — import errors from regex patterns indicate an outdated template.
 
 | | Hosted (elfhosted, fortheweak.cloud) | Self-hosted |
 |---|---|---|
 | Inline regex | Validated against host allowlist | Works — all patterns allowed |
 | Synced regex URLs | Whitelisted URLs only | All URLs allowed |
-| Performance | Shared resources | Dedicated |
 
 <Info>
   As of v2.9.0, all Core Builds templates are verified against both elfhosted and fortheweak allowlists. If you see a "regex not allowed" error after importing, re-import the latest template version — older templates may contain pattern strings that predate the v2.9.0 allowlist sync.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -36,7 +36,7 @@ mode: "wide"
 </div>
 
 <Info>
-  **What's new in v2.9.0:** Regex compatibility fix for fortheweak — 11 ranked + 3 excluded pattern entries removed from all 33 non-Anime templates. LQ groups remain excluded via Tamtaro's synced URL; WEB-DL and release group scoring preserved via remaining ranked tiers.
+  **What's new in v2.9.0:** Regex compatibility fix for fortheweak (11 ranked + 3 excluded entries removed from all 33 non-Anime templates); debrid timeout raised 3000ms → 5000ms on 35 templates — fixes Playback Error on Nuvio and AIOStreams v2.24.0+.
 </Info>
 
 <CardGroup cols={2}>

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -7,16 +7,20 @@ description: "Planned work, active development, and recently completed milestone
 
 | Version | Item |
 |---|---|
+| v2.9.0 | Regex compatibility — fortheweak whitelist sync (11 ranked + 3 excluded removed from all 33 non-Anime templates) |
+| v2.9.0 | Debrid timeout raised 3000ms → 5000ms on 35 templates — fixes playback errors on Nuvio and AIOStreams v2.24.0+ |
+| v2.9.0 | AllDebrid setup guide |
+| v2.9.0 | Docs expansion — formatters (3→16), device profiles, troubleshooting rewrite, Choosing a Host section |
 | v2.8.4 | Boost Cached Usenet PSE restored — all 27 TorBox templates |
 | v2.8.3 | seadexBestOnly fixed on 5 general-purpose 4K templates |
-| v2.8.3 | Hard resolution kill ESE added to all 13 x 1080p templates |
+| v2.8.3 | Hard resolution kill ESE added to all 13 × 1080p templates |
 | v2.8.2 | Samsung TV codec fixes — AV1/VC-1 hard-excluded, DV/AI upscale removed |
-| v2.8.2 | Regex patterns embedded inline — fixes public instance "Forbidden URL" errors |
+| v2.8.2 | Regex scoring migrated to syncedRankedRegexUrls — eliminates "Forbidden URL" errors on public instances |
 | v2.8.0 | AllDebrid template family (4 templates) |
 | v2.8.0 | Apple TV 4K (Nightly) |
 | v2.8.0 | Samsung TV promoted to stable |
 | v2.8.0 | pow() exponential age-decay replaces hard 60-day cliff |
-| v2.8.0 | Core Builds Expression Layer — all 7 expressions deployed |
+| v2.8.0 | Core Builds Expression Layer — 24 ESEs, 3 ISEs, IQR PSEs deployed |
 | v2.7.5 | Addon timeout tuning — fixes silent Usenet result drops |
 | v2.7.5 | Dedup tiebreakers — torrent_seeders + usenet_age |
 | v2.7.0 | Core Nexus 4K Hybrid — TorBox + NZBGeek Usenet |
@@ -75,7 +79,6 @@ description: "Planned work, active development, and recently completed milestone
 ### Documentation
 
 - **Video walkthrough** — Import flow and template selection for new users
-- **AllDebrid setup guide** — Mirror of the TorBox import guide scoped to AllDebrid
 
 ---
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -17,6 +17,12 @@ All templates require **AIOStreams v2.30+**. Every standard template has a **Lit
   **Quick import:** click an Import button to open the template directly in your AIOStreams instance. Or copy the raw URL to paste manually into any host.
 </Note>
 
+<Warning>
+  **A TMDB Read Access Token is required for templates to work correctly.** Without it, title matching falls back to AIOStreams defaults — foreign titles, anime, and anything with multiple versions will match poorly or return no results.
+
+  Get yours free at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api) → **Read Access Token** → paste into AIOStreams → **Settings → TMDB Access Token**.
+</Warning>
+
 ## TorBox Pro
 
 <Tabs>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -93,6 +93,7 @@ Before troubleshooting, confirm what you're running.
 
   <Accordion title="Results appear but nothing plays">
     Most common causes:
+    - **Debrid link timeout (Nuvio / AIOStreams v2.24.0+)** — If you see a visible Playback Error, the debrid link resolver timed out. Re-import the v2.9.0+ template — the `stremthruTorz`/`stremthruStore` timeout was raised to 5000ms to cover congested periods. If errors persist, check [TorBox's status page](https://torbox.app/status) for outages, or try a different stream from the list.
     - **Codec not supported on your device** — check the stream's codec in the formatter display. If it's AV1 on a device without hardware AV1 decode (Fire Stick 4K, older Samsung Tizen), the stream will buffer or fail. Switch to a device-specific template (Samsung TV, Fire Stick) which hard-exclude unsupported codecs.
     - **DV-only stream on a non-DV device** — the Samsung templates have a DV-Only Kill ESE enabled by default. If you're on a generic template, enable the DV-Only Kill ESE manually in AIOStreams.
     - **Bitrate too high** — very high-bitrate REMUX streams can stall on slower connections or budget hardware. Try the B-tier or lower result in the list.

--- a/docs/which-template.mdx
+++ b/docs/which-template.mdx
@@ -9,7 +9,7 @@ Every template has a **Lite variant** (`-lite` suffix). Use Lite if you get too 
   <Tab title="TorBox Pro">
     <CardGroup cols={2}>
       <Card title="4K Apex" icon="crown" href="/template-directory">
-        Flagship 4K. DV/HDR REMUX, Usenet via Newznab, IQR adaptive bitrate filtering.
+        Flagship 4K. DV/HDR REMUX, TorBox Usenet, IQR adaptive bitrate filtering.
         **Best for:** most Pro users who want 4K.
       </Card>
       <Card title="4K Apex (TorBox-only)" icon="bolt" href="/template-directory">
@@ -70,6 +70,10 @@ Every template has a **Lite variant** (`-lite` suffix). Use Lite if you get too 
     <Tip>
       Not sure between Essential and Flash? Use Essential — it falls back to uncached if nothing is cached. Flash returns nothing if the title isn't in TorBox's cache.
     </Tip>
+
+    <Note>
+      **Samsung TV?** The Samsung TV templates work on any TorBox plan. See [Device Profiles → Samsung TV](/device-profiles#samsung-tv).
+    </Note>
   </Tab>
 
   <Tab title="AllDebrid">


### PR DESCRIPTION
## Summary

- **Logo height** `55 → 75` in `docs.json` — larger nav logo in the left corner
- **`how-it-works.mdx`** — three stale figures fixed:
  - "Seven stream expressions" card → 24 ESEs / 3 ISEs / IQR PSEs
  - "149 release groups scored" → 37 inline per template + 174 via synced Vidhin05 URL
  - PSE count "7–12" → "varies by template"
- **`roadmap.mdx`** — multiple staleness fixes:
  - Added v2.9.0 completed items: regex compat fix, debrid timeout raise, AllDebrid guide, docs expansion
  - Fixed v2.8.2 regex entry (old wording implied inline embedding was the fix — it wasn't, `syncedRankedRegexUrls` was)
  - Fixed "7 expressions" → "24 ESEs, 3 ISEs, IQR PSEs" in the completed row
  - Removed "AllDebrid setup guide" from Planned — it shipped
- **`device-profiles.mdx`** — new **Streaming Clients** section added before General Tips:
  - **Nuvio** (Tapframe) — Stremio-compatible, surfaces debrid errors immediately instead of retrying silently; Info callout explaining the v2.9.0 timeout fix context
  - **Stremio** — standard setup, auto-retries silently
  - **WuPlay** — Chromecast / browser streaming

## Test plan

- [ ] Verify logo renders larger in Mintlify nav (height 75 vs 55)
- [ ] Confirm Streaming Clients section renders in device-profiles between Low-RAM and General Tips
- [ ] Check roadmap Recently Completed table doesn't overflow on narrow viewports
- [ ] Verify Nuvio link (`nuvio.app`) resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_