### PR TITLE
docs: refresh expression-layer and troubleshooting pages

### DIFF
--- a/docs/expression-layer.mdx
+++ b/docs/expression-layer.mdx
@@ -19,49 +19,68 @@ A stream matched by an ESE never reaches PSE scoring. ISE-matched streams jump t
 
 ## ESEs — The Kill Stack
 
-Standard templates run **24 ESEs**. Lite templates run **12** (hard kills only — quality gates removed).
+Standard templates run **25–26 ESEs** depending on template type. Lite templates run 12 (hard kills only — quality gates removed).
+
+### Infrastructure ESEs (all templates)
+
+These run first and manage result counts, addon fairness, and platform-specific guards:
+
+| ESE | What it does |
+|---|---|
+| Per-Addon Flood Guard | Caps each scraper at its flood limit — Meteor ≤5, Comet RD ≤5, MediaFusion ≤4, EZTV/HdHub ≤3, Knaben/TorrentGalaxy ≤1. Prevents one noisy scraper from flooding the list. |
+| Usenet Propagation Guard | Suppresses Usenet NZBs younger than 2 hours when propagated alternatives exist — avoids corrupt early-propagation grabs. |
+| AI Upscale Exclusion | Removes AI-upscaled streams from non-library, non-SeaDex results. |
+| RD Copyright (per DMM) | Hides Real-Debrid copyright-blocked streams (WEB-DL/WEBRip flagged by RD's May 2026 filter). |
+| Extra Cached / Uncached limit ESEs | Three ESEs that cap how many cached HQ, cached LQ, and uncached streams can appear in the final list. |
+| Final Limit (All) | Hard cap on total results after all other ESEs have run. |
 
 ### Hard Kills (both Standard and Lite)
-These always run — they remove streams that are broken, unwatchable, or inappropriate regardless of library size:
+
+These always run — they remove streams that are broken, unwatchable, or structurally wrong regardless of library size:
 
 | ESE | What it kills |
 |---|---|
-| CAM Kill | Camera recordings, TS (Telesync), TC, SCR |
-| YouTube Kill | Streams sourced from YouTube rips |
-| 3D Kill | Full SBS / OU 3D streams |
-| Sub-720p Kill | 144p, 240p, 360p, 480p, 576p resolutions |
-| Bad NZB Kill | Malformed or incomplete Usenet NZBs |
-| Season Pack (episode query) | Season pack results on single-episode queries |
-| Hard Resolution Kill (1080p templates) | 2160p and 1440p on 1080p-only templates |
+| Hard CAM Kill | Camera recordings, TS (Telesync), TC, SCR |
+| Hard External Kill | YouTube rips and all external-type streams |
+| Hard Resolution Kill (1080p templates) | 2160p and 1440p — prevents 4K leaking into 1080p-only templates. Does not kill 720p on templates with a 720p fallback tier. |
+| Sub-720p Kill | 144p, 240p, 360p resolutions |
+| ongoingSeasonPack | On ongoing series, kills season packs when individual episode streams exist |
+| Kill Multi-Episode When Singles Exist | Removes multi-episode files on single-episode queries when per-episode streams are available |
+| Kill Season Packs When Episodes Exist | Removes full season packs on episode queries when individual episode results are available |
+| Kill Ambiguous Packs When Non-Pack Exist | Removes packs with ambiguous season/episode metadata when clean single-episode results exist |
 
 ### Quality Gates (Standard only)
-These run only on standard templates and can filter legitimate content on thin libraries:
+
+These run only on standard templates — they can filter legitimate content on thin libraries:
 
 | ESE | What it gates |
 |---|---|
-| Low Bitrate Kill | Streams with bitrate below the statistical floor for that title |
-| Low Seeder Kill | Torrents with fewer than 3 seeders |
-| Upscaled 4K Kill | AI-upscaled 4K that isn't native UHD |
-| Bad BluRay Kill | BluRay releases from known low-quality groups |
-| Corrupt Encode Kill | Releases flagged by community as defective |
+| Low Bitrate (G's) | Streams with bitrate below the statistical floor for that title |
+| Low Seeders | Torrents with fewer than 3 seeders |
+| Bad 4K Anime | 4K anime where a better-quality SeaDex result exists |
+| Upscaled 4K | AI-upscaled 4K that isn't native UHD — exempts WEB-DL/WEBRip for theatrical releases without a Blu-ray |
+| Bad 4K BluRay | 4K BluRay releases from known low-quality groups |
+| Bad 1080p BluRay | 1080p BluRay from low-quality groups when better sources exist |
+| Bad NZBs | Malformed, sample, or incomplete Usenet NZBs |
+| Extra SeaDex | Hides excess SeaDex results beyond the best when better-ranked alternatives are available |
+| Low SEL Score | Removes streams that scored in the bottom tier across all stream expressions |
 
 <Tip>
-  If the standard template returns very few results, switch to the Lite variant. If Lite returns results, one of the quality gate ESEs is filtering your content — likely the bitrate floor or low-seeder kill.
+  If the standard template returns very few results, switch to the Lite variant. If Lite returns results, one of the quality gate ESEs is filtering your content — most commonly the bitrate floor or low-seeder kill.
 </Tip>
 
 ---
 
 ## ISEs — Boost Stack
 
-ISEs run after ESEs and before PSEs. Matched streams jump to the top of results regardless of their PSE score.
+ISEs run after ESEs and before PSEs. Matched streams jump ahead of all ranked results regardless of their PSE score.
 
 | ISE | What it boosts |
 |---|---|
 | Library | Streams from your AIOStreams library (continue watching) |
+| digitalRelease Bypass | Passes through streams on movie/anime.movie queries to prevent premature ESE filtering on digital release day |
 | Cached First | All cached debrid/Usenet streams above uncached |
-| English | English-language streams above non-English |
-
-The `ongoingSeasonPack` ISE is also deployed — on ongoing series, season packs surface if no individual episode stream is available.
+| REPACK/PROPER Passthrough | Pins REPACK and PROPER releases above the result limit so patched encodes always surface |
 
 ---
 
@@ -121,11 +140,22 @@ bitrate(STREAMS,
 
 On release day, a wide window accepts most encodes — you want something to play. Over 90 days, the window converges on the median as more encodes appear and the statistical picture stabilises. This replaces the old hard 60-day cliff that caused all streams to drop in rank exactly on day 61.
 
+### Additional PSE tiers
+
+After the IQR quality tiers, three further PSEs run across all templates:
+
+| PSE | What it boosts |
+|---|---|
+| Codec Efficiency Booster | Surfaces HEVC/x265 encodes ahead of AVC/x264 at equivalent quality |
+| Audio Pinnacle | Promotes lossless and object-based audio: Atmos/TrueHD → DTS-HD MA/DTS:X → EAC3/DD+ |
+| HDR/DV Priority | Within 4K results, surfaces DV/HDR10+/HDR10 ahead of SDR |
+| Boost Cached Usenet | Catches any cached TorBox Usenet NZBs that slipped outside the IQR window and promotes them above uncached results |
+
 ---
 
 ## Hybrid TorBox-Priority PSEs
 
-The 4K Hybrid template adds a TorBox-cached twin PSE before each IQR tier:
+The 4K Hybrid template (and 4K Apex variants) adds a TorBox-cached twin PSE before each IQR tier:
 
 ```
 service(
@@ -140,10 +170,11 @@ This returns only TorBox-cached streams that match the IQR window. If no TorBox 
 
 ## Release Group Scoring
 
-Two regex systems run simultaneously and must have no overlapping pattern names (duplicates cause double-scoring):
+Two systems work together: `preferredRegexPatterns` for top-tier boosts and `regexOverrides` for the full scoring ladder.
 
 ### `preferredRegexPatterns`
-Template-specific patterns embedded per category. Score range: 70–100.
+
+Template-specific patterns with a strong positive boost. Score range: 70–100.
 
 | Template type | Count | Patterns |
 |---|---|---|
@@ -151,14 +182,15 @@ Template-specific patterns embedded per category. Score range: 70–100.
 | 1080p | 5 | Web T1, 126811, FLUX, SiC, BHDStudio |
 | Anime | 0 | SeaDex/AnimeTosho handle quality |
 
-### `rankedRegexPatterns`
-37 inline entries per template (embedded directly — not from an external file). Score range: −200 to +100.
+### `regexOverrides`
+
+48 inline scoring overrides applied on top of the Vidhin05 synced pattern set (`syncedRankedRegexUrls`). Vidhin05 provides 174 patterns as a base; the overrides reassign scores for groups Core Builds cares about. Score range: −200 to +100.
 
 | Tier | Score | Examples |
 |---|---|---|
 | S | +100 | FraMeSToR, SURCODE, EPSiLON |
-| A | +80 | KRaLiMaRKo, HONE, FGT (4K) |
-| B | +60 | DON, NCmt, SA89 |
+| A | +80 | KRaLiMaRKo, HONE, 126811, FLUX |
+| B | +60 | DON, NCmt, BHDStudio |
 | Penalised | −50 | Known upscale groups |
 | Bad | −75 | Consistently poor encode groups |
 | Blacklist | −200 | Scene groups releasing defective content |
@@ -171,10 +203,10 @@ AIOStreams enforces hard limits on expression size:
 
 | Limit | Value | Current highest |
 |---|---|---|
-| Max per expression | 3,000 chars | 2,953 chars (47 headroom) |
+| Max per expression | 3,000 chars | 2,953 chars (Final Limit ESE — 47 headroom) |
 | Max total (all expressions) | 50,000 chars | ~35,000 chars |
 | Max expression count | 200 | Well under |
 
 <Warning>
-  Do not grow the `Final Limit (All)` ESE further — it is already at 2,953 characters. Any addition risks hitting the 3,000 char hard limit.
+  Do not grow the `Final Limit (All)` ESE further — it is already at 2,953 characters. Any addition risks hitting the 3,000 char hard limit and breaking import.
 </Warning>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -65,14 +65,18 @@ Before troubleshooting, confirm what you're running.
   <Accordion title="No results / very few results">
     **Check first:**
     - Is the title in TorBox's cache? Search at [torbox.app](https://torbox.app)
-    - Are your scrapers enabled? Open AIOStreams → Add-ons — confirm Comet, MediaFusion, etc. are enabled
     - Are your API keys entered? TorBox key in Services, TMDB in Settings
+    - Are your scrapers enabled? Open AIOStreams → Add-ons — from v2.9.4, MediaFusion and HdHub are on by default; on older imports they may be toggled off
 
     **If you're on a Flash or Speed template:**
     These templates exit as soon as they find cached results. If TorBox doesn't have the title cached, Flash returns nothing. Switch to Core Nexus Essential for full coverage with uncached fallback.
 
     **Try the Lite variant:**
-    The standard template runs 24 ESEs (quality gates). Lite runs 12 — hard kills stay but quality gates are removed. If Lite returns results, one of the quality gates is filtering your content.
+    The standard template runs quality-gate ESEs (low bitrate, low seeders, bad encodes). Lite removes those gates — hard kills stay but quality filters are gone. If Lite returns results, one of the quality gates is filtering your content.
+  </Accordion>
+
+  <Accordion title="Stream returns only 1080p — no 720p results">
+    Fixed in v2.9.4. Earlier versions of the base Stream template had no 720p fallback tier — if a title had no 1080p source indexed, the template returned zero results instead of falling back to 720p WEB-DL or WEBRip. Re-import the latest Stream template. The Lite and Fire Stick variants already had this fallback; it now applies to the base template too.
   </Accordion>
 
   <Accordion title="4K streams showing on a 1080p template">
@@ -108,12 +112,12 @@ Before troubleshooting, confirm what you're running.
   <Accordion title="Samsung TV — audio not playing / stuttering">
     The Samsung TV templates exclude lossless audio (`TrueHD`, `DTS-HD MA`, `DTS:X`, `FLAC`) by default — these formats require HDMI ARC/eARC passthrough to a compatible receiver. If you have a compatible receiver and want lossless audio, remove those tags from `excludedAudioTags` in the AIOStreams settings after importing.
 
-    If audio is stuttering on tracks that should work, confirm your template is v0.2.8 or later and re-import.
+    If audio is stuttering on tracks that should work, re-import the latest Samsung TV template.
   </Accordion>
 
   <Accordion title="Samsung TV — Dolby Vision streams still appearing">
     The DV-Only Kill ESE is enabled by default on Samsung templates. If you're still seeing DV streams:
-    - Confirm your template version is v0.2.8 or later (re-import if not)
+    - Re-import the latest Samsung TV template
     - Check you haven't disabled the `No DV-Only` ESE in the AIOStreams expression editor
   </Accordion>
 


### PR DESCRIPTION
## Summary

### `expression-layer.mdx` — significant accuracy fixes

The page had several factual errors that have accumulated since the expression layer was first documented:

- **ESE count corrected**: was "24 ESEs", now accurately "25–26 depending on template type"
- **Missing ESEs added**: Per-Addon Flood Guard, Usenet Propagation Guard, AI Upscale Exclusion, RD Copyright, Extra Cached/Uncached limit ESEs — all shipped across v2.9.1–v2.9.3 but never documented here
- **Kill Stack restructured**: now split into Infrastructure / Hard Kills / Quality Gates for clarity
- **`ongoingSeasonPack` moved**: was incorrectly listed as an ISE — it's an ESE (index 7 in all templates)
- **Missing ISEs added**: REPACK/PROPER Passthrough, digitalRelease Bypass
- **Missing PSEs added**: Audio Pinnacle, HDR/DV Priority, Codec Efficiency Booster
- **Regex section corrected**: `rankedRegexPatterns` has 0 entries in all active templates; scoring is done via `regexOverrides` (48 entries) layered on top of the Vidhin05 `syncedRankedRegexUrls` base — documented accurately
- **Hybrid TorBox-Priority PSEs**: noted these apply to 4K Apex variants too, not just 4K Hybrid

### `troubleshooting.mdx` — stale content fixes

- "No results" advice updated: MediaFusion and HdHub are on by default from v2.9.4 — old advice told users to enable them manually
- New entry: "Stream returns only 1080p — no 720p results" pointing to the v2.9.4 720p fallback fix
- Samsung TV accordions: removed stale "v0.2.8 or later" version references

## Test plan

- [ ] expression-layer renders without MDX errors
- [ ] ESE / ISE / PSE tables display correctly
- [ ] troubleshooting new 720p accordion renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_