### PR TITLE
chore: v2.9.9 release prep — CHANGELOG, CLAUDE.md, whats-new, roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## [Unreleased]
+## 2.9.9 (2026-06-24)
+
+### Added
+- **REPACK/PROPER Passthrough ISE — all templates.** A new ISE pins REPACK and PROPER releases ahead of limit filters and exclusion logic. Previously, a corrected re-encode could be suppressed if it fell outside the quality window or hit a result cap before being evaluated. It now bypasses those gates and always surfaces in the stream list. Applied via the shared ISE file — no per-template change required; all templates pick this up automatically.
+- **Codec Efficiency Booster PSE — AllDebrid and Samsung TV templates.** HEVC and AV1 streams are prioritised over AVC at equivalent quality and bitrate. Previously this boost was Apex and 4K Hybrid only; now active on all 4 AllDebrid templates and all 3 Samsung TV templates.
+- **Audio Pinnacle PSE — AllDebrid and Samsung TV templates.** Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 priority ordering within each quality tier. Same expansion as Codec Efficiency Booster.
+- **HDR/DV Priority PSE — AllDebrid and Samsung TV templates.** Dolby Vision and HDR10+ surface above HDR10 and SDR within 4K results. Same expansion.
+
+### Fixed
+- **Apple TV 4K Nightly — SeaDex passthrough ISE.** The template had SeaDex enabled in its preset list and config but was missing the passthrough ISE that marks SeaDex-matched streams as exempt from limit and exclusion filters. SeaDex results were being filtered the same as everything else. Added — SeaDex streams now bypass those filters on Apple TV 4K.
+- **Speed TorBox templates — broken dynamic group addon references** (`speed-4k`, `speed-4k-lite`, `speed`, `speed-lite`). The dynamic addon group was pointing at instanceIds `nx-fix-01` and `nx-fix-02` which do not exist in any of the templates. AIOStreams' group validation was failing silently on import. Fixed to reference the correct Zilean and StremThru Torz instanceIds. A disabled MediaFusion fallback preset also added so fresh imports pass validation before TorBox credentials are configured.
+- **Anime BD T1 regex drift — 34 templates.** Vidhin05 updated `English/regexes.json`, removing ZR and NAN0 from the Anime BD T1 pattern. The old `preferredRegexPatterns` entry (which included `/\b(DemiHuman|FLE|Flugel|LYS1TH3A|ZR)\b|(?<=remux).*\b(NAN0)\b/`) no longer matched elfhosted's allowlist — causing a "1 regex not allowed" error on import. Updated to match Vidhin05's current pattern (without ZR/NAN0) across all 34 non-Anime templates. `regexOverrides` entries for Anime BD T1 also updated for consistency.
+
+### Changed
+- **NZBGeek preset disabled by default — Hybrid templates** (`4K Hybrid`, `Hybrid`, `Hybrid Lite`). On shared hosting (ElfHosted, fortheweak.cloud), AIOStreams search and NZB grab requests can originate from different IPs. NZBGeek detects this pattern as multi-IP access and bans the account. The NZBGeek (`newznab`) preset is now `enabled: false` on all three Hybrid templates. Users on ElfHosted can re-enable it after routing requests through the [Zyclops proxy](https://zyclops.elfhosted.com); self-hosted users with a single IP can enable it directly.
+
+### Docs
+- **NZBGeek shared-hosting guidance.** The Hybrid accordion in `importing.mdx` now explains the IP-mismatch ban mechanism, the Zyclops proxy workaround for ElfHosted, and the NZBHydra2 alternative for self-hosted instances. NinjaCentral (the only indexer to publicly confirm AIOStreams public-instance compatibility) documented as a no-restrictions alternative. Same guidance added to the NZBGeek troubleshooting accordion in `master-guide.mdx`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,51 +94,51 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ---
 
-## Active Template Inventory (as of v2.9.7)
+## Active Template Inventory (as of v2.9.9)
 
 ### Single (TorBox Pro)
-- `Single/core-nexus-4k-apex.json` v0.4.17 — flagship 4K, IQR PSEs, pow() decay, 5s dynamic fetching cap
-- `Single/core-nexus-4k-apex-torbox.json` v2.9.5 — TorBox-cached-only Apex variant
-- `Single/core-nexus-stream.json` v2.9.7 — 1080p streaming quality, 720p fallback
-- `Single/core-nexus-stream-lite.json` v2.9.4 — lite variant
-- `Single/core-nexus-stream-firestick.json` v2.9.6 — Fire Stick optimised
-- `Single/core-nexus-stream-firestick-lite.json` v2.9.4
+- `Single/core-nexus-4k-apex.json` v0.4.18 — flagship 4K, IQR PSEs, pow() decay, 5s dynamic fetching cap
+- `Single/core-nexus-4k-apex-torbox.json` v2.9.6 — TorBox-cached-only Apex variant
+- `Single/core-nexus-stream.json` v2.9.8 — 1080p streaming quality, 720p fallback
+- `Single/core-nexus-stream-lite.json` v2.9.5 — lite variant
+- `Single/core-nexus-stream-firestick.json` v2.9.7 — Fire Stick optimised
+- `Single/core-nexus-stream-firestick-lite.json` v2.9.5
 
 ### Essential (TorBox Essential)
-- `Essential/core-nexus-4k-essential.json` v2.9.5 — 4K with IQR PSEs, pow() decay
-- `Essential/core-nexus-4k-essential-lite.json` v2.9.4 — CB-style PSEs
-- `Essential/core-nexus-essential.json` v2.9.6 — 1080p
-- `Essential/core-nexus-essential-lite.json` v2.9.4
+- `Essential/core-nexus-4k-essential.json` v2.9.6 — 4K with IQR PSEs, pow() decay
+- `Essential/core-nexus-4k-essential-lite.json` v2.9.5 — CB-style PSEs
+- `Essential/core-nexus-essential.json` v2.9.7 — 1080p
+- `Essential/core-nexus-essential-lite.json` v2.9.5
 
 ### Flash
-- `Flash/core-nexus-flash-4k.json` v2.9.3 — cached-only 4K instant play
-- `Flash/core-nexus-flash.json` v2.9.4 — cached-only 1080p instant play
+- `Flash/core-nexus-flash-4k.json` v2.9.4 — cached-only 4K instant play
+- `Flash/core-nexus-flash.json` v2.9.5 — cached-only 1080p instant play
 
 ### Speed (TorBox)
-- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.4 — fast cached 4K
-- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.4
-- `Speed/TorBox/core-nexus-speed.json` v2.9.4 — fast cached 1080p
-- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.4
+- `Speed/TorBox/core-nexus-speed-4k.json` v2.9.5 — fast cached 4K
+- `Speed/TorBox/core-nexus-speed-4k-lite.json` v2.9.5
+- `Speed/TorBox/core-nexus-speed.json` v2.9.5 — fast cached 1080p
+- `Speed/TorBox/core-nexus-speed-lite.json` v2.9.5
 
 ### Speed (EasyNews)
-- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.4 — EasyNews 4K
-- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.5 — EasyNews 1080p
+- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.5 — EasyNews 4K
+- `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.6 — EasyNews 1080p
 
 ### AllDebrid
-- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.15 — 4K with IQR PSEs
-- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.12 — 4K CB-style
-- `AllDebrid/core-nexus-alldebrid.json` v0.1.15 — 1080p
-- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.14 — 1080p lite
+- `AllDebrid/core-nexus-4k-alldebrid.json` v0.1.16 — 4K with IQR PSEs
+- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.13 — 4K CB-style
+- `AllDebrid/core-nexus-alldebrid.json` v0.1.16 — 1080p
+- `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.15 — 1080p lite
 
 ### Hybrid
-- `Hybrid/core-nexus-4k-hybrid.json` v2.9.6 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset
-- `Hybrid/core-nexus-hybrid.json` v2.9.7 — 1080p hybrid, TorBox-priority twins (IQR), NZBGeek preset
-- `Hybrid/core-nexus-hybrid-lite.json` v2.9.7 — TorBox-priority twins (CB-style), NZBGeek preset
+- `Hybrid/core-nexus-4k-hybrid.json` v2.9.8 — TorBox + RD, service() priority PSEs, IQR, NZBGeek preset (disabled by default)
+- `Hybrid/core-nexus-hybrid.json` v2.9.9 — 1080p hybrid, TorBox-priority twins (IQR), NZBGeek preset (disabled by default)
+- `Hybrid/core-nexus-hybrid-lite.json` v2.9.9 — TorBox-priority twins (CB-style), NZBGeek preset (disabled by default)
 
 ### Device
-- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.16 — 1080p, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
-- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.16 — 4K, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
-- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.17 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
+- `Device/Samsung/core-nexus-samsung-tv.json` v0.2.17 — 1080p, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
+- `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.17 — 4K, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
+- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.18 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
 
 ### Anime
 - `Anime/core-nexus-anime-4k.json` v2.8.8 — 4K anime, SeaDex + AnimeTosho
@@ -149,12 +149,12 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 - `Anime/core-nexus-anime-dub-lite.json` v2.8.6
 
 ### Nightly (gitignored — force-add to commit)
-- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.12 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.8 — Essential 4K experimental
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.8 — Essential 1080p experimental
-- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.9.1 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins
-- `Nightly/Single/core-nexus-stream-labs.json` v0.6.9 — perGroup() prototypes, dynamicAddonFetching, StreamNZB preset
-- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.1 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features
+- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.13 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.1.9 — Essential 4K experimental
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.9 — Essential 1080p experimental
+- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.9.2 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins
+- `Nightly/Single/core-nexus-stream-labs.json` v0.6.10 — perGroup() prototypes, dynamicAddonFetching, StreamNZB preset
+- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.2 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features
 - `Nightly/Anime/core-nexus-anime-4k-labs.json` v0.1.0 — Score IQR Guard, perGroup() dedup, Indexer Diversity, hasSeaDex conditional tiers, anime elite pins
 
 ---

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -7,6 +7,9 @@ description: "Planned work, active development, and recently completed milestone
 
 | Version | Item |
 |---|---|
+| v2.9.9 | Anime BD T1 regex drift fix — Vidhin05 removed ZR/NAN0; pattern updated across all 34 non-Anime templates; resolves "1 regex not allowed" on elfhosted |
+| v2.9.9 | NZBGeek preset disabled by default — Hybrid, Hybrid Lite, 4K Hybrid — prevents IP-mismatch bans on shared hosting (ElfHosted, fortheweak.cloud) |
+| v2.9.9 | NZBGeek shared-hosting docs — Zyclops proxy workaround, NinjaCentral as public-instance alternative, IP-mismatch mechanism explained |
 | v2.9.8 | REPACK/PROPER Passthrough ISE — pins REPACK/PROPER releases ahead of limit/excluded filters; all templates via shared ISE file |
 | v2.9.8 | Codec Efficiency Booster PSE — HEVC/AV1 over AVC; AllDebrid and Samsung TV templates |
 | v2.9.8 | Audio Pinnacle PSE — Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 priority; AllDebrid and Samsung TV templates |
@@ -55,6 +58,10 @@ description: "Planned work, active development, and recently completed milestone
 ---
 
 ## Planned
+
+### v3.0.0 — Major Release
+
+The next major version is a full suite redesign. Details will be announced closer to release. Feedback welcome in [Discussions](https://github.com/brevityA/Core-Builds/discussions).
 
 ### Expression Layer
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -8,6 +8,16 @@ For full technical details, see the [Changelog](/changelog).
 
 ---
 
+## v2.9.9 — June 2026
+
+**Anime BD T1 regex updated — resolves the "1 regex not allowed" import error.**
+Vidhin05 (the source elfhosted uses to validate allowed regex patterns) silently updated their file, removing two release groups — ZR and NAN0 — from the Anime BD T1 pattern. If you saw a "1 out of N regexes not allowed" error when importing a template, this was the cause. All templates now match Vidhin05's current version of the pattern. Re-import from the [Template Directory](/template-directory) to clear the error.
+
+**NZBGeek preset now disabled by default on Hybrid templates.**
+NZBGeek has been issuing account bans to users running AIOStreams on shared hosting (ElfHosted, fortheweak.cloud). The root cause is an IP mismatch: on these platforms, search queries and NZB grabs can come from different IPs, which NZBGeek flags as multi-account sharing. The NZBGeek preset is still included in all Hybrid templates — it is just switched off out of the box. Re-enabling it on ElfHosted requires routing requests through the [Zyclops proxy](https://zyclops.elfhosted.com) so both operations share a single IP. On a private or self-hosted instance where all requests originate from one IP, you can enable the preset directly. See [Importing a Template](/importing) for the full setup steps.
+
+---
+
 ## v2.9.8 — June 2026
 
 **REPACK/PROPER releases now always surface, even when they'd normally be filtered out.**


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — promotes `[Unreleased]` to `## 2.9.9 (2026-06-24)` with entries covering all changes since v2.9.7: REPACK/PROPER ISE, Booster PSEs on AllDebrid/Samsung TV, Apple TV 4K SeaDex fix, Speed template instanceId fix, Anime BD T1 Vidhin05 drift fix, NZBGeek disabled-by-default, docs update
- **CLAUDE.md** — Active Template Inventory synced to actual main versions (28 templates had drifted since the v2.9.7 heading); Hybrid template descriptions updated to note NZBGeek preset is disabled by default
- **docs/whats-new.mdx** — new v2.9.9 section covering Anime BD T1 regex fix and NZBGeek default change
- **docs/roadmap.mdx** — v2.9.9 rows added to Recently Completed; v3.0.0 milestone note added to Planned

## Test plan

- [ ] CHANGELOG `## 2.9.9 (2026-06-24)` is the top entry, [Unreleased] is gone
- [ ] CLAUDE.md inventory versions match actual template `metadata.version` fields
- [ ] whats-new.mdx v2.9.9 section appears above v2.9.8
- [ ] roadmap.mdx v2.9.9 rows are at the top of Recently Completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_