### PR TITLE
docs: hide breadcrumb and page header on landing page

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,14 +1,17 @@
 ---
-title: "Core Builds"
+sidebarTitle: "Introduction"
 mode: "wide"
-breadcrumbs: false
 ---
 
 <style>{`
+  article nav,
+  article header,
+  article > h1,
   [class*="Breadcrumb"], [class*="breadcrumb"],
   [class*="PageHeader"], [class*="page-header"],
   [class*="ContentHeader"], [class*="content-header"],
-  [class*="ArticleHeader"], [class*="article-header"] { display: none !important; }
+  [class*="ArticleHeader"], [class*="article-header"],
+  [class*="eyebrow"], [class*="Eyebrow"] { display: none !important; }
 `}</style>
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Core Builds"
 mode: "wide"
+breadcrumbs: false
 ---
 
 <style>{`
-  [class*="PageHeader"], [class*="page-header"], [class*="ContentHeader"],
-  [class*="content-header"], [class*="prose"] > h1:first-child,
+  [class*="Breadcrumb"], [class*="breadcrumb"],
+  [class*="PageHeader"], [class*="page-header"],
+  [class*="ContentHeader"], [class*="content-header"],
   [class*="ArticleHeader"], [class*="article-header"] { display: none !important; }
 `}</style>
 
@@ -14,7 +16,7 @@ mode: "wide"
   <img
     src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square_transparent.svg"
     alt="Core Builds"
-    style={{ width: '240px', height: '240px', display: 'block', margin: '0 auto 24px' }}
+    style={{ width: '300px', height: '300px', display: 'block', margin: '0 auto 24px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -16,7 +16,7 @@ breadcrumbs: false
   <img
     src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square_transparent.svg"
     alt="Core Builds"
-    style={{ width: '300px', height: '300px', display: 'block', margin: '0 auto 24px' }}
+    style={{ width: '400px', height: '400px', display: 'block', margin: '0 auto 24px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,22 +1,25 @@
 ---
 title: "Core Builds"
-description: "Optimised AIOStreams templates for TorBox, AllDebrid and EasyNews."
 mode: "wide"
 ---
+
+<style>{`
+  [class*="PageHeader"], [class*="page-header"], [class*="ContentHeader"],
+  [class*="content-header"], [class*="prose"] > h1:first-child,
+  [class*="ArticleHeader"], [class*="article-header"] { display: none !important; }
+`}</style>
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>
 
   <img
-    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/core_icon_transparent.svg"
+    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square_transparent.svg"
     alt="Core Builds"
-    style={{ width: '88px', height: '88px', display: 'block', margin: '0 auto 20px' }}
+    style={{ width: '160px', height: '160px', display: 'block', margin: '0 auto 24px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>
     AIOStreams Templates
   </div>
-
-  <h1 style={{ fontSize: '52px', fontWeight: '800', color: '#f1f5f9', margin: '0 0 20px', lineHeight: '1.1', letterSpacing: '-0.02em' }}>Core Builds</h1>
 
   <p style={{ fontSize: '18px', color: '#94a3b8', margin: '0 0 36px', lineHeight: '1.65' }}>
     Smart filtering, scored sorting, and zero-friction playback —<br />

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -14,7 +14,7 @@ mode: "wide"
   <img
     src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square_transparent.svg"
     alt="Core Builds"
-    style={{ width: '160px', height: '160px', display: 'block', margin: '0 auto 24px' }}
+    style={{ width: '240px', height: '240px', display: 'block', margin: '0 auto 24px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>

--- a/docs/logo/banner_square_transparent.svg
+++ b/docs/logo/banner_square_transparent.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" width="600" height="600">
+  <defs>
+    <linearGradient id="hexGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#4facfe"/>
+    </linearGradient>
+    <linearGradient id="diamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="50%" stop-color="#c060c0"/>
+      <stop offset="100%" stop-color="#ff4b2b"/>
+    </linearGradient>
+    <linearGradient id="orangeGrad" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#ff9472"/>
+      <stop offset="100%" stop-color="#e8401a"/>
+    </linearGradient>
+    <filter id="hexGlow"><feGaussianBlur stdDeviation="10" result="blur"/><feComposite in="SourceGraphic" in2="blur" operator="over"/></filter>
+    <filter id="diamGlow"><feGaussianBlur stdDeviation="12" result="blur"/><feComposite in="SourceGraphic" in2="blur" operator="over"/></filter>
+    <filter id="softGlow"><feGaussianBlur stdDeviation="20"/></filter>
+  </defs>
+
+  <!-- Ambient glow -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="#00e5ff" opacity="0.04" filter="url(#softGlow)"/>
+  <polygon points="300,212 356,268 300,324 244,268" fill="#c060c0" opacity="0.08" filter="url(#softGlow)"/>
+
+  <!-- Hex glow -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="none" stroke="#00e5ff" stroke-width="28" stroke-linejoin="round" opacity="0.3" filter="url(#hexGlow)"/>
+
+  <!-- Hex outline -->
+  <polygon points="300,152 400,208 400,320 300,376 200,320 200,208" fill="none" stroke="url(#hexGrad)" stroke-width="20" stroke-linejoin="round"/>
+
+  <!-- Diamond glow -->
+  <polygon points="300,212 356,268 300,324 244,268" fill="url(#diamGrad)" opacity="0.4" filter="url(#diamGlow)"/>
+
+  <!-- Diamond -->
+  <polygon points="300,212 356,268 300,324 244,268" fill="url(#diamGrad)" opacity="0.95"/>
+
+  <!-- CORE BUILDS -->
+  <text x="300" y="450"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="26" font-weight="600" letter-spacing="5"
+    fill="#00e5ff" text-anchor="middle">CORE BUILDS</text>
+
+  <!-- BY BREVITY -->
+  <text x="300" y="476"
+    font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+    font-size="19" font-weight="300" letter-spacing="5"
+    fill="url(#orangeGrad)" text-anchor="middle" opacity="0.65">BY BREVITY</text>
+</svg>


### PR DESCRIPTION
Previous attempt used guessed class names that didn't match Mintlify's hashed CSS modules. This switches to targeting semantic HTML elements (`article nav`, `article header`, `article > h1`) which are stable regardless of Mintlify's build output. Also replaces `title` with `sidebarTitle` so the sidebar nav label is preserved but no auto-generated h1 is rendered above the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_