### PR TITLE
docs(v3.0.1): sync version numbers and add hotfix changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.0.1 (2026-06-24)
+
+### Fixed
+- **Essential Labs groups validation error** (`core-nexus-4k-essential-labs.json`, `core-nexus-essential-labs.json`). Both templates copied the `groups.groupings` block from the Apex family, referencing `nx-fix-01` and `nx-fix-02` (Comet and Meteor instanceIds). Neither preset exists in the Essential Labs templates — AIOStreams' group validator rejects imports when a grouping references an addon that isn't in the preset list. Fixed by disabling `groups` and clearing `groupings: []`. Essential-style templates use `dynamicAddonFetching` for conditional scraper fetching, not addon groups.
+- **Essential Labs `dynamicAddonFetching` condition** — both templates had `{{inputs.exitThreshold}}` and `{{inputs.maxWaitMs}}` placeholder variables with no corresponding `inputs` section, causing the condition to fail at runtime. Replaced with hardcoded values matching the stable Essential 4K pattern: `>= 10 cached 2160p streams or > 5000 ms` (4K) and `>= 15 cached 1080p streams or > 5000 ms` (1080p).
+  - `core-nexus-4k-essential-labs.json`: v0.2.0 → v0.2.3
+  - `core-nexus-essential-labs.json`: v0.1.9 → v0.1.12
+
+---
+
 ## 3.0.0 (2026-06-24)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,12 +121,12 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 - `Speed/TorBox/core-nexus-speed-lite.json` v2.9.6
 
 ### Speed (EasyNews)
-- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.6 — EasyNews 4K
+- `Speed/EasyNews/core-nexus-speed-4k-plus.json` v2.9.7 — EasyNews 4K
 - `Speed/EasyNews/core-nexus-speed-easynews.json` v2.9.7 — EasyNews 1080p
 
 ### AllDebrid
-- `AllDebrid/core-nexus-4k-alldebrid.json` v0.3.0 — 4K with IQR PSEs, Score IQR Guard, elite group pins, perGroup() Extra Cached
-- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.14 — 4K CB-style
+- `AllDebrid/core-nexus-4k-alldebrid.json` v0.3.1 — 4K with IQR PSEs, Score IQR Guard, elite group pins, perGroup() Extra Cached
+- `AllDebrid/core-nexus-4k-alldebrid-lite.json` v0.1.15 — 4K CB-style
 - `AllDebrid/core-nexus-alldebrid.json` v0.1.17 — 1080p
 - `AllDebrid/core-nexus-alldebrid-lite.json` v0.1.16 — 1080p lite
 
@@ -138,7 +138,7 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 ### Device
 - `Device/Samsung/core-nexus-samsung-tv.json` v0.2.18 — 1080p, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
 - `Device/Samsung/core-nexus-samsung-tv-4k.json` v0.2.18 — 4K, DV-Only Kill on, AV1/VC-1 excluded, REPACK ISE + booster PSEs
-- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.19 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
+- `Device/Samsung/core-nexus-samsung-ru7100-4k.json` v0.2.20 — RU7100 4K, full APEX IQR PSE stack, FLAC/AAC native audio, HDR10+/HLG (promoted from Nightly)
 
 ### Anime
 - `Anime/core-nexus-anime-4k.json` v2.8.8 — 4K anime, SeaDex + AnimeTosho
@@ -150,8 +150,8 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ### Nightly (gitignored — force-add to commit)
 - `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.13 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.2.0 — Essential 4K experimental, Bitrate Floor ESEs (4K+1080p REMUX)
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.9 — Essential 1080p experimental
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.2.3 — Essential 4K experimental, Bitrate Floor ESEs (4K+1080p REMUX), groups disabled (dynamicAddonFetching only)
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.12 — Essential 1080p experimental, groups disabled (dynamicAddonFetching only)
 - `Nightly/Single/core-nexus-4k-apex-labs.json` v0.10.0 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins, Bitrate Floor ESEs (4K+1080p REMUX)
 - `Nightly/Single/core-nexus-stream-labs.json` v0.7.0 — perGroup() prototypes, dynamicAddonFetching, StreamNZB preset, Bitrate Floor ESEs (1080p REMUX AV1 kill + 8Mbps floor)
 - `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.2 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -17,7 +17,7 @@
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v2.9.7** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v3.0.1** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
 > 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/wiki) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -79,7 +79,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Samsung RU7100 4K — v0.2.19
+    ### Samsung RU7100 4K — v0.2.20
     RU7100 and compatible 2019–2022 Tizen TVs. Full APEX IQR Tukey fence PSE stack — more aggressive filtering than Samsung TV 4K. AV1/VC-1/DV hard-excluded, FLAC/AAC native audio, HDR10+/HDR10/HLG.
 
     <CardGroup cols={2}>
@@ -320,7 +320,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
 <Tabs>
   <Tab title="4K">
-    ### 4K AllDebrid — v0.3.0
+    ### 4K AllDebrid — v0.3.1
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json" />
@@ -344,7 +344,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
   </Tab>
 
   <Tab title="Lite">
-    ### 4K AllDebrid Lite — v0.1.14
+    ### 4K AllDebrid Lite — v0.1.15
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json" />
@@ -551,7 +551,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Essential Labs — v0.1.9
+    ### Essential Labs — v0.1.12
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json" />
@@ -563,7 +563,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### 4K Essential Labs — v0.1.9
+    ### 4K Essential Labs — v0.2.3
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json" />


### PR DESCRIPTION
## Summary

- Adds `## 3.0.1` CHANGELOG entry covering the Essential Labs groups/daf hotfixes (PRs #265–267)
- Updates README current version badge: `v2.9.7` → `v3.0.1`
- Syncs 6 stale template versions in CLAUDE.md and `docs/template-directory.mdx`

## Version corrections

| Template | Was | Now |
|---|---|---|
| `4k-alldebrid.json` | v0.3.0 | v0.3.1 |
| `4k-alldebrid-lite.json` | v0.1.14 | v0.1.15 |
| `speed-4k-plus.json` | v2.9.6 | v2.9.7 |
| `samsung-ru7100-4k.json` | v0.2.19 | v0.2.20 |
| `4k-essential-labs.json` | v0.2.0 | v0.2.3 |
| `essential-labs.json` | v0.1.9 | v0.1.12 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_