### PR TITLE
fix(configurator): always show Install to Stremio when manifest URL is known

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -1101,20 +1101,20 @@ async function tryInstallToHost(base, tmpl, uuid, pwd) {
   return resolvedUuid ? { base, uuid: resolvedUuid, data } : null;
 }
 
-function manifestCard(base, uuid, showInstall) {
+function manifestCard(base, uuid) {
   const manifestUrl = `${base}/api/stremio/${uuid}/manifest.json`;
   const stremioUrl  = `https://web.stremio.com/#/?addon=${encodeURIComponent(manifestUrl)}`;
   const configUrl   = `${base}/stremio/configure`;
   const safeUrl     = manifestUrl.replace(/"/g, '&quot;');
   return `<div class="import-success" style="margin-top:12px">
     <strong>Manifest URL ✓</strong>
-    <div style="color:#6b7280;font-size:.79rem;margin:4px 0 10px">Click to copy — paste into any Stremio-compatible client under Add-ons → Install by URL.</div>
+    <div style="color:#6b7280;font-size:.79rem;margin:4px 0 10px">Click the URL to copy it, or use the buttons below.</div>
     <div class="manifest-url" onclick="navigator.clipboard.writeText('${safeUrl}');showToast('Manifest URL copied')" title="Click to copy">${manifestUrl}</div>
     <div style="display:flex;gap:10px;margin-top:12px;flex-wrap:wrap">
-      ${showInstall ? `<a href="${stremioUrl}" target="_blank" style="flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000;border-radius:8px;font-weight:700;font-size:.88rem;text-decoration:none">
+      <a href="${stremioUrl}" target="_blank" style="flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000;border-radius:8px;font-weight:700;font-size:.88rem;text-decoration:none">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
         Install to Stremio
-      </a>` : ''}
+      </a>
       <a href="${configUrl}" target="_blank" style="flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;background:transparent;border:1px solid #30363d;color:#8b949e;border-radius:8px;font-weight:600;font-size:.88rem;text-decoration:none">
         Open AIOStreams →
       </a>
@@ -1134,7 +1134,7 @@ async function openInAIOStreams() {
 
   // "Get Manifest URL" tab + known UUID → construct directly, no API call (avoids CORS)
   if (aioTab === 'manifest' && uuid && !isAuto) {
-    result.innerHTML = manifestCard(base, uuid, false);
+    result.innerHTML = manifestCard(base, uuid);
     showToast('Manifest URL ready — click to copy');
     return;
   }
@@ -1157,7 +1157,7 @@ async function openInAIOStreams() {
       }
 
       if (ok) {
-        result.innerHTML = manifestCard(ok.base, ok.uuid, aioTab === 'direct');
+        result.innerHTML = manifestCard(ok.base, ok.uuid);
         showToast(uuid && !isAuto ? 'Config updated — manifest ready' : 'Config created — manifest ready');
         btn.disabled = false; btn.innerHTML = origHtml;
         return;


### PR DESCRIPTION
## Problem

"Install to Stremio" was effectively unreachable:
- On the **Direct Install** tab — button only appeared after a successful API call, but CORS always blocks it on ElfHosted
- On the **Get Manifest URL** tab — button was explicitly hidden (`showInstall=false`) even when the UUID and manifest URL were right there

## Fix

Remove the `showInstall` parameter from `manifestCard()` — the Install to Stremio button now always shows whenever a manifest URL is displayed. Both tabs get it.

The correct flow for ElfHosted users is now:
1. Enter UUID → switch to **Get Manifest URL** tab → click button
2. Result card shows manifest URL (click to copy) + **Install to Stremio** + **Open AIOStreams →**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_