### PR TITLE
docs: fix nav logo — icon at correct height

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "Core Builds",
   "logo": {
-    "light": "/logo/core_builds_banner.png",
-    "dark": "/logo/core_builds_banner.png",
-    "height": 120
+    "light": "/logo/core_icon.svg",
+    "dark": "/logo/core_icon.svg",
+    "height": 28
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {


### PR DESCRIPTION
## Summary

`core_builds_banner.png` at `height: 120` was a full-width banner image being squashed into the top-left nav corner. Replaced with `core_icon.svg` at `height: 28` — the same size pattern AIOStreams and other Mintlify sites use. Mintlify automatically renders the icon alongside the "Core Builds" name text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_