### PR TITLE
docs: update remaining v3.0.0 references to v3.0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 
 ---
 
-## Active Template Inventory (as of v3.0.0-dev)
+## Active Template Inventory (as of v3.0.2)
 
 ### Single (TorBox Pro)
 - `Single/core-nexus-4k-apex.json` v0.6.0 — flagship 4K, IQR PSEs, pow() decay, 5s dynamic fetching cap, Score IQR Guard, elite group pins, perGroup() Extra Cached

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/brevityA/Core-Builds/validate.yml?style=for-the-badge&label=BUILD&logo=github&logoColor=white&labelColor=1a1f27" alt="Build Status"/>
   </a>
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://img.shields.io/badge/RELEASE-v3.0.0-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
+    <img src="https://img.shields.io/badge/RELEASE-v3.0.2-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
   </a>
 </p>
 

--- a/docs/template-directory.mdx
+++ b/docs/template-directory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Template Directory"
-description: "Every active template with import URLs, versions, and plan requirements. Current version: v3.0.0"
+description: "Every active template with import URLs, versions, and plan requirements. Current version: v3.0.2"
 ---
 
 <Frame>


### PR DESCRIPTION
Cleans up remaining v3.0.0 references that weren't caught in the previous docs sync:\n\n- `README.md`: release badge `v3.0.0` → `v3.0.2`\n- `docs/template-directory.mdx`: description field `v3.0.0` → `v3.0.2`\n- `CLAUDE.md`: inventory header `v3.0.0-dev` → `v3.0.2`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_