### PR TITLE
docs: transparent hero icon + nav logo with Core Builds text

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "Core Builds",
   "logo": {
-    "light": "/logo/banner_square.svg",
-    "dark": "/logo/banner_square.svg",
-    "height": 24
+    "light": "/logo/nav_logo.svg",
+    "dark": "/logo/nav_logo.svg",
+    "height": 32
   },
   "favicon": "/logo/core_icon.svg",
   "colors": {

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,9 +7,9 @@ mode: "wide"
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>
 
   <img
-    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square.svg"
+    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/core_icon_transparent.svg"
     alt="Core Builds"
-    style={{ width: '80px', height: '80px', display: 'block', margin: '0 auto 20px' }}
+    style={{ width: '88px', height: '88px', display: 'block', margin: '0 auto 20px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>

--- a/docs/logo/core_icon_transparent.svg
+++ b/docs/logo/core_icon_transparent.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
+    </linearGradient>
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
+    </linearGradient>
+    <filter id="hexGlow">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="diamGlow">
+      <feGaussianBlur stdDeviation="14" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="24"/>
+    </filter>
+  </defs>
+
+  <!-- Ambient glow -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="#00e5ff" opacity="0.04" filter="url(#softGlow)"/>
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="#c060c0" opacity="0.08" filter="url(#softGlow)"/>
+
+  <!-- Hex glow layer -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round"
+    opacity="0.3" filter="url(#hexGlow)"/>
+
+  <!-- Hex outline -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+    fill="none" stroke="url(#hexGrad)" stroke-width="22" stroke-linejoin="round"/>
+
+  <!-- Diamond glow -->
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+
+  <!-- Diamond -->
+  <polygon points="256,166 346,256 256,346 166,256"
+    fill="url(#diamGrad)" opacity="0.95"/>
+</svg>

--- a/docs/logo/nav_logo.svg
+++ b/docs/logo/nav_logo.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 64" width="320" height="64">
+  <defs>
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
+    </linearGradient>
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
+    </linearGradient>
+    <filter id="hexGlow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="diamGlow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+  </defs>
+
+  <!-- Icon (centred on 32x64 left block, scaled down from 512 viewBox) -->
+  <g transform="translate(4, 4) scale(0.109375)">
+    <!-- Hex glow -->
+    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+      fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round"
+      opacity="0.35" filter="url(#hexGlow)"/>
+    <!-- Hex outline -->
+    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149"
+      fill="none" stroke="url(#hexGrad)" stroke-width="22" stroke-linejoin="round"/>
+    <!-- Diamond glow -->
+    <polygon points="256,166 346,256 256,346 166,256"
+      fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+    <!-- Diamond -->
+    <polygon points="256,166 346,256 256,346 166,256"
+      fill="url(#diamGrad)" opacity="0.95"/>
+  </g>
+
+  <!-- "Core Builds" text -->
+  <text x="68" y="40"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="22" font-weight="600"
+    fill="#f1f5f9">Core Builds</text>
+</svg>


### PR DESCRIPTION
Two logo changes:

**Landing page hero** — swaps `banner_square.svg` for `core_icon_transparent.svg` (same hex icon, dark circle background removed, fully transparent).

**Nav corner** — new `nav_logo.svg`: the hex icon + "Core Builds" text baked into a single 320×64 SVG. Since Mintlify doesn't reliably append the site name text at larger icon heights, baking it in guarantees it always renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_