### PR TITLE
docs: add square logo to landing page hero

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,7 +6,13 @@ mode: "wide"
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>
 
-  <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '28px', letterSpacing: '0.01em' }}>
+  <img
+    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square.svg"
+    alt="Core Builds"
+    style={{ width: '80px', height: '80px', display: 'block', margin: '0 auto 20px' }}
+  />
+
+  <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>
     AIOStreams Templates
   </div>
 


### PR DESCRIPTION
Adds `banner_square.svg` at 80×80px to the hero section of `introduction.mdx`, sitting above the badge pill and the "Core Builds" title — so both the logo and the title are visible on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_