### PR TITLE
chore: CHANGELOG v2.9.3, CLAUDE.md version sync, Nightly Samsung ESE fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ---
 
+## 2.9.3 (2026-06-20)
+
+### Fixed
+- **`/*Upscaled 4k*/` ESE — WEB-DL/WEBRip exemption** (24 stable templates + `Nightly/Samsung/core-nexus-samsung-tv-4k.json`). The ESE blocked all 4K streams whenever a 1080p Bluray REMUX existed but no 4K REMUX was found. This incorrectly suppressed genuine 4K WEB-DL releases for new theatrical releases (e.g. Spider-Man: Brand New Day) where a streaming master exists but the Blu-ray hasn't shipped yet. Added `and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0` as an additional gate — 4K WEB-DL and WEBRip streams are now preserved in this scenario.
+- **`metadata.changelog` string field** removed from 6 templates (`core-nexus-4k-alldebrid-lite.json`, `core-nexus-4k-alldebrid.json`, `core-nexus-alldebrid-lite.json`, `core-nexus-alldebrid.json`, `core-nexus-samsung-tv-4k.json`, `core-nexus-samsung-tv.json`). AIOStreams schema requires `metadata.changelog` to be an array or absent — a plain string causes "Invalid input → at metadata.changelog" on import.
+
+### Chore
+- **`docs/template-directory.mdx` version sync** — all 38 template version numbers in the docs were stale. Synced to actual template `metadata.version` values.
+
+---
+
 ## 2.9.2 (2026-06-19)
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,25 +90,25 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ---
 
-## Active Template Inventory (as of v2.9.2)
+## Active Template Inventory (as of v2.9.3)
 
 ### Single (TorBox Pro)
 - `Single/core-nexus-4k-apex.json` v0.4.12 — flagship 4K, IQR PSEs, pow() decay
 - `Single/core-nexus-4k-apex-torbox.json` v2.9.1 — TorBox-cached-only Apex variant
-- `Single/core-nexus-stream.json` v2.9.1 — 1080p streaming quality
+- `Single/core-nexus-stream.json` v2.9.2 — 1080p streaming quality
 - `Single/core-nexus-stream-lite.json` v2.9.1 — lite variant
-- `Single/core-nexus-stream-firestick.json` v2.9.1 — Fire Stick optimised
+- `Single/core-nexus-stream-firestick.json` v2.9.2 — Fire Stick optimised
 - `Single/core-nexus-stream-firestick-lite.json` v2.9.1
 
 ### Essential (TorBox Essential)
 - `Essential/core-nexus-4k-essential.json` v2.9.1 — 4K with IQR PSEs, pow() decay
 - `Essential/core-nexus-4k-essential-lite.json` v2.9.1 — CB-style PSEs
-- `Essential/core-nexus-essential.json` v2.9.1 — 1080p
+- `Essential/core-nexus-essential.json` v2.9.2 — 1080p
 - `Essential/core-nexus-essential-lite.json` v2.9.1
 
 ### Flash
 - `Flash/core-nexus-flash-4k.json` v2.9.1 — cached-only 4K instant play
-- `Flash/core-nexus-flash.json` v2.9.1 — cached-only 1080p instant play
+- `Flash/core-nexus-flash.json` v2.9.2 — cached-only 1080p instant play
 
 ### Speed (TorBox)
 - `Speed/TorBox/core-nexus-speed-4k.json` v2.9.1 — fast cached 4K
@@ -118,36 +118,36 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ### Speed (EasyNews)
 - `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.1 — EasyNews 4K
-- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.1 — EasyNews 1080p
+- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.2 — EasyNews 1080p
 
 ### AllDebrid
 - `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.9 — 4K with IQR PSEs
 - `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.7 — 4K CB-style
-- `AllDebrid/core-nexus-alldebrid.json` v0.1.8 — 1080p
-- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.8 — 1080p lite
+- `AllDebrid/core-nexus-alldebrid.json` v0.1.9 — 1080p
+- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.9 — 1080p lite
 
 ### Hybrid
-- `Hybrid/core-nexus-4k-hybrid.json` v2.9.1 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
-- `Hybrid/core-nexus-hybrid.json` v2.9.1 — 1080p hybrid, NZBGeek preset
+- `Hybrid/core-nexus-4k-hybrid.json` v2.9.2 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
+- `Hybrid/core-nexus-hybrid.json` v2.9.2 — 1080p hybrid, NZBGeek preset
 - `Hybrid/core-nexus-hybrid-lite.json` v2.9.1 — NZBGeek preset
 
 ### Device
-- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.10 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
-- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.10 — 4K, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.11 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
+- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.11 — 4K, DV-Only Kill on, AV1/VC-1 excluded
 
 ### Anime
-- `Anime/core-nexus-anime-4k.json` v2.8.4 — 4K anime, SeaDex + AnimeTosho
+- `Anime/core-nexus-anime-4k.json` v2.8.5 — 4K anime, SeaDex + AnimeTosho
 - `Anime/core-nexus-anime-4k-lite.json` v2.8.4
-- `Anime/core-nexus-anime.json` v2.8.4 — 1080p anime
+- `Anime/core-nexus-anime.json` v2.8.5 — 1080p anime
 - `Anime/core-nexus-anime-lite.json` v2.8.4
-- `Anime/core-nexus-anime-dub.json` v2.8.4 — dubbed variant
+- `Anime/core-nexus-anime-dub.json` v2.8.5 — dubbed variant
 - `Anime/core-nexus-anime-dub-lite.json` v2.8.4
 
 ### Nightly (gitignored — force-add to commit)
-- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.6 — DV Profile 5/8, AV1 excluded
+- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.7 — DV Profile 5/8, AV1 excluded
 - `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.6 — Essential 4K experimental
 - `Nightly/Essential/core-nexus-essential-labs.json` v0.1.6 — Essential 1080p experimental
