### PR TITLE
feat(configurator): add SVG favicon

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Core Builds — Template Configurator</title>
+<link rel="icon" type="image/svg+xml" href="../Assets/core_icon.svg">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#e6edf3;min-height:100dvh;display:flex;flex-direction:column;align-items:center;padding:24px 16px 20px}


### PR DESCRIPTION
Adds `<link rel="icon" type="image/svg+xml" href="../Assets/core_icon.svg">` to the configurator `<head>` — uses the existing Core Builds hexagon icon as the browser tab favicon.

SVG favicons are supported in all modern browsers (Chrome 80+, Firefox 41+, Safari 12+, Edge 80+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_