### PR TITLE
docs: hide breadcrumb and page header on landing page

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,14 +1,17 @@
 ---
-title: "Core Builds"
+sidebarTitle: "Introduction"
 mode: "wide"
-breadcrumbs: false
 ---
 
 <style>{`
+  article nav,
+  article header,
+  article > h1,
   [class*="Breadcrumb"], [class*="breadcrumb"],
   [class*="PageHeader"], [class*="page-header"],
   [class*="ContentHeader"], [class*="content-header"],
-  [class*="ArticleHeader"], [class*="article-header"] { display: none !important; }
+  [class*="ArticleHeader"], [class*="article-header"],
+  [class*="eyebrow"], [class*="Eyebrow"] { display: none !important; }
 `}</style>
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>


### PR DESCRIPTION
Targets semantic HTML elements (`article nav`, `article header`, `article > h1`) to hide the Mintlify-generated breadcrumb and page header — stable regardless of Mintlify's hashed CSS module class names. Also switches `title` to `sidebarTitle` so the sidebar nav label is preserved without rendering an auto-generated h1 above the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_