### PR TITLE
docs(v3.0.2): sync versions and add audit fix changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.0.2 (2026-06-25)
+
+### Fixed
+- **Essential Labs full audit pass** — both `core-nexus-4k-essential-labs.json` (v0.2.3 → v0.2.4) and `core-nexus-essential-labs.json` (v0.1.12 → v0.1.13):
+  - **`{{inputs.exitThreshold}}` / `{{inputs.maxWaitMs}}` restored** — PR #267 hardcoded these values, orphaning the import-time configuration UI and substituting wrong thresholds (10 cached streams / 5000 ms instead of the designed 5 / 4000 ms). The `inputs` section in both templates is now wired back to the `dynamicAddonFetching.condition` string.
+  - **Dead Flood Guard replaced** — the ESE referenced Meteor, Comet RD, MediaFusion, EZTV, Knaben, and HdHub, none of which exist in these templates (only StremThru Torz + TorBox Search). Replaced with live caps: StremThru Torz ≤ 10, TorBox Search ≤ 5.
+  - **Extra Cached ESEs → `perGroup()`** — verbose 20–35 clause `merge(slice(...))` chains replaced with `perGroup(..., 'resolution', 3)` expressions, matching the stable 3.0.0 pattern.
+  - **Low resolutions removed from `preferredResolutions`** — 144p, 240p, 360p removed.
+  - **AV1 and VC-1 removed from `preferredEncodes`** — these encodes ranked ahead of standard HEVC/AVC without device justification.
+  - **`enableSeadex: false`** — neither template has a SeaDex preset; all `seadex(streams)` ESE calls were returning `[]`.
+  - **`addonDescription` updated** — was stuck at `"Nightly Labs v0.1.0"` since initial creation.
+
+---
+
 ## 3.0.1 (2026-06-24)
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,8 +150,8 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ### Nightly (gitignored — force-add to commit)
 - `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.1.13 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.2.3 — Essential 4K experimental, Bitrate Floor ESEs (4K+1080p REMUX), groups disabled (dynamicAddonFetching only)
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.12 — Essential 1080p experimental, groups disabled (dynamicAddonFetching only)
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.2.4 — Essential 4K experimental, Bitrate Floor ESEs (4K+1080p REMUX), perGroup() Extra Cached, configurable daf thresholds at import
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.1.13 — Essential 1080p experimental, perGroup() Extra Cached, configurable daf thresholds at import
 - `Nightly/Single/core-nexus-4k-apex-labs.json` v0.10.0 — Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins, Bitrate Floor ESEs (4K+1080p REMUX)
 - `Nightly/Single/core-nexus-stream-labs.json` v0.7.0 — perGroup() prototypes, dynamicAddonFetching, StreamNZB preset, Bitrate Floor ESEs (1080p REMUX AV1 kill + 8Mbps floor)
 - `Nightly/Single/core-nexus-all-rounder-labs.json` v0.1.2 — isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -17,7 +17,7 @@
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v3.0.1** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v3.0.2** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
 > 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/wiki) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -551,7 +551,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### Essential Labs — v0.1.12
+    ### Essential Labs — v0.1.13
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json" />
@@ -563,7 +563,7 @@ All templates require **AIOStreams v2.30+**. Each section has a **Lite** tab for
 
     ---
 
-    ### 4K Essential Labs — v0.2.3
+    ### 4K Essential Labs — v0.2.4
 
     <CardGroup cols={2}>
       <Card title="Import on ElfHosted" icon="arrow-up-right" href="https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json" />


### PR DESCRIPTION
## Summary

- Adds `## 3.0.2` CHANGELOG entry covering the Essential Labs full audit (PR #269)
- Updates README current version badge: `v3.0.1` → `v3.0.2`
- Syncs Essential Labs versions in CLAUDE.md and `docs/template-directory.mdx`

| File | Change |
|---|---|
| `CHANGELOG.md` | New 3.0.2 entry |
| `README.md` | v3.0.1 → v3.0.2 |
| `CLAUDE.md` | 4k-essential-labs v0.2.3→v0.2.4, essential-labs v0.1.12→v0.1.13 |
| `template-directory.mdx` | Same version heading updates |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_