### PR TITLE
docs: landing page UX audit

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -20,20 +20,27 @@ mode: "wide"
   <img
     src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/docs/logo/banner_square_transparent.svg"
     alt="Core Builds"
-    style={{ width: '400px', height: '400px', display: 'block', margin: '0 auto 24px' }}
+    style={{ width: '320px', height: '320px', display: 'block', margin: '0 auto 24px' }}
   />
 
   <div style={{ display: 'inline-block', background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.3)', color: '#93C5FD', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>
     AIOStreams Templates
   </div>
 
-  <p style={{ fontSize: '18px', color: '#94a3b8', margin: '0 0 36px', lineHeight: '1.65' }}>
+  <p style={{ fontSize: '18px', color: '#94a3b8', margin: '0 0 8px', lineHeight: '1.65' }}>
     Smart filtering, scored sorting, and zero-friction playback —<br />
     optimised for TorBox, AllDebrid and EasyNews.
   </p>
 
+  <p style={{ fontSize: '13px', color: '#475569', margin: '0 0 32px' }}>
+    One-click install for Stremio via AIOStreams.
+  </p>
+
   <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '32px' }}>
-    <a href="/importing" style={{ display: 'inline-flex', alignItems: 'center', background: '#ffffff', color: '#0f172a', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none' }}>Read the docs</a>
+    <a href="/which-template" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#3B82F6', color: '#ffffff', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none' }}>
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+      Get Started
+    </a>
     <a href="https://github.com/brevityA/Core-Builds" target="_blank" style={{ display: 'inline-flex', alignItems: 'center', background: 'transparent', color: '#94a3b8', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none', border: '1px solid #334155' }}>GitHub</a>
     <a href="/template-directory" style={{ display: 'inline-flex', alignItems: 'center', background: 'transparent', color: '#94a3b8', padding: '10px 22px', borderRadius: '8px', fontSize: '14px', fontWeight: '600', textDecoration: 'none', border: '1px solid #334155' }}>Templates</a>
   </div>
@@ -44,35 +51,35 @@ mode: "wide"
       <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>TEMPLATES</div>
     </div>
     <div style={{ flex: 1, textAlign: 'center', padding: '20px 0' }}>
-      <div style={{ fontSize: '22px', fontWeight: '800', color: '#60a5fa' }}>v2.9.3</div>
-      <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>LATEST</div>
+      <div style={{ fontSize: '22px', fontWeight: '800', color: '#60a5fa' }}><a href="/changelog" style={{ color: 'inherit', textDecoration: 'none' }}>v2.9.3</a></div>
+      <div style={{ fontSize: '9px', color: '#52525b', letterSpacing: '1.5px', marginTop: '4px' }}>LATEST — <a href="/changelog" style={{ color: '#475569', fontSize: '9px', textDecoration: 'none', letterSpacing: '1px' }}>CHANGELOG ↗</a></div>
     </div>
   </div>
 
   <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '56px' }}>
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#3B82F6', flexShrink: 0 }}></span>TorBox</span>
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#a78bfa', flexShrink: 0 }}></span>AllDebrid</span>
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#34d399', flexShrink: 0 }}></span>EasyNews</span>
+    <a href="/template-directory#torbox-pro" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8', textDecoration: 'none' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#3B82F6', flexShrink: 0 }}></span>TorBox</a>
+    <a href="/template-directory#alldebrid" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8', textDecoration: 'none' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#a78bfa', flexShrink: 0 }}></span>AllDebrid</a>
+    <a href="/template-directory#easynews-speed" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: '#0f172a', border: '1px solid #1e3a5f', borderRadius: '999px', padding: '6px 14px', fontSize: '12px', fontWeight: '600', color: '#94a3b8', textDecoration: 'none' }}><span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#34d399', flexShrink: 0 }}></span>EasyNews</a>
   </div>
 
 </div>
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '0 24px 72px' }}>
 
-  <p style={{ fontSize: '11px', fontWeight: '600', letterSpacing: '1.5px', color: '#475569', marginBottom: '16px' }}>EXPLORE THE DOCS</p>
+  <p style={{ fontSize: '11px', fontWeight: '600', letterSpacing: '1.5px', color: '#64748b', marginBottom: '16px' }}>GET STARTED</p>
 
   <CardGroup cols={2}>
-    <Card title="Which Template?" icon="map" href="/which-template">
+    <Card title="Which Template?" icon="map" href="/which-template" color="#3B82F6">
       Find the right template for your setup in 30 seconds.
-    </Card>
-    <Card title="Template Directory" icon="list" href="/template-directory">
-      Every template with one-click import buttons and raw URLs.
     </Card>
     <Card title="Import a Template" icon="download" href="/importing">
       Step-by-step first-run guide — API keys, TMDB token, Stremio install.
     </Card>
     <Card title="How It Works" icon="gear" href="/how-it-works">
       Bitrate filtering, PSE/ESE architecture, and addon stack explained.
+    </Card>
+    <Card title="Template Directory" icon="list" href="/template-directory">
+      Every template with one-click import buttons and raw URLs.
     </Card>
     <Card title="Expression Layer" icon="code" href="/expression-layer">
       IQR PSEs, flood guards, and the full SEL function reference.


### PR DESCRIPTION
Full UX audit of the introduction landing page:

- Logo 400px → 320px (content visible above fold on mobile)
- Primary CTA "Read the docs" → "Get Started" (blue filled, arrow icon, links to /which-template)
- Add sub-tagline: "One-click install for Stremio via AIOStreams."
- v2.9.3 stat + label both link to /changelog
- Service pills (TorBox / AllDebrid / EasyNews) are now links to their template-directory sections
- Card order rebalanced for new-user flow: Which Template → Import → How It Works → Template Directory → Expression Layer → Troubleshooting
- Section label "EXPLORE THE DOCS" → "GET STARTED", brighter colour
- Which Template card gets blue colour accent

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_