### PR TITLE
fix(speed): correct broken dynamic group addon references — v2.9.4

### DIFF
--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -687,8 +687,8 @@
       "groupings": [
         {
           "addons": [
-            "nx-fix-02",
-            "nx-fix-01"
+            "nx-fix-04",
+            "67c"
           ],
           "condition": "count(cached(previousStreams)) < 3"
         }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -735,8 +735,8 @@
       "groupings": [
         {
           "addons": [
-            "nx-fix-02",
-            "nx-fix-01"
+            "nx-fix-04",
+            "67c"
           ],
           "condition": "count(cached(previousStreams)) < 3"
         }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -651,8 +651,8 @@
       "groupings": [
         {
           "addons": [
-            "nx-fix-02",
-            "nx-fix-01"
+            "nx-fix-04",
+            "67c"
           ],
           "condition": "count(cached(previousStreams)) < 3"
         }

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -699,8 +699,8 @@
       "groupings": [
         {
           "addons": [
-            "nx-fix-02",
-            "nx-fix-01"
+            "nx-fix-04",
+            "67c"
           ],
           "condition": "count(cached(previousStreams)) < 3"
         }


### PR DESCRIPTION
## Summary

All 4 Speed TorBox templates (`Speed 4K`, `Speed 4K Lite`, `Speed`, `Speed Lite`) bump `v2.9.3 → v2.9.4`.

## Root cause

`groups.groupings[0].addons` referenced phantom instanceIds `['nx-fix-02', 'nx-fix-01']` that don't exist in any preset. AIOStreams validates group addon references and throws **"Every group must have at least one addon"** when none of the referenced IDs resolve to a real preset.

## Fix

Updated group refs to `['nx-fix-04', '67c']` — the actual instanceIds for **Zilean** and **StremThru Torz**, the two content scrapers these templates are built around. The dynamic group condition (`count(cached(previousStreams)) < 3`) now correctly gates on the real scraper pair.

## Test plan

- [ ] Speed 4K imports cleanly on AIOStreams without "Every group must have at least one addon"
- [ ] Dynamic addon fetching exits correctly at ≥3 cached 4K streams or 4s timeout
- [ ] `python3 -m pytest tests/ -q` — 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_