### PR TITLE
fix: remove invalid metadata.changelog string field (6 templates)

### DIFF
--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.1.6: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams.\nv0.1.3: Restore correct regex configuration \u2014 full {name, pattern, score} entries in rankedRegexPatterns, preferredRegexPatterns restored, excludedRegexPatterns restored to 12 (including lookbehind), syncedExcludedRegexUrls restored to Tamtaro. Aligns with verified working elfhosted configuration."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.1.8: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams.\nv0.1.5: Restore correct regex configuration \u2014 full {name, pattern, score} entries in rankedRegexPatterns, preferredRegexPatterns restored, excludedRegexPatterns restored to 12 (including lookbehind), syncedExcludedRegexUrls restored to Tamtaro. Aligns with verified working elfhosted configuration."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.1.7: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams.\nv0.1.4: Restore correct regex configuration \u2014 full {name, pattern, score} entries in rankedRegexPatterns, preferredRegexPatterns restored, excludedRegexPatterns restored to 12 (including lookbehind), syncedExcludedRegexUrls restored to Tamtaro. Aligns with verified working elfhosted configuration."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.1.7: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams.\nv0.1.4: Restore correct regex configuration \u2014 full {name, pattern, score} entries in rankedRegexPatterns, preferredRegexPatterns restored, excludedRegexPatterns restored to 12 (including lookbehind), syncedExcludedRegexUrls restored to Tamtaro. Aligns with verified working elfhosted configuration."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.2.9: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -10,8 +10,7 @@
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json",
-    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
-    "changelog": "v0.2.9: Per-Addon Flood Guard ESE added \u2014 caps Meteor \u2264 5, Comet RD \u2264 5, MediaFusion \u2264 4, Torrent Galaxy/EZTV/Knaben/HdHub \u2264 3 on non-library, non-SeaDex streams."
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
   },
   "config": {
     "trusted": false,


### PR DESCRIPTION
## Summary

- Deleted the `metadata.changelog` string field from 6 templates that had it set as a plain string value
- AIOStreams schema requires `metadata.changelog` to be an array or absent — a plain string causes the import error: _"Invalid input → at metadata.changelog"_
- Affected templates: `core-nexus-4k-alldebrid`, `core-nexus-4k-alldebrid-lite`, `core-nexus-alldebrid`, `core-nexus-alldebrid-lite`, `core-nexus-samsung-tv`, `core-nexus-samsung-tv-4k`

## Test plan

- [x] All 120 pytest tests pass
- [x] Full schema audit clean (no other `metadata.changelog` string fields detected across all active templates)
- [x] Samsung TV 4K import error resolved

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_