### PR TITLE
docs: hide intro header + cyan nav text

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,9 @@
+/* Hide the auto-generated page title on the introduction page.
+   Detected by the presence of banner_square_transparent.svg — unique to that page. */
+body:has(img[src*="banner_square_transparent"]) h1 {
+  display: none !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -84,5 +84,9 @@
     "og:image": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_builds_banner.png",
     "og:site_name": "Core Builds",
     "twitter:card": "summary_large_image"
-  }
+  },
+  "styling": {
+    "eyebrow": "never"
+  },
+  "css": "/custom.css"
 }

--- a/docs/logo/nav_logo.svg
+++ b/docs/logo/nav_logo.svg
@@ -40,5 +40,5 @@
   <text x="68" y="40"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="22" font-weight="600"
-    fill="#f1f5f9">Core Builds</text>
+    fill="#00e5ff">Core Builds</text>
 </svg>


### PR DESCRIPTION
- `styling.eyebrow: never` — removes "Getting Started" breadcrumb globally
- `custom.css` — hides h1 on introduction page using `body:has(img[src*="banner_square_transparent"]) h1` (page-specific, no class name guessing)
- `nav_logo.svg` — "Core Builds" text colour `#f1f5f9` → `#00e5ff` to match the hero logo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_