### PR TITLE
fix(nightly): add SeaDex ISE to Apple TV 4K + sync CLAUDE.md inventory to v2.9.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,51 +94,51 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ---
 
-## Active Template Inventory (as of v2.9.5)
+## Active Template Inventory (as of v2.9.7)
 
 ### Single (TorBox Pro)
-- `Single/core-nexus-4k-apex.json` v0.4.16 — flagship 4K, IQR PSEs, pow() decay, 5s dynamic fetching cap
-- `Single/core-nexus-4k-apex-torbox.json` v2.9.4 — TorBox-cached-only Apex variant
-- `Single/core-nexus-stream.json` v2.9.6 — 1080p streaming quality, 720p fallback
-- `Single/core-nexus-stream-lite.json` v2.9.3 — lite variant
-- `Single/core-nexus-stream-firestick.json` v2.9.5 — Fire Stick optimised
-- `Single/core-nexus-stream-firestick-lite.json` v2.9.3
+- `Single/core-nexus-4k-apex.json` v0.4.17 — flagship 4K, IQR PSEs, pow() decay, 5s dynamic fetching cap
+- `Single/core-nexus-4k-apex-torbox.json` v2.9.5 — TorBox-cached-only Apex variant
+- `Single/core-nexus-stream.json` v2.9.7 — 1080p streaming quality, 720p fallback
+- `Single/core-nexus-stream-lite.json` v2.9.4 — lite variant
+- `Single/core-nexus-stream-firestick.json` v2.9.6 — Fire Stick optimised
+- `Single/core-nexus-stream-firestick-lite.json` v2.9.4
 
 ### Essential (TorBox Essential)
-- `Essential/core-nexus-4k-essential.json` v2.9.4 — 4K with IQR PSEs, pow() decay
-- `Essential/core-nexus-4k-essential-lite.json` v2.9.3 — CB-style PSEs
-- `Essential/core-nexus-essential.json` v2.9.5 — 1080p
-- `Essential/core-nexus-essential-lite.json` v2.9.3
+- `Essential/core-nexus-4k-essential.json` v2.9.5 — 4K with IQR PSEs, pow() decay
+- `Essential/core-nexus-4k-essential-lite.json` v2.9.4 — CB-style PSEs
+- `Essential/core-nexus-essential.json` v2.9.6 — 1080p
+- `Essential/core-nexus-essential-lite.json` v2.9.4
 
 ### Flash
-- `Flash/core-nexus-flash-4k.json` v2.9.2 — cached-only 4K instant play
-- `Flash/core-nexus-flash.json` v2.9.3 — cached-only 1080p instant play
+- `Flash/core-nexus-flash-4k.json` v2.9.3 — cached-only 4K instant play
+- `Flash/core-nexus-flash.json` v2.9.4 — cached-only 1080p instant play
 
 ### Speed (TorBox)
-- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.1 — fast cached 4K
-- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.1
-- `Speed/TorBox/core-nexus-speed.json` v2.9.1 — fast cached 1080p
-- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.1
+- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.2 — fast cached 4K
+- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.2
+- `Speed/TorBox/core-nexus-speed.json` v2.9.2 — fast cached 1080p
+- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.2
 
 ### Speed (EasyNews)
-- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.3 — EasyNews 4K
-- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.4 — EasyNews 1080p
+- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.4 — EasyNews 4K
+- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.5 — EasyNews 1080p
 
 ### AllDebrid
-- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.14 — 4K with IQR PSEs
-- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.11 — 4K CB-style
-- `AllDebrid/core-nexus-alldebrid.json` v0.1.14 — 1080p
-- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.13 — 1080p lite
+- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.15 — 4K with IQR PSEs
+- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.12 — 4K CB-style
+- `AllDebrid/core-nexus-alldebrid.json` v0.1.15 — 1080p
+- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.14 — 1080p lite
 
 ### Hybrid
