### PR TITLE
fix(labs): replace unresolved input variables in Essential Labs daf condition

### DIFF
--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 4K build. Template directives: TorBox Search and exit thresholds configurable at import. Based on 4K Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -699,7 +699,7 @@
     "selOverrides": [],
     "dynamicAddonFetching": {
       "enabled": true,
-      "condition": "count(cached(resolution(totalStreams, '2160p'))) >= {{inputs.exitThreshold}} or totalTimeTaken > {{inputs.maxWaitMs}}"
+      "condition": "count(cached(resolution(totalStreams, '2160p'))) >= 10 or totalTimeTaken > 5000"
     },
     "groups": {
       "enabled": false,

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 1080p build. Template directives: TorBox Search and exit thresholds configurable at import.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -655,7 +655,7 @@
     "selOverrides": [],
     "dynamicAddonFetching": {
       "enabled": true,
-      "condition": "count(cached(resolution(totalStreams, '1080p'))) >= {{inputs.exitThreshold}} or totalTimeTaken > {{inputs.maxWaitMs}}"
+      "condition": "count(cached(resolution(totalStreams, '1080p'))) >= 15 or totalTimeTaken > 5000"
     },
     "groups": {
       "enabled": false,


### PR DESCRIPTION
## Summary

- Replaces unresolved `{{inputs.exitThreshold}}` / `{{inputs.maxWaitMs}}` placeholders in both Essential Labs `dynamicAddonFetching` conditions — no `inputs` section was defined so these would fail at runtime
- Uses the same thresholds as the stable Essential 4K template, with a 5 s time fallback
- Essential-style templates use `dynamicAddonFetching` only; `groups` remains disabled (as fixed in #266)

## Changes

| Template | Version | New condition |
|---|---|---|
| `core-nexus-4k-essential-labs.json` | v0.2.2 → v0.2.3 | `>= 10 cached 2160p or > 5000ms` |
| `core-nexus-essential-labs.json` | v0.1.11 → v0.1.12 | `>= 15 cached 1080p or > 5000ms` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_