### PR TITLE
docs: document NZBGeek shared-hosting restrictions and Zyclops workaround

### DIFF
--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -5,7 +5,7 @@
     "description": "4K flagship for TorBox users who also run a Usenet indexer. Pairs TorBox debrid with NZBGeek for maximum source diversity across debrid, torrent, and Usenet streams. Prioritises 2160p with 1080p fallback. Full HDR and lossless audio. Adaptive IQR bitrate PSEs \u2014 Tukey fence (\u22654 ranked) with min/max and new-release median cluster fallbacks. NZBGeek API key required \u2014 enter your key in the Usenet preset before saving.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1871,7 +1871,7 @@
       {
         "type": "newznab",
         "instanceId": "nzbgeek-1",
-        "enabled": true,
+        "enabled": false,
         "options": {
           "name": "NZBGeek",
           "newznabUrl": "https://api.nzbgeek.info",

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams \u2014 uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only \u2014 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB\u201360 GB, 1080p capped at 25 GB. NZBGeek API key required \u2014 enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. Relaxed filtering \u2014 quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.8",
+    "version": "2.9.9",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1778,7 +1778,7 @@
       {
         "type": "newznab",
         "instanceId": "nzbgeek-1",
-        "enabled": true,
+        "enabled": false,
         "options": {
           "name": "NZBGeek",
           "newznabUrl": "https://api.nzbgeek.info",

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams \u2014 uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only \u2014 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB\u201360 GB, 1080p capped at 25 GB. NZBGeek API key required \u2014 enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.8",
+    "version": "2.9.9",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1844,7 +1844,7 @@
       {
         "type": "newznab",
         "instanceId": "nzbgeek-1",
-        "enabled": true,
+        "enabled": false,
         "options": {
           "name": "NZBGeek",
           "newznabUrl": "https://api.nzbgeek.info",

--- a/docs/debrid-comparison.mdx
+++ b/docs/debrid-comparison.mdx
@@ -45,10 +45,10 @@ TorBox templates use the `stremthruTorz` preset for stream delivery — this is 
 
 <CardGroup cols={2}>
   <Card title="Hybrid Templates" icon="shuffle">
-    4K Hybrid, Hybrid, and Hybrid Lite — TorBox torrent cache combined with NZBGeek Usenet. Requires a separate NZBGeek API key. One of the most complete dual-source setups available.
+    4K Hybrid, Hybrid, and Hybrid Lite — TorBox torrent cache combined with a Usenet indexer. The NZBGeek preset is included but disabled by default; enable it after import. One of the most complete dual-source setups available.
   </Card>
   <Card title="Usenet Scrapers" icon="database">
-    The `newznab` preset (NZBGeek) is only meaningful on TorBox Pro. Usenet streams are delivered via the Pro plan's NZB download capability.
+    The `newznab` preset is only meaningful on TorBox Pro. Usenet streams are delivered via the Pro plan's NZB download capability.
   </Card>
 </CardGroup>
 

--- a/docs/importing.mdx
+++ b/docs/importing.mdx
@@ -59,7 +59,13 @@ Re-import the same URL. AIOStreams will load the latest version and merge it ove
   </Accordion>
 
   <Accordion title="Hybrid templates (4K Hybrid, Hybrid, Hybrid Lite)">
-    Go to **Add-ons → Newznab** and enter your NZBGeek API key.
+    The NZBGeek (Newznab) preset is included but **disabled by default**. NZBGeek flags accounts accessed from multiple IP addresses simultaneously — a pattern that occurs on shared hosting (ElfHosted, fortheweak.cloud) where search and download requests can originate from different IPs.
+
+    **To enable on ElfHosted:** use the [Zyclops proxy](https://zyclops.elfhosted.com) — set the proxy URL in the Newznab addon config so both search and grab route through the same IP. Then enter your NZBGeek API key in **Add-ons → Newznab**.
+
+    **On a private/self-hosted AIOStreams instance:** enable the preset, enter your API key, and ensure the built-in NZB grab proxy is active (`AIOSTREAMS_AUTH` credentials set) so search and grab share the same IP.
+
+    If you want a Usenet indexer with no IP restrictions on shared hosting, [NinjaCentral](https://ninjacentral.co.za) has publicly confirmed AIOStreams public-instance compatibility.
   </Accordion>
   <Accordion title="AllDebrid templates">
     Go to **Add-ons → StremThru AllDebrid** and enter your AllDebrid API key.

--- a/docs/instance-status.mdx
+++ b/docs/instance-status.mdx
@@ -41,7 +41,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **ATBP** | 🟢 Online | [aio.atbphosting.com](https://aio.atbphosting.com/stremio/configure) |
 | **Omni's** | 🟢 Online | [aiostreams.12312023.xyz](https://aiostreams.12312023.xyz/stremio/configure) |
 
-*Last checked: 2026-06-24 03:08 UTC*
+*Last checked: 2026-06-24 08:06 UTC*
 {/* STATUS_STABLE_END */}
 
 ---
@@ -60,7 +60,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **Kuu's Nightly** | 🟢 Online | [aiostreams-nightly.stremio.ru](https://aiostreams-nightly.stremio.ru/stremio/configure) |
 | **Viren's Nightly** | 🟢 Online | [aiostreams.viren070.me](https://aiostreams.viren070.me/stremio/configure) |
 
-*Last checked: 2026-06-24 03:08 UTC*
+*Last checked: 2026-06-24 08:06 UTC*
 {/* STATUS_NIGHTLY_END */}
 
 ---

--- a/docs/master-guide.mdx
+++ b/docs/master-guide.mdx
@@ -319,8 +319,14 @@ If you did a soft reset (re-imported a template) and your manifest URL did not c
   <Accordion title="Credentials modal does not appear after re-import">
     Some hosts cache the credential state. Try logging out and back in, or clearing your browser cache, then re-importing.
   </Accordion>
-  <Accordion title="NZBGeek still not working after reset (Hybrid template)">
-    The NZBGeek API key is not entered in the credentials modal — it must be configured in the Addons section after loading. See the [Import a Template](/importing) guide for the full NZBGeek setup step.
+  <Accordion title="NZBGeek not working on ElfHosted / fortheweak (Hybrid template)">
+    NZBGeek flags accounts accessed from multiple IP addresses simultaneously. On shared hosting, the search request and the NZB download can originate from different IPs, which triggers this.
+
+    The NZBGeek preset is **disabled by default** from v2.9.8 onwards. To use it on ElfHosted, route it through [Zyclops](https://zyclops.elfhosted.com) — set the Zyclops proxy URL in the Newznab addon config so search and grab share one IP, then enter your API key.
+
+    On a private/self-hosted AIOStreams instance this is not an issue — enable the preset and enter your API key normally.
+
+    If you want a Usenet indexer that explicitly allows public AIOStreams instances, [NinjaCentral](https://ninjacentral.co.za) has confirmed compatibility.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -53,8 +53,8 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### 4K Hybrid — v2.9.5
-    TorBox Pro + NZBGeek. Full 4K with TorBox-priority PSEs. Requires NZBGeek API key.
+    ### 4K Hybrid — v2.9.8
+    TorBox Pro + Usenet indexer (NZBGeek included, disabled by default). Full 4K with TorBox-priority PSEs. Enable the Newznab preset after import — see the [importing guide](/importing) for shared-hosting notes.
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json" />
@@ -131,8 +131,8 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Hybrid — v2.9.6
-    TorBox + NZBGeek, 1080p. Requires NZBGeek API key.
+    ### Hybrid — v2.9.9
+    TorBox + Usenet indexer (NZBGeek included, disabled by default), 1080p. Enable the Newznab preset after import — see the [importing guide](/importing) for shared-hosting notes.
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json" />
@@ -169,7 +169,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Hybrid Lite — v2.9.6
+    ### Hybrid Lite — v2.9.9
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json" />


### PR DESCRIPTION
## Summary

- Documents the NZBGeek IP restriction issue on shared AIOStreams hosting
- Points ElfHosted users to Zyclops as the correct fix
- Notes NinjaCentral as the only indexer with explicit public-instance clearance
- Updates Hybrid template version numbers to match the `fix/nzbgeek-disable-by-default` change (PR #259)

## Files changed

- **`importing.mdx`** — Hybrid accordion now explains the IP mismatch issue, Zyclops workaround, and NinjaCentral alternative
- **`master-guide.mdx`** — Troubleshooting entry retitled from "NZBGeek still not working after reset" to the actual root cause, with the Zyclops fix
- **`template-directory.mdx`** — Hybrid descriptions updated to "NZBGeek included, disabled by default"; version numbers bumped
- **`debrid-comparison.mdx`** — Hybrid card copy updated to match disabled-by-default state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_