### PR TITLE
docs: hide Getting Started eyebrow on introduction page

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,6 +1,14 @@
-/* Hide the auto-generated page title on the introduction page.
-   Detected by the presence of banner_square_transparent.svg — unique to that page. */
-body:has(img[src*="banner_square_transparent"]) h1 {
+/* Introduction page: hide auto-generated header elements.
+   Detected by presence of banner_square_transparent.svg — unique to that page. */
+body:has(img[src*="banner_square_transparent"]) h1,
+body:has(img[src*="banner_square_transparent"]) [class*="eyebrow" i],
+body:has(img[src*="banner_square_transparent"]) [class*="Eyebrow" i],
+body:has(img[src*="banner_square_transparent"]) [class*="breadcrumb" i],
+body:has(img[src*="banner_square_transparent"]) [class*="Breadcrumb" i],
+body:has(img[src*="banner_square_transparent"]) [class*="PageHeader" i],
+body:has(img[src*="banner_square_transparent"]) [class*="page-header" i],
+body:has(img[src*="banner_square_transparent"]) [class*="ContentHeader" i],
+body:has(img[src*="banner_square_transparent"]) [class*="ArticleHeader" i] {
   display: none !important;
   height: 0 !important;
   margin: 0 !important;


### PR DESCRIPTION
Extends the `body:has(img[src*="banner_square_transparent"])` CSS rule to also target eyebrow/breadcrumb class patterns — removes the "Getting Started" label that `styling.eyebrow: never` failed to suppress.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_