### PR TITLE
feat(configurator): Create Import URL — paste.rs hosted import like template sourceUrls

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -101,7 +101,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 const STEPS = 7;
 let step = 1;
-const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', rpdbKey:'' };
+const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', rpdbKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''} };
 
 const DEFS = [
   { id:'service', title:'Debrid Service', desc:'Which service are you using for cached streams?', key:'service', cols:'c4d',
@@ -175,7 +175,7 @@ function render() {
 
   if (step === STEPS) {
     const auto = defaultName();
-    const hasApis = S.tmdbToken || S.tmdbApiKey || S.rpdbKey;
+    const hasApis = S.tmdbToken || S.tmdbApiKey || S.rpdbKey || Object.values(S.creds).some(v=>v);
     main.innerHTML = `
       <div class="card">
         <h2>Your Configuration</h2>
@@ -190,7 +190,12 @@ function render() {
           }).join('')}
           ${hasApis ? `<div class="sum-item" style="grid-column:1/-1">
             <div class="sum-lbl">API Keys</div>
-            <div class="sum-val" style="font-weight:400;font-size:.85rem">${S.tmdbToken ? '✓ TMDB token' : ''}${S.tmdbApiKey ? (S.tmdbToken ? ' · ' : '') + '✓ TMDB API key' : ''}${S.rpdbKey ? ((S.tmdbToken || S.tmdbApiKey) ? ' · ' : '') + '✓ RPDB key' : ''}</div>
+            <div class="sum-val" style="font-weight:400;font-size:.85rem">${[
+              Object.values(S.creds).filter(v=>v).length ? '✓ debrid credentials' : '',
+              S.tmdbToken ? '✓ TMDB token' : '',
+              S.tmdbApiKey ? '✓ TMDB API key' : '',
+              S.rpdbKey ? '✓ RPDB key' : ''
+            ].filter(Boolean).join(' · ')}</div>
           </div>` : ''}
         </div>
         <div class="name-row">
@@ -213,16 +218,28 @@ function render() {
     document.getElementById('nameIn').value = S.name;
 
   } else if (def.id === 'apis') {
+    const debridInputs = getDebridInputs();
     main.innerHTML = `
       <div class="card">
         <h2>API Keys <span style="color:#8b949e;font-size:.85rem;font-weight:400">(Optional)</span></h2>
         <p class="desc">${def.desc}</p>
-        <div class="name-row" style="margin-bottom:16px">
+        ${debridInputs.length ? `
+        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Debrid Service</div>
+        ${debridInputs.map(inp => `
+        <div class="name-row" style="margin-bottom:14px">
+          <label>${inp.label}</label>
+          <input class="name-input" id="cred_${inp.id}" type="text" placeholder="${inp.placeholder}"
+            value="" oninput="S.creds['${inp.id}']=this.value" maxlength="120">
+        </div>`).join('')}
+        <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
+        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
+        ` : ''}
+        <div class="name-row" style="margin-bottom:14px">
           <label>TMDB Read Access Token (v4)</label>
           <input class="name-input" id="tmdbIn" type="text" placeholder="eyJhbGciOiJSUzI1NiJ9…"
             value="" oninput="S.tmdbToken=this.value" maxlength="400">
         </div>
-        <div class="name-row" style="margin-bottom:16px">
+        <div class="name-row" style="margin-bottom:14px">
           <label>TMDB API Key (v3)</label>
           <input class="name-input" id="tmdbKeyIn" type="text" placeholder="abc123def456…"
             value="" oninput="S.tmdbApiKey=this.value" maxlength="60">
@@ -234,12 +251,17 @@ function render() {
         </div>
         <div class="notice" style="margin-top:14px">
           <strong>Where to find these</strong>
-          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API → both the Read Access Token (v4) and API Key (v3) are listed there<br>
-          <strong style="color:#8b949e;font-weight:400">RPDB:</strong> ratingposterdb.com → your account → API key (free tier starts with t0-)
+          ${debridInputs.map(inp => `<strong style="color:#8b949e;font-weight:400">${inp.label.replace(' API Key','')}:</strong> ${inp.where}<br>`).join('')}
+          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API (both keys listed there)<br>
+          <strong style="color:#8b949e;font-weight:400">RPDB:</strong> ratingposterdb.com → your account → API key (free tier: t0-…)
         </div>
       </div>`;
     nav.style.display = 'flex';
     document.getElementById('btnBack').style.visibility = 'visible';
+    debridInputs.forEach(inp => {
+      const el = document.getElementById('cred_' + inp.id);
+      if (el) el.value = S.creds[inp.id] || '';
+    });
     document.getElementById('tmdbIn').value = S.tmdbToken;
     document.getElementById('tmdbKeyIn').value = S.tmdbApiKey;
     document.getElementById('rpdbIn').value = S.rpdbKey;
@@ -323,6 +345,25 @@ function toggleMulti(val) {
 }
 
 // ─── Template generation ─────────────────────────────────────────────────────
+
+function getDebridInputs() {
+  const svc = S.service;
+  const defs = {
+    torbox:    { label:'TorBox API Key',    placeholder:'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', where:'torbox.app → Account → API' },
+    realdebrid:{ label:'Real-Debrid API Key', placeholder:'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',  where:'real-debrid.com/apitoken' },
+    alldebrid: { label:'AllDebrid API Key', placeholder:'XXXXXXXXXXXXXXXX',                    where:'alldebrid.com/apikeys' },
+    premiumize:{ label:'Premiumize API Key', placeholder:'XXXXXXXXXXXXXXXX',                   where:'premiumize.me/account' },
+    debridlink:{ label:'Debrid-Link API Key', placeholder:'XXXXXXXXXXXXXXXX',                  where:'debrid-link.com → Account → API' },
+  };
+  const ids = [];
+  if (svc==='torbox-pro'||svc==='torbox-ess'||svc==='hybrid') ids.push('torbox');
+  if (svc==='realdebrid'||svc==='hybrid') ids.push('realdebrid');
+  if (svc==='alldebrid')  ids.push('alldebrid');
+  if (svc==='premiumize') ids.push('premiumize');
+  if (svc==='debridlink') ids.push('debridlink');
+  if (svc==='multi') S.multiServices.forEach(s => ids.push(s));
+  return ids.map(id => ({id, ...defs[id]}));
+}
 
 function ruid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
@@ -443,16 +484,18 @@ function presets() {
   return list;
 }
 
+function cred(id) { return S.creds[id] ? {apiKey: S.creds[id]} : {}; }
+
 function services() {
   const svc = S.service;
   const isMulti = svc === 'multi';
   const m = S.multiServices;
   return [
-    {id:'realdebrid',  enabled: svc==='realdebrid' || svc==='hybrid' || (isMulti && m.includes('realdebrid')), credentials:{}},
-    {id:'alldebrid',   enabled: svc==='alldebrid'  || (isMulti && m.includes('alldebrid')),  credentials:{}},
-    {id:'premiumize',  enabled: svc==='premiumize'  || (isMulti && m.includes('premiumize')), credentials:{}},
-    {id:'debridlink',  enabled: svc==='debridlink'  || (isMulti && m.includes('debridlink')), credentials:{}},
-    {id:'torbox',      enabled: svc==='torbox-pro' || svc==='torbox-ess' || svc==='hybrid', credentials:{}},
+    {id:'realdebrid',  enabled: svc==='realdebrid' || svc==='hybrid' || (isMulti && m.includes('realdebrid')), credentials:cred('realdebrid')},
+    {id:'alldebrid',   enabled: svc==='alldebrid'  || (isMulti && m.includes('alldebrid')),  credentials:cred('alldebrid')},
+    {id:'premiumize',  enabled: svc==='premiumize'  || (isMulti && m.includes('premiumize')), credentials:cred('premiumize')},
+    {id:'debridlink',  enabled: svc==='debridlink'  || (isMulti && m.includes('debridlink')), credentials:cred('debridlink')},
+    {id:'torbox',      enabled: svc==='torbox-pro' || svc==='torbox-ess' || svc==='hybrid', credentials:cred('torbox')},
     {id:'offcloud',    enabled: false, credentials:{}},
     {id:'putio',       enabled: false, credentials:{}},
     {id:'easynews',    enabled: false, credentials:{}},

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -101,7 +101,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 const STEPS = 7;
 let step = 1;
-const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', rpdbKey:'' };
+const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', rpdbKey:'' };
 
 const DEFS = [
   { id:'service', title:'Debrid Service', desc:'Which service are you using for cached streams?', key:'service', cols:'c4d',
@@ -175,7 +175,7 @@ function render() {
 
   if (step === STEPS) {
     const auto = defaultName();
-    const hasApis = S.tmdbToken || S.rpdbKey;
+    const hasApis = S.tmdbToken || S.tmdbApiKey || S.rpdbKey;
     main.innerHTML = `
       <div class="card">
         <h2>Your Configuration</h2>
@@ -190,7 +190,7 @@ function render() {
           }).join('')}
           ${hasApis ? `<div class="sum-item" style="grid-column:1/-1">
             <div class="sum-lbl">API Keys</div>
-            <div class="sum-val" style="font-weight:400;font-size:.85rem">${S.tmdbToken ? '✓ TMDB access token' : ''}${S.tmdbToken && S.rpdbKey ? ' · ' : ''}${S.rpdbKey ? '✓ RPDB key' : ''}</div>
+            <div class="sum-val" style="font-weight:400;font-size:.85rem">${S.tmdbToken ? '✓ TMDB token' : ''}${S.tmdbApiKey ? (S.tmdbToken ? ' · ' : '') + '✓ TMDB API key' : ''}${S.rpdbKey ? ((S.tmdbToken || S.tmdbApiKey) ? ' · ' : '') + '✓ RPDB key' : ''}</div>
           </div>` : ''}
         </div>
         <div class="name-row">
@@ -218,9 +218,14 @@ function render() {
         <h2>API Keys <span style="color:#8b949e;font-size:.85rem;font-weight:400">(Optional)</span></h2>
         <p class="desc">${def.desc}</p>
         <div class="name-row" style="margin-bottom:16px">
-          <label>TMDB Read Access Token</label>
+          <label>TMDB Read Access Token (v4)</label>
           <input class="name-input" id="tmdbIn" type="text" placeholder="eyJhbGciOiJSUzI1NiJ9…"
             value="" oninput="S.tmdbToken=this.value" maxlength="400">
+        </div>
+        <div class="name-row" style="margin-bottom:16px">
+          <label>TMDB API Key (v3)</label>
+          <input class="name-input" id="tmdbKeyIn" type="text" placeholder="abc123def456…"
+            value="" oninput="S.tmdbApiKey=this.value" maxlength="60">
         </div>
         <div class="name-row">
           <label>RPDB API Key</label>
@@ -229,13 +234,14 @@ function render() {
         </div>
         <div class="notice" style="margin-top:14px">
           <strong>Where to find these</strong>
-          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API → Read Access Token (v4)<br>
+          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API → both the Read Access Token (v4) and API Key (v3) are listed there<br>
           <strong style="color:#8b949e;font-weight:400">RPDB:</strong> ratingposterdb.com → your account → API key (free tier starts with t0-)
         </div>
       </div>`;
     nav.style.display = 'flex';
     document.getElementById('btnBack').style.visibility = 'visible';
     document.getElementById('tmdbIn').value = S.tmdbToken;
+    document.getElementById('tmdbKeyIn').value = S.tmdbApiKey;
     document.getElementById('rpdbIn').value = S.rpdbKey;
     syncNext();
 
@@ -789,7 +795,7 @@ function build() {
       posterService:'rpdb',
       enhanceResults:true,
       tmdbAccessToken:S.tmdbToken || '<template_placeholder>',
-      tmdbApiKey:'<template_placeholder>',
+      tmdbApiKey:S.tmdbApiKey || '<template_placeholder>',
       usePosterRedirectApi:true,
       usePosterServiceForMeta:true,
       maxResults:rc.maxResults,

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -8,16 +8,22 @@
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#e6edf3;min-height:100vh;display:flex;flex-direction:column;align-items:center;padding:24px 16px}
 .wrap{width:100%;max-width:700px}
-.hdr{text-align:center;margin-bottom:28px}
-.hdr-logo{display:flex;align-items:center;justify-content:center;gap:12px;margin-bottom:8px}
-.hdr-logo img{width:40px;height:40px;filter:drop-shadow(0 0 8px rgba(124,58,237,.5))}
-.hdr h1{font-size:1.9rem;font-weight:800;letter-spacing:-0.02em;color:#fff}
-.hdr h1 span{background:linear-gradient(135deg,#7c3aed,#a855f7);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
-.hdr p{color:#8b949e;margin-top:6px;font-size:.95rem}
-.prog-wrap{margin:20px 0 6px}
-.prog-track{background:#21262d;border-radius:4px;height:6px;overflow:hidden}
-.prog-fill{background:linear-gradient(90deg,#7c3aed,#a855f7);height:100%;transition:width .35s ease;border-radius:4px}
-.prog-label{color:#8b949e;font-size:.78rem;text-align:right;margin-top:5px;letter-spacing:.03em}
+.hdr{margin-bottom:22px}
+.hdr-banner{display:flex;align-items:center;gap:16px;background:#080c10;border:1px solid #162030;border-radius:14px;padding:18px 22px;margin-bottom:16px;position:relative;overflow:hidden}
+.hdr-banner::before{content:'';position:absolute;inset:0;background-image:linear-gradient(rgba(0,212,255,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(0,212,255,.035) 1px,transparent 1px);background-size:56px 56px;pointer-events:none}
+.hdr-icon{width:52px;height:52px;flex-shrink:0;position:relative;z-index:1;filter:drop-shadow(0 0 10px rgba(0,212,255,.35))}
+.hdr-divider{width:1.5px;height:52px;background:linear-gradient(to bottom,transparent,rgba(0,212,255,.6),transparent);flex-shrink:0;position:relative;z-index:1}
+.hdr-text{position:relative;z-index:1}
+.hdr-title{font-size:1.7rem;font-weight:900;letter-spacing:-.02em;line-height:1;margin-bottom:3px}
+.hdr-core{color:#fff}
+.hdr-builds{color:#00d4ff}
+.hdr-underline{height:2px;width:110px;background:rgba(0,212,255,.45);border-radius:1px;margin-bottom:5px}
+.hdr-by{font-size:.68rem;letter-spacing:.14em;color:#7eeeff;opacity:.7;margin-bottom:4px}
+.hdr-sub{font-size:.82rem;color:#8b949e}
+.prog-wrap{margin:0 0 6px}
+.prog-track{background:#21262d;border-radius:4px;height:5px;overflow:hidden}
+.prog-fill{background:linear-gradient(90deg,#0891b2,#00d4ff);height:100%;transition:width .35s ease;border-radius:4px}
+.prog-label{color:#8b949e;font-size:.75rem;text-align:right;margin-top:5px;letter-spacing:.03em}
 .card{background:#161b22;border:1px solid #30363d;border-radius:14px;padding:28px;margin-bottom:14px;animation:fadeIn .2s ease}
 @keyframes fadeIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 .card h2{font-size:1.15rem;font-weight:700;margin-bottom:5px}
@@ -31,14 +37,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .opts.c2d{grid-template-columns:1fr}
 .opt input{display:none}
 .opt label{display:flex;flex-direction:column;background:#0d1117;border:2px solid #30363d;border-radius:10px;padding:16px;cursor:pointer;transition:border-color .15s,background .15s;height:100%;user-select:none}
-.opt input:checked+label{border-color:#7c3aed;background:#110d2a}
-.opt label:hover{border-color:#584090}
+.opt input:checked+label{border-color:#00d4ff;background:#00131c}
+.opt label:hover{border-color:#005c7a}
 .opt-icon{font-size:1.4rem;margin-bottom:7px;flex-shrink:0}
 .opt-name{font-weight:700;font-size:.93rem}
 .opt-desc{color:#8b949e;font-size:.8rem;margin-top:4px;line-height:1.45}
 .name-row label{color:#8b949e;font-size:.82rem;display:block;margin-bottom:6px;text-transform:uppercase;letter-spacing:.05em}
 .name-input{width:100%;background:#0d1117;border:2px solid #30363d;border-radius:8px;color:#e6edf3;padding:12px 16px;font-size:1rem;transition:border-color .15s;outline:none}
-.name-input:focus{border-color:#7c3aed}
+.name-input:focus{border-color:#00d4ff}
 .name-input::placeholder{color:#484f58}
 .summary{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:20px}
 .sum-item{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 14px}
@@ -49,7 +55,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .btn:active{transform:scale(.97)}
 .btn:hover{opacity:.86}
 .btn-back{background:#21262d;color:#e6edf3;flex-shrink:0}
-.btn-next{background:linear-gradient(135deg,#7c3aed,#a855f7);color:#fff;flex:1}
+.btn-next{background:linear-gradient(135deg,#0e7490,#00d4ff);color:#fff;flex:1}
 .btn-next:disabled{opacity:.38;cursor:not-allowed}
 .btn-dl{width:100%;padding:16px;font-size:1.08rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:opacity .15s,transform .1s}
 .btn-dl:active{transform:scale(.98)}
@@ -61,8 +67,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   .wrap{max-width:980px}
   .card{padding:36px}
   .card h2{font-size:1.3rem}
-  .hdr h1{font-size:2.2rem}
-  .hdr-logo img{width:48px;height:48px}
+  .hdr-banner{padding:22px 32px;gap:22px}
+  .hdr-icon{width:64px;height:64px}
+  .hdr-divider{height:64px}
+  .hdr-title{font-size:2.1rem}
+  .hdr-underline{width:136px}
   .opts{gap:12px}
   .opts.c4d{grid-template-columns:repeat(4,1fr)}
   .opts.c3d{grid-template-columns:repeat(3,1fr)}
@@ -79,17 +88,34 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <body>
 <div class="wrap">
   <header class="hdr">
-    <div class="hdr-logo">
-      <img src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg" alt="Core Builds">
-      <div>
-        <h1><span>Core Builds</span></h1>
-        <div style="font-size:.78rem;color:#8b949e;letter-spacing:.06em;margin-top:1px">by Brevity</div>
+    <div class="hdr-banner">
+      <svg class="hdr-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+        <defs>
+          <linearGradient id="hg1" x1="50%" y1="0%" x2="50%" y2="100%"><stop offset="0%" stop-color="#00e5ff"/><stop offset="100%" stop-color="#4facfe"/></linearGradient>
+          <linearGradient id="hg2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4facfe"/><stop offset="50%" stop-color="#c060c0"/><stop offset="100%" stop-color="#ff4b2b"/></linearGradient>
+          <filter id="hf1"><feGaussianBlur stdDeviation="10" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+          <filter id="hf2"><feGaussianBlur stdDeviation="14" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+          <filter id="hf3"><feGaussianBlur stdDeviation="24"/></filter>
+        </defs>
+        <circle cx="256" cy="256" r="248" fill="#080c10"/>
+        <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.05" filter="url(#hf3)"/>
+        <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.09" filter="url(#hf3)"/>
+        <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round" opacity="0.3" filter="url(#hf1)"/>
+        <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#hg1)" stroke-width="22" stroke-linejoin="round"/>
+        <polygon points="256,166 346,256 256,346 166,256" fill="url(#hg2)" opacity="0.4" filter="url(#hf2)"/>
+        <polygon points="256,166 346,256 256,346 166,256" fill="url(#hg2)" opacity="0.95"/>
+      </svg>
+      <div class="hdr-divider"></div>
+      <div class="hdr-text">
+        <div class="hdr-title"><span class="hdr-core">CORE</span><span class="hdr-builds"> BUILDS</span></div>
+        <div class="hdr-underline"></div>
+        <div class="hdr-by">BY BREVITY</div>
+        <div class="hdr-sub">Template Configurator — AIOStreams</div>
       </div>
     </div>
-    <p>Template Configurator — generate a custom AIOStreams template</p>
     <div class="prog-wrap">
       <div class="prog-track"><div class="prog-fill" id="pFill" style="width:0%"></div></div>
-      <div class="prog-label" id="pLabel">Step 1 of 6</div>
+      <div class="prog-label" id="pLabel">Step 1 of 7</div>
     </div>
   </header>
   <div id="main"></div>

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -63,6 +63,19 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .btn-dl{width:100%;padding:16px;font-size:1.08rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:opacity .15s,transform .1s}
 .btn-dl:active{transform:scale(.98)}
 .btn-dl:hover{opacity:.9}
+.btn-aio{width:100%;padding:14px;font-size:1rem;font-weight:700;border-radius:10px;border:2px solid #0e7490;cursor:pointer;background:transparent;color:#00d4ff;margin-top:10px;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px}
+.btn-aio:hover{background:#00131c;border-color:#00d4ff}
+.btn-aio:active{transform:scale(.98)}
+.aio-section{margin-top:20px;border-top:1px solid #21262d;padding-top:18px}
+.aio-section h3{font-size:.82rem;font-weight:600;color:#8b949e;text-transform:uppercase;letter-spacing:.08em;margin-bottom:12px}
+.aio-fields{display:grid;gap:10px;margin-bottom:0}
+.toast{position:fixed;bottom:24px;left:50%;transform:translateX(-50%) translateY(20px);background:#0a2a1a;border:1px solid #2ea043;color:#3fb950;padding:12px 22px;border-radius:10px;font-size:.9rem;font-weight:600;z-index:999;opacity:0;transition:all .3s;pointer-events:none;white-space:nowrap}
+.toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+.toast.error{background:#1a0a0a;border-color:#8b1a1a;color:#f87171}
+.import-success{background:#061a0e;border:1px solid #2ea043;border-radius:10px;padding:16px;margin-top:12px;font-size:.85rem}
+.import-success strong{color:#3fb950;display:block;margin-bottom:8px;font-size:.95rem}
+.manifest-url{background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:10px 12px;font-family:monospace;font-size:.78rem;color:#8b949e;word-break:break-all;margin-top:6px;cursor:pointer;transition:border-color .15s}
+.manifest-url:hover{border-color:#00d4ff;color:#00d4ff}
 .notice{background:#0d2317;border:1px solid #2ea043;border-radius:9px;padding:13px 16px;font-size:.83rem;color:#8b949e;margin-top:14px;line-height:1.5}
 .notice strong{color:#3fb950;display:block;margin-bottom:3px}
 .tag{display:inline-block;background:#1f2937;border:1px solid #374151;border-radius:5px;padding:2px 8px;font-size:.75rem;color:#9ca3af;margin-top:6px;font-family:monospace}
@@ -84,11 +97,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   .opts.c3d .opt-desc,.opts.c2d .opt-desc{font-size:.83rem}
   .summary{grid-template-columns:repeat(3,1fr)}
   .nav{max-width:480px}
-  .btn-dl{max-width:480px}
+  .btn-dl,.btn-aio{max-width:480px}
 }
 </style>
 </head>
 <body>
+<div id="toast" class="toast"></div>
 <div class="wrap">
   <header class="hdr">
     <div class="hdr-banner">
@@ -130,7 +144,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 const STEPS = 7;
 let step = 1;
-const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''} };
+const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''}, instanceUrl:'', instancePassword:'' };
 
 const DEFS = [
   { id:'service', title:'Debrid Service', desc:'Which service are you using for cached streams?', key:'service', cols:'c4d',
@@ -232,10 +246,29 @@ function render() {
             value="" oninput="S.name=this.value" maxlength="60">
         </div>
         <button class="btn-dl" onclick="generate()">⬇ Generate &amp; Download Template</button>
-        <div class="notice">
-          <strong>How to import</strong>
-          AIOStreams → Templates → Import → paste the raw file URL, or upload the JSON file directly.<br>
-          Enter your service credentials after import.${hasApis ? ' TMDB and RPDB keys are baked in.' : ' API keys left as placeholders — fill in after import if needed.'}
+        <div class="aio-section">
+          <h3>Open in AIOStreams</h3>
+          <div class="aio-fields">
+            <div class="name-row" style="margin-bottom:0">
+              <label>AIOStreams Instance URL</label>
+              <input class="name-input" id="aioUrl" type="url" placeholder="https://aiostreams.elfhosted.com"
+                value="${S.instanceUrl}" oninput="S.instanceUrl=this.value.trim()" maxlength="200">
+            </div>
+            <div class="name-row" style="margin-bottom:0">
+              <label>Password <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#4b5563">(optional — enables auto-create via API)</span></label>
+              <input class="name-input" id="aioPwd" type="password" placeholder="your AIOStreams password"
+                value="${S.instancePassword}" oninput="S.instancePassword=this.value" maxlength="200">
+            </div>
+          </div>
+          <button class="btn-aio" onclick="openInAIOStreams()">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+            Open in AIOStreams
+          </button>
+          <div id="aioResult"></div>
+        </div>
+        <div class="notice" style="margin-top:14px">
+          <strong>Manual import</strong>
+          AIOStreams → Templates → Import → paste the raw file URL, or upload the JSON file directly.${hasApis ? ' TMDB and RPDB keys are baked in.' : ' API keys left as placeholders — fill in after import if needed.'}
           <div style="margin-top:10px;padding-top:10px;border-top:1px solid #1a3a24;color:#6b7280;font-size:.78rem">
             Core Builds by Brevity &nbsp;·&nbsp;
             <a href="https://github.com/brevityA/Core-Builds" target="_blank" style="color:#3fb950;text-decoration:none">github.com/brevityA/Core-Builds</a>
@@ -898,6 +931,67 @@ function generate() {
   a.click();
   document.body.removeChild(a);
   setTimeout(() => URL.revokeObjectURL(url), 100);
+}
+
+function showToast(msg, isError) {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.className = 'toast' + (isError ? ' error' : '') + ' show';
+  clearTimeout(t._timer);
+  t._timer = setTimeout(() => { t.className = 'toast' + (isError ? ' error' : ''); }, 3200);
+}
+
+async function openInAIOStreams() {
+  const base = (S.instanceUrl || '').trim().replace(/\/$/, '');
+  if (!base) { showToast('Enter your AIOStreams instance URL first', true); return; }
+
+  const tmpl = build();
+  const json = JSON.stringify(tmpl, null, 2);
+
+  try { await navigator.clipboard.writeText(json); } catch(e) {}
+
+  const result = document.getElementById('aioResult');
+
+  if (S.instancePassword) {
+    try {
+      const res = await fetch(`${base}/api/v1/user`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config: tmpl, password: S.instancePassword })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const uuid = data?.uuid || data?.user?.uuid || data?.id;
+        if (uuid) {
+          const manifestUrl = `${base}/api/stremio/${uuid}/manifest.json`;
+          const configUrl   = `${base}/stremio/configure#${uuid}`;
+          result.innerHTML = `<div class="import-success">
+            <strong>Template created in AIOStreams</strong>
+            Install this manifest URL in Stremio:<br>
+            <div class="manifest-url" onclick="navigator.clipboard.writeText('${manifestUrl}');showToast('Manifest URL copied')" title="Click to copy">${manifestUrl}</div>
+            <div style="margin-top:10px">
+              <a href="${configUrl}" target="_blank" style="color:#3fb950;font-size:.85rem">Open in AIOStreams configure →</a>
+            </div>
+          </div>`;
+          showToast('Template created — manifest URL ready');
+          return;
+        }
+      }
+      const errText = await res.text().catch(()=>'');
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606">
+        <strong style="color:#f87171">API responded ${res.status}</strong>
+        <div style="color:#6b7280;font-size:.8rem;margin-top:4px">${errText.slice(0,200)||'Check your password and instance URL'}</div>
+      </div>`;
+    } catch(e) {
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606">
+        <strong style="color:#f87171">Could not reach API</strong>
+        <div style="color:#6b7280;font-size:.8rem;margin-top:4px">CORS or network error — opening configure page instead. JSON is copied to your clipboard.</div>
+      </div>`;
+    }
+  }
+
+  window.open(`${base}/stremio/configure`, '_blank');
+  showToast('JSON copied — paste in Templates → Import');
 }
 
 render();

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -6,8 +6,8 @@
 <title>Core Builds — Template Configurator</title>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#e6edf3;min-height:100vh;display:flex;flex-direction:column;align-items:center;padding:24px 16px}
