### PR TITLE
docs: show square logo + Core Builds name in nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5,7 +5,7 @@
   "logo": {
     "light": "/logo/banner_square.svg",
     "dark": "/logo/banner_square.svg",
-    "height": 36
+    "height": 24
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {


### PR DESCRIPTION
Drops nav logo `height` from 36 → 24. At 36px Mintlify fills the logo slot with just the image and suppresses the name text. At 24px it treats it as an icon-sized logo and renders the "Core Builds" site name alongside it in the top-left corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_