### PR TITLE
docs: v2.9.8 what's new + roadmap update + CLAUDE.md Speed version sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,10 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 - `Flash/core-nexus-flash.json` v2.9.4 — cached-only 1080p instant play
 
 ### Speed (TorBox)
-- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.2 — fast cached 4K
-- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.2
-- `Speed/TorBox/core-nexus-speed.json` v2.9.2 — fast cached 1080p
-- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.2
+- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.4 — fast cached 4K
+- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.4
+- `Speed/TorBox/core-nexus-speed.json` v2.9.4 — fast cached 1080p
+- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.4
 
 ### Speed (EasyNews)
 - `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.4 — EasyNews 4K

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -7,8 +7,14 @@ description: "Planned work, active development, and recently completed milestone
 
 | Version | Item |
 |---|---|
+| v2.9.8 | REPACK/PROPER Passthrough ISE — pins REPACK/PROPER releases ahead of limit/excluded filters; all templates via shared ISE file |
+| v2.9.8 | Codec Efficiency Booster PSE — HEVC/AV1 over AVC; AllDebrid and Samsung TV templates |
+| v2.9.8 | Audio Pinnacle PSE — Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 priority; AllDebrid and Samsung TV templates |
+| v2.9.8 | HDR / DV Priority PSE — DV/HDR10+/HDR10 over SDR within 4K; AllDebrid and Samsung TV templates |
+| v2.9.8 | Apple TV 4K Nightly — SeaDex passthrough ISE added (was missing despite SeaDex preset being enabled) |
+| v2.9.8 | Speed TorBox templates — broken dynamic group instanceId references fixed; disabled MediaFusion fallback added |
 | v2.9.7 | Meteor timeout 10000ms → 6000ms — 28 templates — fixes Nuvio "addon request timed out" on niche/new series |
-| v2.9.7 | 4K Apex v0.4.16 — time-based dynamicAddonFetching exit (5s hard cap + ≥5 cached 4K) |
+| v2.9.7 | 4K Apex v0.4.17 — time-based dynamicAddonFetching exit (5s hard cap + ≥5 cached 4K) |
 | v2.9.6 | Hybrid TorBox-priority PSEs — Hybrid (IQR twins) and Hybrid Lite (CB-style twins) complete the pattern from 4K Hybrid |
 | v2.9.5 | TorrentsDB added to 13 non-Lite templates — 21+ provider coverage (YTS, 1337x, Nyaa, AnimeTosho, regional), TorBox native, no API key, flood guard ≤1 |
 | v2.9.4 | Stream 720p fallback PSEs — surfaces 720p WEB-DL/WEBRip when no 1080p source exists |
@@ -53,20 +59,17 @@ description: "Planned work, active development, and recently completed milestone
 ### Expression Layer
 
 <AccordionGroup>
-  <Accordion title="REPACK/PROPER Passthrough ISE">
-    Pins REPACK/PROPER releases ahead of limit/excluded filters. Ensures patched releases always surface. Critical for Anime (fansub REPACKs), Hybrid, and Stream.
-  </Accordion>
   <Accordion title="Usenet Propagation Guard ESE">
     Holds back NZBs younger than 2 hours when propagated alternatives exist. Eliminates corrupt early-propagation grabs. All Usenet-enabled templates.
   </Accordion>
-  <Accordion title="Codec Efficiency Booster PSE">
-    Surfaces HEVC/AV1 encodes ahead of AVC equivalents. Stream, Essential, Anime primarily.
+  <Accordion title="Codec Efficiency Booster PSE — broader rollout">
+    Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Stream, Essential, Anime.
   </Accordion>
-  <Accordion title="Audio Pinnacle PSE">
-    Promotes lossless/object-based audio: Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3/DD+. Critical for Apex, 4K Hybrid, 4K Essential.
+  <Accordion title="Audio Pinnacle PSE — broader rollout">
+    Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Apex, 4K Hybrid, 4K Essential.
   </Accordion>
-  <Accordion title="HDR / DV Priority PSE">
-    Within 4K results, surfaces DV/HDR10+/HDR10 ahead of SDR. Critical for Apex, 4K Essential, 4K Hybrid, Flash 4K.
+  <Accordion title="HDR / DV Priority PSE — broader rollout">
+    Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Apex, 4K Essential, 4K Hybrid, Flash 4K.
   </Accordion>
   <Accordion title="pin() top result">
     Pin the #1 PSE-matched stream to position 1 regardless of sort order.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -8,6 +8,22 @@ For full technical details, see the [Changelog](/changelog).
 
 ---
 
+## v2.9.8 — June 2026
+
+**REPACK/PROPER releases now always surface, even when they'd normally be filtered out.**
+When a release group issues a REPACK or PROPER — a corrected re-encode replacing a broken or mislabelled original — the previous filtering logic could suppress it if it fell outside the quality window or hit a limit cap. It now bypasses those filters and always reaches your stream list. This is especially relevant for anime fansub groups, which frequently issue REPACKs for audio sync or subtitle fixes. Applied to all templates via the shared ISE file.
+
+**Booster PSEs added to AllDebrid and Samsung TV templates.**
+Three new priority expressions are now active on all AllDebrid and Samsung TV templates: Codec Efficiency Booster (surfaces HEVC/AV1 ahead of AVC at equivalent quality), Audio Pinnacle (promotes Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 within each quality tier), and HDR/DV Priority (surfaces Dolby Vision and HDR10+ ahead of HDR10 and SDR within 4K results). These were previously Apex and 4K Hybrid only — the AllDebrid and Samsung families now have the same priority stack.
+
+**Apple TV 4K Nightly — SeaDex passthrough fixed.**
+The Apple TV 4K Nightly template had SeaDex enabled in its preset list and its config, but was missing the SeaDex passthrough ISE that tells AIOStreams to treat SeaDex-matched streams as untouchable. In practice this meant SeaDex results were subject to the same limit and exclusion filters as everything else. Fixed — SeaDex streams now bypass those filters on Apple TV 4K exactly as they do on every other template.
+
+**Speed templates — dynamic group references corrected.**
+All four Speed TorBox templates (Speed 4K, Speed 4K Lite, Speed, Speed Lite) had a broken reference in their dynamic addon grouping: the group was pointing at instanceIds `nx-fix-01` and `nx-fix-02` which don't exist in any of the templates. AIOStreams' group validation was failing silently on import. Fixed to point at the correct Zilean and StremThru Torz instanceIds. A disabled MediaFusion preset has also been added as a fallback so fresh imports don't fail validation before TorBox credentials are configured.
+
+---
+
 ## v2.9.7 — June 2026
 
 **Meteor scraper timeout lowered — fixes "addon request timed out" on Nuvio and similar players.**


### PR DESCRIPTION
## Summary

- **`docs/whats-new.mdx`** — v2.9.8 section added covering: REPACK/PROPER Passthrough ISE, booster PSEs on AllDebrid/Samsung, Apple TV SeaDex fix, Speed group reference fix
- **`docs/roadmap.mdx`** — REPACK ISE, Codec Efficiency, Audio Pinnacle, HDR/DV Priority moved from Planned to Recently Completed (all shipped v2.9.8); booster PSEs noted as planned for broader rollout; Apex version corrected v0.4.16 → v0.4.17
- **`CLAUDE.md`** — Speed TorBox versions corrected v2.9.2 → v2.9.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_