-.wrap{width:100%;max-width:700px}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#e6edf3;min-height:100dvh;display:flex;flex-direction:column;align-items:center;padding:24px 16px 20px}
+.wrap{width:100%;max-width:700px;flex:1;display:flex;flex-direction:column}
 .hdr{margin-bottom:22px}
 .hdr-banner{display:flex;align-items:center;gap:16px;background:#080c10;border:1px solid #162030;border-radius:14px;padding:18px 22px;margin-bottom:16px;position:relative;overflow:hidden}
 .hdr-banner::before{content:'';position:absolute;inset:0;background-image:linear-gradient(rgba(0,212,255,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(0,212,255,.035) 1px,transparent 1px);background-size:56px 56px;pointer-events:none}
@@ -24,7 +24,9 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .prog-track{background:#21262d;border-radius:4px;height:5px;overflow:hidden}
 .prog-fill{background:linear-gradient(90deg,#0891b2,#00d4ff);height:100%;transition:width .35s ease;border-radius:4px}
 .prog-label{color:#8b949e;font-size:.75rem;text-align:right;margin-top:5px;letter-spacing:.03em}
-.card{background:#161b22;border:1px solid #30363d;border-radius:14px;padding:28px;margin-bottom:14px;animation:fadeIn .2s ease}
+.card{background:#161b22;border:1px solid #30363d;border-radius:14px;padding:28px;margin-bottom:14px;animation:fadeIn .2s ease;flex:1;display:flex;flex-direction:column}
+#main{flex:1;display:flex;flex-direction:column}
+.opts{align-content:start}
 @keyframes fadeIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 .card h2{font-size:1.15rem;font-weight:700;margin-bottom:5px}
 .card .desc{color:#8b949e;font-size:.88rem;margin-bottom:20px;line-height:1.5}
@@ -50,7 +52,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .sum-item{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 14px}
 .sum-lbl{color:#8b949e;font-size:.72rem;text-transform:uppercase;letter-spacing:.06em}
 .sum-val{font-weight:700;font-size:.9rem;margin-top:3px;color:#e6edf3}
-.nav{display:flex;gap:12px;margin-top:6px}
+.nav{display:flex;gap:12px;margin-top:6px;position:sticky;bottom:16px;z-index:10}
+.nav::before{content:'';position:absolute;inset:-20px -16px 0;background:linear-gradient(to bottom,transparent,#0d1117 35%);pointer-events:none;z-index:-1}
 .btn{padding:12px 28px;border-radius:9px;border:none;font-size:.97rem;font-weight:700;cursor:pointer;transition:opacity .15s,transform .1s}
 .btn:active{transform:scale(.97)}
 .btn:hover{opacity:.86}

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -101,7 +101,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 const STEPS = 7;
 let step = 1;
-const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', rpdbKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''} };
+const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''} };
 
 const DEFS = [
   { id:'service', title:'Debrid Service', desc:'Which service are you using for cached streams?', key:'service', cols:'c4d',
@@ -175,7 +175,7 @@ function render() {
 
   if (step === STEPS) {
     const auto = defaultName();
-    const hasApis = S.tmdbToken || S.tmdbApiKey || S.rpdbKey || Object.values(S.creds).some(v=>v);
+    const hasApis = S.tmdbToken || S.tmdbApiKey || Object.values(S.creds).some(v=>v);
     main.innerHTML = `
       <div class="card">
         <h2>Your Configuration</h2>
@@ -193,8 +193,7 @@ function render() {
             <div class="sum-val" style="font-weight:400;font-size:.85rem">${[
               Object.values(S.creds).filter(v=>v).length ? '✓ debrid credentials' : '',
               S.tmdbToken ? '✓ TMDB token' : '',
-              S.tmdbApiKey ? '✓ TMDB API key' : '',
-              S.rpdbKey ? '✓ RPDB key' : ''
+              S.tmdbApiKey ? '✓ TMDB API key' : ''
             ].filter(Boolean).join(' · ')}</div>
           </div>` : ''}
         </div>
@@ -239,21 +238,15 @@ function render() {
           <input class="name-input" id="tmdbIn" type="text" placeholder="eyJhbGciOiJSUzI1NiJ9…"
             value="" oninput="S.tmdbToken=this.value" maxlength="400">
         </div>
-        <div class="name-row" style="margin-bottom:14px">
+        <div class="name-row">
           <label>TMDB API Key (v3)</label>
           <input class="name-input" id="tmdbKeyIn" type="text" placeholder="abc123def456…"
             value="" oninput="S.tmdbApiKey=this.value" maxlength="60">
         </div>
-        <div class="name-row">
-          <label>RPDB API Key</label>
-          <input class="name-input" id="rpdbIn" type="text" placeholder="t0-abcdef123…"
-            value="" oninput="S.rpdbKey=this.value" maxlength="80">
-        </div>
         <div class="notice" style="margin-top:14px">
           <strong>Where to find these</strong>
           ${debridInputs.map(inp => `<strong style="color:#8b949e;font-weight:400">${inp.label.replace(' API Key','')}:</strong> ${inp.where}<br>`).join('')}
-          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API (both keys listed there)<br>
-          <strong style="color:#8b949e;font-weight:400">RPDB:</strong> ratingposterdb.com → your account → API key (free tier: t0-…)
+          <strong style="color:#8b949e;font-weight:400">TMDB:</strong> themoviedb.org → Settings → API (both keys listed there)
         </div>
       </div>`;
     nav.style.display = 'flex';
@@ -264,7 +257,6 @@ function render() {
     });
     document.getElementById('tmdbIn').value = S.tmdbToken;
     document.getElementById('tmdbKeyIn').value = S.tmdbApiKey;
-    document.getElementById('rpdbIn').value = S.rpdbKey;
     syncNext();
 
   } else {
@@ -834,7 +826,7 @@ function build() {
       excludedRegexPatterns:[],
       addonCategoryColors:{Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'},
       mergedCatalogs:[],
-      rpdbApiKey:S.rpdbKey || 't0-free-rpdb',
+      rpdbApiKey:'t0-free-rpdb',
       posterService:'rpdb',
       enhanceResults:true,
       tmdbAccessToken:S.tmdbToken || '<template_placeholder>',

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -246,6 +246,11 @@ function render() {
             value="" oninput="S.name=this.value" maxlength="60">
         </div>
         <button class="btn-dl" onclick="generate()">⬇ Generate &amp; Download Template</button>
+        <button class="btn-aio" onclick="createImportUrl()" id="btnImport">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+          Create Import URL
+        </button>
+        <div id="importUrlResult"></div>
         <div class="aio-section">
           <h3>Open in AIOStreams</h3>
           <div class="aio-fields">
@@ -939,6 +944,65 @@ function showToast(msg, isError) {
   t.className = 'toast' + (isError ? ' error' : '') + ' show';
   clearTimeout(t._timer);
   t._timer = setTimeout(() => { t.className = 'toast' + (isError ? ' error' : ''); }, 3200);
+}
+
+function buildPublic() {
+  const tmpl = build();
+  const pub = JSON.parse(JSON.stringify(tmpl));
+  if (pub.config) {
+    if (pub.config.tmdbAccessToken && pub.config.tmdbAccessToken !== '<TMDB_READ_ACCESS_TOKEN>') pub.config.tmdbAccessToken = '<TMDB_READ_ACCESS_TOKEN>';
+    if (pub.config.tmdbApiKey && pub.config.tmdbApiKey !== '<TMDB_API_KEY>') pub.config.tmdbApiKey = '<TMDB_API_KEY>';
+    if (pub.config.services) pub.config.services = pub.config.services.map(s => ({ ...s, credentials: {} }));
+  }
+  return pub;
+}
+
+async function createImportUrl() {
+  const btn = document.getElementById('btnImport');
+  const result = document.getElementById('importUrlResult');
+  btn.disabled = true;
+  btn.textContent = 'Creating…';
+  result.innerHTML = '';
+
+  const json = JSON.stringify(buildPublic(), null, 2);
+  let url = null;
+
+  // Try paste.rs
+  try {
+    const r = await fetch('https://paste.rs/', { method:'POST', headers:{'Content-Type':'text/plain'}, body:json });
+    if (r.ok) url = (await r.text()).trim();
+  } catch(e) {}
+
+  // Fallback: dpaste.com
+  if (!url) {
+    try {
+      const body = new URLSearchParams({ content: json, syntax:'json', expiry_days:'365' });
+      const r = await fetch('https://dpaste.com/api/v2/', { method:'POST', body });
+      if (r.ok) {
+        const t = (await r.text()).trim().replace(/"/g,'');
+        url = t.startsWith('http') ? t + '.txt' : null;
+      }
+    } catch(e) {}
+  }
+
+  btn.disabled = false;
+  btn.innerHTML = '<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg> Create Import URL';
+
+  if (url) {
+    const safeUrl = url.replace(/"/g,'&quot;');
+    result.innerHTML = `<div class="import-success" style="margin-top:10px">
+      <strong>Import URL ready</strong>
+      <div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">AIOStreams → Templates → Import → paste this URL. API keys stripped — add them in AIOStreams after import.</div>
+      <div class="manifest-url" onclick="navigator.clipboard.writeText('${safeUrl}');showToast('URL copied')" title="Click to copy">${url}</div>
+    </div>`;
+    showToast('Import URL ready — click to copy');
+  } else {
+    result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px">
+      <strong style="color:#f87171">Could not reach paste service</strong>
+      <div style="color:#6b7280;font-size:.79rem;margin-top:4px">Use ⬇ Download instead, then import the file in AIOStreams → Templates → Import.</div>
+    </div>`;
+    showToast('Paste service unreachable — try Download instead', true);
+  }
 }
 
 async function openInAIOStreams() {

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -214,7 +214,7 @@ function render() {
         </div>
       </div>`;
     nav.style.display = 'none';
-    document.getElementById('nameIn').value = S.name;
+    document.getElementById('nameIn').value = S.name || defaultName();
 
   } else if (def.id === 'apis') {
     const debridInputs = getDebridInputs();
@@ -366,17 +366,25 @@ function ruid() {
 function sid() { return Math.random().toString(36).substring(2,8); }
 
 function defaultName() {
-  let svc;
-  if (S.service === 'multi') {
+  const res = S.resolution;
+  const svc = S.service;
+  const is4k = res === '4k';
+  const isUW = res === 'ultrawide';
+  const names = {
+    'torbox-pro':  is4k ? 'Core Nexus 4K Apex'        : isUW ? 'Core Nexus Ultrawide'            : 'Core Nexus Stream',
+    'torbox-ess':  is4k ? 'Core Nexus 4K Essential'   : isUW ? 'Core Nexus Essential Ultrawide'  : 'Core Nexus Essential',
+    'alldebrid':   is4k ? 'Core Nexus 4K AllDebrid'   : isUW ? 'Core Nexus AllDebrid Ultrawide'  : 'Core Nexus AllDebrid',
+    'realdebrid':  is4k ? 'Core Nexus 4K RD'          : isUW ? 'Core Nexus RD Ultrawide'         : 'Core Nexus RD',
+    'premiumize':  is4k ? 'Core Nexus 4K Premiumize'  : isUW ? 'Core Nexus Premiumize Ultrawide' : 'Core Nexus Premiumize',
+    'debridlink':  is4k ? 'Core Nexus 4K Debrid-Link' : isUW ? 'Core Nexus Debrid-Link Ultrawide': 'Core Nexus Debrid-Link',
+    'hybrid':      is4k ? 'Core Nexus 4K Hybrid'      : isUW ? 'Core Nexus Hybrid Ultrawide'     : 'Core Nexus Hybrid',
+  };
+  if (svc === 'multi') {
     const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL'};
-    svc = 'Multi (' + S.multiServices.map(s => abbr[s] || s).join('+') + ')';
-  } else {
-    svc = {'torbox-pro':'TorBox Pro','torbox-ess':'TorBox Essential',
-      'alldebrid':'AllDebrid','realdebrid':'Real-Debrid',
-      'premiumize':'Premiumize','debridlink':'Debrid-Link','hybrid':'Hybrid'}[S.service] || '';
+    const svcs = S.multiServices.map(s => abbr[s] || s).join('+');
+    return `Core Nexus${is4k?' 4K':''} Multi (${svcs})${isUW?' Ultrawide':''}`.trim();
   }
-  const res = {'4k':'4K','1080p':'1080p','ultrawide':'Ultrawide'}[S.resolution] || '';
-  return `Core Nexus Custom ${svc} ${res}`.trim();
+  return names[svc] || 'Core Nexus Custom';
 }
 
 function presets() {


### PR DESCRIPTION
## Summary

Adds a **Create Import URL** button to the review step that works exactly like the `sourceUrl` links in the static templates directory — paste the URL into AIOStreams → Templates → Import and done.

**How it works:**
- Builds the template JSON with API keys/credentials stripped to placeholders (safe for public hosting — matches what the static templates do)
- POSTs to `paste.rs` (primary) with `dpaste.com` as fallback
- Returns a publicly accessible URL that AIOStreams can fetch server-side
- Click-to-copy URL box shown on success
- Graceful error if both paste services are unreachable (directs to Download instead)

**Security:** `tmdbAccessToken`, `tmdbApiKey`, and all debrid `credentials` are replaced with `<PLACEHOLDER>` / `{}` before posting. Only the filter/sort/format config is public — same as any template in the repo.

## Test plan
- [ ] Click "Create Import URL" → URL appears, click copies to clipboard
- [ ] Paste URL into AIOStreams → Templates → Import → template loads correctly
- [ ] API keys fields show as placeholders in imported template (not real values)
- [ ] If paste.rs unreachable, error message shown with fallback to Download
- [ ] Download still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_