### PR TITLE
feat: host configurator on GitHub Pages + embed in docs

### DIFF
--- a/.github/workflows/deploy-configurator.yml
+++ b/.github/workflows/deploy-configurator.yml
@@ -1,0 +1,39 @@
+name: Deploy Configurator to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'configurator/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload configurator artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./configurator
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/configurator.mdx
+++ b/docs/configurator.mdx
@@ -13,17 +13,18 @@ description: "Build a custom AIOStreams template in 6 steps — no manual JSON e
 
 The **Template Configurator** is a self-contained HTML tool that generates a ready-to-import AIOStreams template based on your setup. Answer 5 questions, download the JSON, import it — done.
 
-<CardGroup cols={2}>
-  <Card title="Download Configurator" icon="download" href="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/configurator/index.html">
-    Save `index.html` and open it in any browser. Works fully offline — no internet required after download.
-  </Card>
-  <Card title="View on GitHub" icon="github" href="https://github.com/brevityA/Core-Builds/blob/main/configurator/index.html">
-    Inspect the source or open the raw file directly.
-  </Card>
-</CardGroup>
+<Card title="Open Template Configurator" icon="wand-magic-sparkles" href="https://brevitya.github.io/Core-Builds/">
+  Opens in a new tab — runs entirely in your browser. No data is sent anywhere.
+</Card>
+
+<iframe
+  src="https://brevitya.github.io/Core-Builds/"
+  style={{ width: '100%', height: '780px', border: 'none', borderRadius: '12px', marginTop: '16px' }}
+  title="Core Builds Template Configurator"
+/>
 
 <Note>
-  **How to open it:** right-click the Download link → Save As → open the saved `.html` file in Chrome, Firefox, or Edge. The wizard runs entirely in your browser — no data is sent anywhere.
+  **Offline use:** the configurator is also a self-contained HTML file — save it and open it locally with no internet needed. [Download from GitHub](https://github.com/brevityA/Core-Builds/blob/main/configurator/index.html) → Raw → Save As.
 </Note>
 
 ---


### PR DESCRIPTION
## Problem

`raw.githubusercontent.com` serves HTML as `text/plain` — clicking the link showed the source code rather than rendering the wizard.

## Solution

- **GitHub Pages workflow** (`.github/workflows/deploy-configurator.yml`) — deploys `configurator/index.html` to `https://brevitya.github.io/Core-Builds/` on every push to main that touches `configurator/`
- **Docs page updated** — link and iframe now point to the GitHub Pages URL so the wizard renders inline on the docs page and opens as a proper web app in a new tab

## One manual step required

Before merging, enable GitHub Pages in the repo settings:

> **Settings → Pages → Source → GitHub Actions**

Once enabled, merging this PR will trigger the first deployment automatically.

## Test plan

- [x] Workflow file is valid YAML
- [x] 186 tests pass
- [x] Docs page iframe points to correct Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_