### PR TITLE
docs: stats bar + improved breadcrumb suppression

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -31,10 +31,25 @@ mode: "wide"
     optimised for TorBox, AllDebrid and EasyNews.
   </p>
 
-  <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '72px' }}>
+  <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '32px' }}>
     <a href="/importing" style={{ display: 'inline-flex', alignItems: 'center', background: '#ffffff', color: '#0f172a', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none' }}>Read the docs</a>
     <a href="https://github.com/brevityA/Core-Builds" target="_blank" style={{ display: 'inline-flex', alignItems: 'center', background: 'transparent', color: '#94a3b8', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none', border: '1px solid #334155' }}>GitHub</a>
     <a href="/template-directory" style={{ display: 'inline-flex', alignItems: 'center', background: 'transparent', color: '#94a3b8', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none', border: '1px solid #334155' }}>Templates</a>
+  </div>
+
+  <div style={{ display: 'flex', background: '#0f172a', borderRadius: '12px', border: '1px solid #1e3a5f', overflow: 'hidden', marginBottom: '56px' }}>
+    <div style={{ flex: 1, textAlign: 'center', padding: '20px 0', borderRight: '1px solid #1e3a5f' }}>
+      <div style={{ fontSize: '28px', fontWeight: '800', color: '#60a5fa' }}>40+</div>
+      <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>TEMPLATES</div>
+    </div>
+    <div style={{ flex: 1, textAlign: 'center', padding: '20px 0', borderRight: '1px solid #1e3a5f' }}>
+      <div style={{ fontSize: '28px', fontWeight: '800', color: '#60a5fa' }}>3</div>
+      <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>SERVICES</div>
+    </div>
+    <div style={{ flex: 1, textAlign: 'center', padding: '20px 0' }}>
+      <div style={{ fontSize: '22px', fontWeight: '800', color: '#60a5fa' }}>v2.9.3</div>
+      <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>LATEST</div>
+    </div>
   </div>
 
 </div>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,14 +4,15 @@ mode: "wide"
 ---
 
 <style>{`
-  article nav,
-  article header,
-  article > h1,
-  [class*="Breadcrumb"], [class*="breadcrumb"],
-  [class*="PageHeader"], [class*="page-header"],
-  [class*="ContentHeader"], [class*="content-header"],
-  [class*="ArticleHeader"], [class*="article-header"],
-  [class*="eyebrow"], [class*="Eyebrow"] { display: none !important; }
+  h1 { display: none !important; }
+  nav:has(button + a) { display: none !important; }
+  :has(+ h1) { display: none !important; }
+  article nav, article header, article > h1 { display: none !important; }
+  [class*="Breadcrumb" i], [class*="breadcrumb" i],
+  [class*="PageHeader" i], [class*="page-header" i],
+  [class*="eyebrow" i], [class*="Eyebrow" i],
+  [class*="ContentHeader" i], [class*="content-header" i],
+  [class*="ArticleHeader" i], [class*="article-header" i] { display: none !important; }
 `}</style>
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '64px 24px 0', textAlign: 'center' }}>


### PR DESCRIPTION
Restores the stats bar and improves the CSS header suppression on the landing page.

**Changes:**
- Restore stats bar: 40+ TEMPLATES · 3 SERVICES · v2.9.3 LATEST
- Switch `title` → `sidebarTitle` to decouple sidebar nav label from rendered `<h1>`
- Remove `breadcrumbs: false` (had no effect in practice)
- Replace class-name-based CSS selectors with `:has()` structural selectors — targets Mintlify's breadcrumb/page header by HTML structure rather than hashed class names

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_