### PR TITLE
docs: sync all template versions in directory (38 stale entries)

### DIFF
--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Template Directory"
-description: "Every active template with import URLs, versions, and plan requirements. Current version: v2.9.1"
+description: "Every active template with import URLs, versions, and plan requirements. Current version: v2.9.2"
 ---
 
 <Frame>
@@ -27,7 +27,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### 4K Apex — v0.4.11
+    ### 4K Apex — v0.4.12
     Flagship 4K. IQR Tukey fence adaptive bitrate filtering, DV/HDR priority, TorBox Usenet.
 
     <CardGroup cols={2}>
@@ -40,7 +40,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### 4K Apex (TorBox-only) — v2.9.0
+    ### 4K Apex (TorBox-only) — v2.9.1
     Cached-only Apex variant. No external scrapers — instant results from TorBox cache only.
 
     <CardGroup cols={2}>
@@ -53,7 +53,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### 4K Hybrid — v2.9.0
+    ### 4K Hybrid — v2.9.2
     TorBox Pro + NZBGeek. Full 4K with TorBox-priority PSEs. Requires NZBGeek API key.
 
     <CardGroup cols={2}>
@@ -66,7 +66,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Samsung TV 4K — v0.2.9
+    ### Samsung TV 4K — v0.2.11
     AV1/VC-1/DV hard-excluded for Tizen. HDR10+ preferred.
 
     <CardGroup cols={2}>
@@ -79,7 +79,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="1080p">
-    ### Stream — v2.9.0
+    ### Stream — v2.9.2
     1080p WEB-DL only. BluRay and Remux excluded.
 
     <CardGroup cols={2}>
@@ -92,7 +92,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Stream (Fire Stick) — v2.9.0
+    ### Stream (Fire Stick) — v2.9.2
     1080p SDR, tuned for Fire Stick and low-RAM devices.
 
     <CardGroup cols={2}>
@@ -105,7 +105,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Samsung TV — v0.2.9
+    ### Samsung TV — v0.2.11
     1080p, AV1/VC-1/DV hard-excluded for Tizen.
 
     <CardGroup cols={2}>
@@ -118,7 +118,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Hybrid — v2.9.0
+    ### Hybrid — v2.9.2
     TorBox + NZBGeek, 1080p. Requires NZBGeek API key.
 
     <CardGroup cols={2}>
@@ -131,7 +131,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="Lite">
-    ### Stream Lite — v2.9.0
+    ### Stream Lite — v2.9.1
     Reduced ESE set. Faster, lighter on the host.
 
     <CardGroup cols={2}>
@@ -144,7 +144,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Stream (Fire Stick) Lite — v2.9.0
+    ### Stream (Fire Stick) Lite — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json" />
@@ -156,7 +156,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Hybrid Lite — v2.9.0
+    ### Hybrid Lite — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json" />
@@ -174,7 +174,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### 4K Essential — v2.9.0
+    ### 4K Essential — v2.9.1
     Full 4K on Essential plan. IQR PSEs, no Usenet.
 
     <CardGroup cols={2}>
@@ -187,7 +187,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Flash 4K — v2.9.0
+    ### Flash 4K — v2.9.1
     Cached-only instant play. Returns nothing if title isn't cached.
 
     <CardGroup cols={2}>
@@ -200,7 +200,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Speed 4K — v2.9.0
+    ### Speed 4K — v2.9.1
     Fast cached 4K. Exits at 3 cached results or timeout.
 
     <CardGroup cols={2}>
@@ -213,7 +213,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="1080p">
-    ### Essential — v2.9.0
+    ### Essential — v2.9.2
     Standard 1080p for Essential subscribers.
 
     <CardGroup cols={2}>
@@ -226,7 +226,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Flash — v2.9.0
+    ### Flash — v2.9.2
     Cached-only instant 1080p play.
 
     <CardGroup cols={2}>
@@ -239,7 +239,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Speed — v2.9.0
+    ### Speed — v2.9.1
     Fast cached 1080p. Exits at 3 cached results or timeout.
 
     <CardGroup cols={2}>
@@ -252,7 +252,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="Lite">
-    ### 4K Essential Lite — v2.9.0
+    ### 4K Essential Lite — v2.9.1
     CB-style PSEs — simpler scoring, lower CPU overhead.
 
     <CardGroup cols={2}>
@@ -265,7 +265,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Speed 4K Lite — v2.9.0
+    ### Speed 4K Lite — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json" />
@@ -277,7 +277,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Essential Lite — v2.9.0
+    ### Essential Lite — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential-lite.json" />
@@ -289,7 +289,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Speed Lite — v2.9.0
+    ### Speed Lite — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json" />
@@ -307,7 +307,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### 4K AllDebrid — v0.1.8
+    ### 4K AllDebrid — v0.1.9
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json" />
@@ -319,7 +319,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="1080p">
-    ### AllDebrid — v0.1.7
+    ### AllDebrid — v0.1.9
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json" />
@@ -331,7 +331,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="Lite">
-    ### 4K AllDebrid Lite — v0.1.6
+    ### 4K AllDebrid Lite — v0.1.7
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json" />
@@ -343,7 +343,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### AllDebrid Lite — v0.1.7
+    ### AllDebrid Lite — v0.1.9
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json" />
@@ -361,7 +361,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### Speed 4K+ — v2.9.0
+    ### Speed 4K+ — v2.9.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json" />
@@ -373,7 +373,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="1080p">
-    ### Speed EasyNews — v2.9.0
+    ### Speed EasyNews — v2.9.2
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json" />
@@ -391,7 +391,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### Anime 4K — v2.8.3
+    ### Anime 4K — v2.8.5
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json" />
@@ -403,7 +403,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="1080p">
-    ### Anime — v2.8.3
+    ### Anime — v2.8.5
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json" />
@@ -415,7 +415,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Anime Dub — v2.8.3
+    ### Anime Dub — v2.8.5
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub.json" />
@@ -427,7 +427,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="Lite">
-    ### Anime 4K Lite — v2.8.3
+    ### Anime 4K Lite — v2.8.4
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json" />
@@ -439,7 +439,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Anime Lite — v2.8.3
+    ### Anime Lite — v2.8.4
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-lite.json" />
@@ -451,7 +451,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Anime Dub Lite — v2.8.3
+    ### Anime Dub Lite — v2.8.4
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json" />
@@ -473,12 +473,12 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 | Template | Version | Status | Import URL |
 |---|---|---|---|
-| Apple TV 4K | v0.1.5 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| Samsung RU7100 4K | v0.2.10 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
-| 4K Apex Labs | v0.8.4 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| Stream Labs | v0.6.4 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| Essential Labs | v0.1.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| 4K Essential Labs | v0.1.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| Apple TV 4K | v0.1.7 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
+| Samsung RU7100 4K | v0.2.11 | Nightly | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json` |
+| 4K Apex Labs | v0.8.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| Stream Labs | v0.6.5 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| Essential Labs | v0.1.6 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| 4K Essential Labs | v0.1.6 | Labs | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
 
 → [What's being tested?](/nightly-and-labs)
 


### PR DESCRIPTION
## Summary

All 38 version numbers in `template-directory.mdx` were stale — the page hadn't been updated since the v2.9.0 era. Multiple rounds of patches (Per-Addon Flood Guard, changelog fix, ESE audit, Upscaled 4K fix) bumped template versions without updating the docs.

**Updated:** every template heading version + Nightly table + page header (v2.9.1 → v2.9.2). All URLs verified correct — no broken paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_