### PR TITLE
docs: add Which Instance Should I Use section to instance-status page

### DIFF
--- a/docs/instance-status.mdx
+++ b/docs/instance-status.mdx
@@ -3,6 +3,28 @@ title: "Instance Status"
 description: "Live status of all known public AIOStreams instances. Auto-checked every 6 hours."
 ---
 
+## Which Instance Should I Use?
+
+The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hit rate limits, **Yeb's** as a solid backup.
+
+<CardGroup cols={3}>
+  <Card title="ElfHosted (Free)" icon="star">
+    Best starting point. Debrid-only — no P2P or HTTP streams, which matches Core Builds perfectly. All templates are tested and verified here first. Expect rate limiting under heavy use.
+  </Card>
+  <Card title="ElfHosted Private" icon="lock">
+    Same host, no rate limits. ~$9/month from the ElfHosted store. Worth it if you stream several hours a day or share a config across multiple profiles.
+  </Card>
+  <Card title="Yeb's (fortheweak)" icon="shield">
+    Run by an AIOStreams Discord admin. Fast and reliable. Uses a stricter regex whitelist — all Core Builds templates (v2.9.0+) are verified against it. Good free alternative to ElfHosted.
+  </Card>
+</CardGroup>
+
+<Tip>
+  **Self-hosting** is always the best option if you're comfortable with Docker — no rate limits, full control, and you stay on your own hardware. See the [AIOStreams self-hosting guide](https://github.com/Viren070/AIOStreams#self-hosting).
+</Tip>
+
+---
+
 <Warning>
   **Green = host is reachable.** Does not guarantee the instance accepts new configs or that your template will import correctly. Always test with a fresh import after choosing a host.
 </Warning>


### PR DESCRIPTION
## Summary

- Adds a three-card recommendation block at the top of the Instance Status page (ElfHosted free → ElfHosted Private → Yeb's) with a self-hosting tip
- Gives users a clear answer to "which instance should I use?" before they read the status table

## Test plan

- [x] Page renders correctly with CardGroup + Tip components
- [x] No broken links

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_