-- `Nightly/Samsung/core-nexus-samsung-tv-4k.json` v0.2.11 — Samsung 4K nightly (RU7100)
+- `Nightly/Samsung/core-nexus-samsung-tv-4k.json` v0.2.12 — Samsung 4K nightly (RU7100)
 - `Nightly/Single/core-nexus-4k-apex-labs.json` v0.8.5 — perGroup() prototypes, dynamicAddonFetching, releaseGroup() ESEs
 - `Nightly/Single/core-nexus-stream-labs.json` v0.6.5 — perGroup() prototypes, dynamicAddonFetching
 

--- a/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Nightly/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung RU7100 (UA65RU7100W) and compatible TVs. Native video containers: MKV, MP4, AVI, MOV, FLV, ASF, 3GP, VOB. Native audio: FLAC, AAC, MP3, M4A, WMA, WAV. No AV1 or Dolby Vision \u2014 DV streams excluded. HDR10+, HDR10, HLG priority. HEVC/AVC encodes only. Audio prioritises FLAC and AAC for native playback; Atmos/TrueHD/DTS ranked lower (passthrough/transcode). Full Core Builds expression layer: IQR Apex PSEs \u00b7 REPACK/PROPER Passthrough \u00b7 Per-Addon Flood Guard \u00b7 Usenet Propagation Guard \u00b7 AI Upscale Exclusion \u00b7 Codec Efficiency Booster \u00b7 Audio Pinnacle (native-first) \u00b7 HDR Priority (no DV) \u00b7 Ranked regex pool \u00b7 Full CB ESE stack.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -260,7 +260,7 @@
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
         "enabled": true
       },
       {

--- a/docs/instance-status.mdx
+++ b/docs/instance-status.mdx
@@ -41,7 +41,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **ATBP** | 🟢 Online | [aio.atbphosting.com](https://aio.atbphosting.com/stremio/configure) |
 | **Omni's** | 🟢 Online | [aiostreams.12312023.xyz](https://aiostreams.12312023.xyz/stremio/configure) |
 
-*Last checked: 2026-06-19 19:41 UTC*
+*Last checked: 2026-06-20 00:19 UTC*
 <!-- STATUS_STABLE_END -->
 
 ---
@@ -60,7 +60,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **Kuu's Nightly** | 🟢 Online | [aiostreams-nightly.stremio.ru](https://aiostreams-nightly.stremio.ru/stremio/configure) |
 | **Viren's Nightly** | 🟢 Online | [aiostreams.viren070.me](https://aiostreams.viren070.me/stremio/configure) |
 
-*Last checked: 2026-06-19 19:41 UTC*
+*Last checked: 2026-06-20 00:19 UTC*
 <!-- STATUS_NIGHTLY_END -->
 
 ---


### PR DESCRIPTION
## Summary

- **CHANGELOG v2.9.3 (2026-06-20)** — documents the Upscaled 4k WEB-DL exemption (24 templates, PR #190), `metadata.changelog` string removal (6 templates, PR #186), and docs version sync chore (PR #191)
- **CLAUDE.md inventory sync** — 16 stale version numbers updated to match actual `metadata.version` values; section header bumped to v2.9.3
- **Nightly Samsung ESE fix** — `Nightly/Samsung/core-nexus-samsung-tv-4k.json` v0.2.11 → v0.2.12: applies the same `/*Upscaled 4k*/` WEB-DL/WEBRip exemption that landed on 24 stable templates in PR #190 (Nightly Samsung was missed by the fix script)

## Test plan

- [ ] 120 tests pass (`python3 -m pytest tests/ -q`)
- [ ] CHANGELOG has `## 2.9.3 (2026-06-20)` entry between `[Unreleased]` and `2.9.2`
- [ ] CLAUDE.md inventory header reads "as of v2.9.3"
- [ ] Nightly Samsung version is 0.2.12 and Upscaled 4k ESE contains `WEB-DL` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_