-- `Hybrid/core-nexus-4k-hybrid.json` v2.9.5 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
-- `Hybrid/core-nexus-hybrid.json` v2.9.6 — 1080p hybrid, TorBox-priority twins (IQR), NZBGeek preset
-- `Hybrid/core-nexus-hybrid-lite.json` v2.9.6 — TorBox-priority twins (CB-style), NZBGeek preset
+- `Hybrid/core-nexus-4k-hybrid.json` v2.9.6 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
+- `Hybrid/core-nexus-hybrid.json` v2.9.7 — 1080p hybrid, TorBox-priority twins (IQR), NZBGeek preset
+- `Hybrid/core-nexus-hybrid-lite.json` v2.9.7 — TorBox-priority twins (CB-style), NZBGeek preset
 
 ### Device
-- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.15 — 1080p, DV-Only Kill on, AV1/VC-1 excluded
-- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.15 — 4K, DV-Only Kill on, AV1/VC-1 excluded, simple quality-tier PSEs
-- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.16 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
+- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.16 — 1080p, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
+- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.16 — 4K, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
+- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.17 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
 
 ### Anime
 - `Anime/core-nexus-anime-4k.json` v2.8.8 — 4K anime, SeaDex + AnimeTosho
@@ -149,12 +149,12 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 - `Anime/core-nexus-anime-dub-lite.json` v2.8.6
 
 ### Nightly (gitignored — force-add to commit)
-- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.10 — DV Profile 5/8, AV1 excluded
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.7 — Essential 4K experimental
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.7 — Essential 1080p experimental
-- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.9.0 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins
-- `Nightly/Single/core-nexus-stream-labs.json` v0.6.7 — perGroup() prototypes, dynamicAddonFetching
-- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.0 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features
+- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.12 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.8 — Essential 4K experimental
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.8 — Essential 1080p experimental
+- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.9.1 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins
+- `Nightly/Single/core-nexus-stream-labs.json` v0.6.9 — perGroup() prototypes, dynamicAddonFetching, StreamNZB preset
+- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.1 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features
 - `Nightly/Anime/core-nexus-anime-4k-labs.json` v0.1.0 — Score IQR Guard, perGroup() dedup, Indexer Diversity, hasSeaDex conditional tiers, anime elite pins
 
 ---

--- a/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+++ b/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Apple TV 4K (3rd gen) and Infuse. Dolby Vision Profile 5/8 is natively supported \u2014 DV streams are prioritised. HDR10+ (3rd gen exclusive), HDR10, HLG, and SDR are also shown. AV1 hard-excluded (no hardware decoder on the A15 chip \u2014 severe performance hit). DD+ Atmos is the native top audio format. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox \u00b7 Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -347,6 +347,10 @@
       },
       {
         "expression": "/*ISE v1.2.3* [git.tamtaro.de]*/[]",
+        "enabled": true
+      },
+      {
+        "expression": "/*SeaDex*/merge(count(addon(cached(streams),'SeaDex'))>0?passthrough(addon(streams,'SeaDex'),'title'):[],count(addon(cached(streams),'SeaDex'))==0 and count(addon(streams,'SeaDex'))>0?addon(streams,'SeaDex'):[])",
         "enabled": true
       },
       {


### PR DESCRIPTION
## Summary

- **Apple TV 4K Nightly** (`v0.1.11 → v0.1.12`) — SeaDex passthrough ISE was missing. Template had `enableSeadex: true` and the SeaDex preset enabled, but the `/*SeaDex*/` ISE was absent — the only Nightly template without it. ISE inserted at position 2 (after Tamtaro entries, before Library ISE).
- **CLAUDE.md** — Template inventory section updated from `v2.9.5` to `v2.9.7` across all families: Single, Essential, Flash, Speed, AllDebrid, Hybrid, Samsung, and Nightly. Versions now match the actual JSON files post v2.9.7 release cycle.

## Test plan

- [ ] Apple TV 4K imports cleanly on AIOStreams
- [ ] SeaDex ISE fires for anime queries on Apple TV template
- [ ] CLAUDE.md version numbers match `metadata.version` in all JSON files
- [ ] `python3 -m pytest tests/ -q` — 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_