### PR TITLE
docs: restore square logo in nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "Core Builds",
   "logo": {
-    "light": "/logo/core_icon.svg",
-    "dark": "/logo/core_icon.svg",
-    "height": 28
+    "light": "/logo/banner_square.svg",
+    "dark": "/logo/banner_square.svg",
+    "height": 36
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {


### PR DESCRIPTION
Switches nav logo from `core_icon.svg` (renders as a small geometric shape) to `banner_square.svg` at height 36 — the actual square logo asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_