### PR TITLE
fix(configurator): Stremio install URLs + 7-host dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.0.4 (2026-06-26)
+
+### Changed
+- **Configurator overhaul** (`configurator/index.html`) — series of UX refinements to the Core Builds wizard:
+  - **Password show/hide toggle** — eye icon added to the password field so users can verify what they typed without a timed reveal
+  - **UUID field links to ElfHosted configure page** — label now includes a direct clickable link to `aiostreams.elfhosted.com/stremio/configure`
+  - **Tab consolidation** — "Direct Install" and "Get Manifest URL" tabs removed; both produced the same output (App + Web install buttons) so the distinction was moot; replaced with a single "Install to Stremio" action area
+  - **Paste-manifest-URL shortcut** — new input at the bottom of the install section accepts an existing manifest URL and immediately renders App + Web install buttons with no API call, covering returning users who already have an AIOStreams account on any host
+  - **ElfHosted error hint now links to configure page** — the inline hint shown when an ElfHosted CORS error occurs now links directly to the configure page instead of describing it
+  - **Host switch clears result card** — switching hosts now clears any previously shown manifest / error card to avoid stale results
+
+---
+
 ## 3.0.3 (2026-06-25)
 
 ### Added

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -259,12 +259,7 @@ function render() {
         </button>
         <div id="importUrlResult"></div>
         <div class="aio-section">
-          <h3>Get Manifest URL</h3>
-          <div class="tab-row">
-            <button class="tab-btn active" id="tabDirect" onclick="setTab('direct')">Direct Install</button>
-            <button class="tab-btn" id="tabManifest" onclick="setTab('manifest')">Get Manifest URL</button>
-          </div>
-          <div class="tab-hint" id="tabHint">Installs the addon directly into Stremio.</div>
+          <h3>Install to Stremio</h3>
           <div class="aio-fields" style="margin-top:12px">
             <div class="name-row" style="margin-bottom:0">
               <label>AIOStreams Host</label>
@@ -290,11 +285,19 @@ function render() {
                 <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">Password</span>
                 <button type="button" onclick="genPwd()" style="font-size:.75rem;color:#00d4ff;background:none;border:none;cursor:pointer;padding:0;font-weight:700">Generate →</button>
               </div>
-              <input class="name-input" id="aioPwd" type="password" placeholder="Create a password to protect your manifest"
-                value="${S.instancePassword}" oninput="S.instancePassword=this.value" maxlength="200" autocomplete="new-password">
+              <div style="position:relative">
+                <input class="name-input" id="aioPwd" type="password" placeholder="Create a password to protect your manifest"
+                  value="${S.instancePassword}" oninput="S.instancePassword=this.value" maxlength="200" autocomplete="new-password"
+                  style="padding-right:40px">
+                <button type="button" id="pwdEye" onclick="togglePwd()"
+                  title="Show/hide password"
+                  style="position:absolute;right:10px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:#4b5563;padding:2px;line-height:1;display:flex;align-items:center">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
             </div>
             <div id="aioUuidRow" class="name-row" style="margin-bottom:0;${S.instanceHost==='elfhosted'?'':'display:none'}">
-              <label>UUID <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#4b5563">(from your ElfHosted configure page)</span></label>
+              <label>UUID <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#4b5563">— find it at <a href="https://aiostreams.elfhosted.com/stremio/configure" target="_blank" style="color:#00d4ff;text-decoration:none">your ElfHosted configure page</a></span></label>
               <input class="name-input" id="aioUuid" type="text" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                 value="${S.instanceUuid}" oninput="S.instanceUuid=this.value.trim()" maxlength="36" style="font-family:monospace;font-size:.88rem">
             </div>
@@ -304,6 +307,14 @@ function render() {
             Install to Stremio
           </button>
           <div id="aioResult"></div>
+          <div style="margin-top:16px;padding-top:14px;border-top:1px solid #21262d">
+            <div style="color:#6b7280;font-size:.79rem;margin-bottom:8px">Already have a manifest URL? Paste it for instant install links:</div>
+            <input class="name-input" id="pasteManifest" type="url"
+              placeholder="https://aiostreams.elfhosted.com/stremio/uuid/password/manifest.json"
+              oninput="onPasteManifest(this.value)"
+              style="font-size:.8rem;font-family:monospace">
+            <div id="pasteManifestResult"></div>
+          </div>
         </div>
         <div class="notice" style="margin-top:14px">
           <strong>Manual import</strong>
@@ -980,18 +991,37 @@ function showToast(msg, isError) {
   t._timer = setTimeout(() => { t.className = 'toast' + (isError ? ' error' : ''); }, 3200);
 }
 
-let aioTab = 'direct';
-function setTab(t) {
-  aioTab = t;
-  document.getElementById('tabDirect').classList.toggle('active', t==='direct');
-  document.getElementById('tabManifest').classList.toggle('active', t==='manifest');
-  document.getElementById('tabHint').textContent = t==='direct'
-    ? 'Installs the addon directly into Stremio.'
-    : 'Generates an AIOStreams manifest URL for any streaming client.';
-  const btn = document.getElementById('btnAio');
-  if (btn) btn.innerHTML = t==='direct'
-    ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg> Install to Stremio'
-    : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg> Get Manifest URL';
+function togglePwd() {
+  const el  = document.getElementById('aioPwd');
+  const eye = document.getElementById('pwdEye');
+  if (!el) return;
+  const show = el.type === 'password';
+  el.type = show ? 'text' : 'password';
+  if (eye) eye.style.color = show ? '#00d4ff' : '#4b5563';
+}
+
+function onPasteManifest(val) {
+  val = (val || '').trim();
+  const result = document.getElementById('pasteManifestResult');
+  if (!val) { result.innerHTML = ''; return; }
+  try { new URL(val); } catch(e) { result.innerHTML = ''; return; }
+  const desktopUrl = val.replace(/^https?:\/\//, 'stremio://');
+  const webUrl     = `https://web.stremio.com/#/addons?addon=${encodeURIComponent(val)}`;
+  const safeVal    = val.replace(/"/g, '&quot;');
+  const btnBase    = 'flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:9px 14px;border-radius:8px;font-weight:700;font-size:.85rem;text-decoration:none';
+  result.innerHTML = `<div style="margin-top:10px">
+    <div class="manifest-url" onclick="navigator.clipboard.writeText('${safeVal}');showToast('Manifest URL copied')" title="Click to copy" style="margin-bottom:10px;font-size:.79rem">${val}</div>
+    <div style="display:flex;gap:8px;flex-wrap:wrap">
+      <a href="${desktopUrl}" style="${btnBase};background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+        Install (App)
+      </a>
+      <a href="${webUrl}" target="_blank" style="${btnBase};background:#1a1f2e;border:1px solid #00d4ff;color:#00d4ff">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        Install (Web)
+      </a>
+    </div>
+  </div>`;
 }
 
 const PUBLIC_HOSTS = [
@@ -1193,7 +1223,7 @@ async function openInAIOStreams() {
 
       // Server responded but rejected the request
       const hostHint = S.instanceHost === 'elfhosted' && !uuid
-        ? '<div style="color:#6b7280;font-size:.78rem;margin-top:8px">💡 ElfHosted accounts are pre-provisioned — enter your UUID from the ElfHosted configure page, then use the Get Manifest URL tab.</div>'
+        ? '<div style="color:#6b7280;font-size:.78rem;margin-top:8px">💡 ElfHosted accounts are pre-provisioned — enter your UUID from your <a href="https://aiostreams.elfhosted.com/stremio/configure" target="_blank" style="color:#00d4ff;text-decoration:none">ElfHosted configure page</a> and your password above.</div>'
         : '';
       const configUrl = `${isAuto ? PUBLIC_HOSTS[0] : base}/stremio/configure`;
       result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px">

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -269,10 +269,15 @@ function render() {
             <div class="name-row" style="margin-bottom:0">
               <label>AIOStreams Host</label>
               <select class="name-input" id="aioHost" onchange="onHostChange(this.value)" style="cursor:pointer;color-scheme:dark">
-                <option value="auto" ${S.instanceHost==='auto'?'selected':''}>Auto (tries all public hosts)</option>
-                <option value="elfhosted" ${S.instanceHost==='elfhosted'||S.instanceHost===''?'selected':''}>ElfHosted — aiostreams.elfhosted.com</option>
+                <option value="auto"       ${S.instanceHost==='auto'?'selected':''}>Auto (tries all public hosts)</option>
+                <option value="elfhosted"  ${S.instanceHost==='elfhosted'||S.instanceHost===''?'selected':''}>ElfHosted — aiostreams.elfhosted.com</option>
                 <option value="fortheweak" ${S.instanceHost==='fortheweak'?'selected':''}>ForthewWeak — aiostreams.fortheweak.cloud</option>
-                <option value="custom" ${S.instanceHost==='custom'?'selected':''}>Custom / Self-hosted</option>
+                <option value="midnight"   ${S.instanceHost==='midnight'?'selected':''}>Midnight's — midnightignite.me</option>
+                <option value="viren"      ${S.instanceHost==='viren'?'selected':''}>Viren's — aiostreams.viren070.me</option>
+                <option value="kuu"        ${S.instanceHost==='kuu'?'selected':''}>Kuu's — aiostreams.stremio.ru</option>
+                <option value="atbp"       ${S.instanceHost==='atbp'?'selected':''}>ATBP — aio.atbphosting.com</option>
+                <option value="omni"       ${S.instanceHost==='omni'?'selected':''}>Omni's — aiostreams.12312023.xyz</option>
+                <option value="custom"     ${S.instanceHost==='custom'?'selected':''}>Custom / Self-hosted</option>
               </select>
             </div>
             <div id="aioUrlRow" class="name-row" style="margin-bottom:0;${S.instanceHost==='custom'?'':'display:none'}">
@@ -288,7 +293,7 @@ function render() {
               <input class="name-input" id="aioPwd" type="password" placeholder="Create a password to protect your manifest"
                 value="${S.instancePassword}" oninput="S.instancePassword=this.value" maxlength="200" autocomplete="new-password">
             </div>
-            <div id="aioUuidRow" class="name-row" style="margin-bottom:0;${S.instanceHost==='custom'||S.instanceHost==='auto'||S.instanceHost==='fortheweak'?'display:none':''}">
+            <div id="aioUuidRow" class="name-row" style="margin-bottom:0;${S.instanceHost==='elfhosted'?'':'display:none'}">
               <label>UUID <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#4b5563">(from your ElfHosted configure page)</span></label>
               <input class="name-input" id="aioUuid" type="text" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                 value="${S.instanceUuid}" oninput="S.instanceUuid=this.value.trim()" maxlength="36" style="font-family:monospace;font-size:.88rem">
@@ -992,11 +997,25 @@ function setTab(t) {
 const PUBLIC_HOSTS = [
   'https://aiostreams.elfhosted.com',
   'https://aiostreams.fortheweak.cloud',
+  'https://aiostreamsfortheweebsstable.midnightignite.me',
+  'https://aiostreams.viren070.me',
+  'https://aiostreams.stremio.ru',
+  'https://aio.atbphosting.com',
+  'https://aiostreams.12312023.xyz',
 ];
 
+const HOST_URLS = {
+  elfhosted:   'https://aiostreams.elfhosted.com',
+  fortheweak:  'https://aiostreams.fortheweak.cloud',
+  midnight:    'https://aiostreamsfortheweebsstable.midnightignite.me',
+  viren:       'https://aiostreams.viren070.me',
+  kuu:         'https://aiostreams.stremio.ru',
+  atbp:        'https://aio.atbphosting.com',
+  omni:        'https://aiostreams.12312023.xyz',
+};
+
 function resolvedInstanceUrl() {
-  if (S.instanceHost === 'elfhosted') return 'https://aiostreams.elfhosted.com';
-  if (S.instanceHost === 'fortheweak') return 'https://aiostreams.fortheweak.cloud';
+  if (HOST_URLS[S.instanceHost]) return HOST_URLS[S.instanceHost];
   return (S.instanceUrl || '').trim().replace(/\/$/, '');
 }
 
@@ -1013,6 +1032,7 @@ function onHostChange(val) {
     const el = document.getElementById('aioUrl');
     if (el) { el.value = ''; el.focus(); }
   }
+  document.getElementById('aioResult').innerHTML = '';
 }
 
 const PWD_WORDS = ['Blue','Red','Dark','Bright','Swift','Deep','High','Storm','Wild','Sharp',
@@ -1101,21 +1121,29 @@ async function tryInstallToHost(base, tmpl, uuid, pwd) {
   return resolvedUuid ? { base, uuid: resolvedUuid, data } : null;
 }
 
-function manifestCard(base, uuid, showInstall) {
-  const manifestUrl = `${base}/api/stremio/${uuid}/manifest.json`;
-  const stremioUrl  = `https://web.stremio.com/#/?addon=${encodeURIComponent(manifestUrl)}`;
+function manifestCard(base, uuid, pwd) {
+  const manifestUrl = pwd
+    ? `${base}/stremio/${uuid}/${encodeURIComponent(pwd)}/manifest.json`
+    : `${base}/stremio/${uuid}/manifest.json`;
+  const desktopUrl  = manifestUrl.replace(/^https?:\/\//, 'stremio://');
+  const webUrl      = `https://web.stremio.com/#/addons?addon=${encodeURIComponent(manifestUrl)}`;
   const configUrl   = `${base}/stremio/configure`;
   const safeUrl     = manifestUrl.replace(/"/g, '&quot;');
+  const btnBase     = 'display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;border-radius:8px;font-weight:700;font-size:.88rem;text-decoration:none';
   return `<div class="import-success" style="margin-top:12px">
     <strong>Manifest URL ✓</strong>
     <div style="color:#6b7280;font-size:.79rem;margin:4px 0 10px">Click to copy — paste into any Stremio-compatible client under Add-ons → Install by URL.</div>
     <div class="manifest-url" onclick="navigator.clipboard.writeText('${safeUrl}');showToast('Manifest URL copied')" title="Click to copy">${manifestUrl}</div>
-    <div style="display:flex;gap:10px;margin-top:12px;flex-wrap:wrap">
-      ${showInstall ? `<a href="${stremioUrl}" target="_blank" style="flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000;border-radius:8px;font-weight:700;font-size:.88rem;text-decoration:none">
+    <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+      <a href="${desktopUrl}" style="flex:1;${btnBase};background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-        Install to Stremio
-      </a>` : ''}
-      <a href="${configUrl}" target="_blank" style="flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px 14px;background:transparent;border:1px solid #30363d;color:#8b949e;border-radius:8px;font-weight:600;font-size:.88rem;text-decoration:none">
+        Install (App)
+      </a>
+      <a href="${webUrl}" target="_blank" style="flex:1;${btnBase};background:#1a1f2e;border:1px solid #00d4ff;color:#00d4ff">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        Install (Web)
+      </a>
+      <a href="${configUrl}" target="_blank" style="flex:1;${btnBase};background:transparent;border:1px solid #30363d;color:#8b949e">
         Open AIOStreams →
       </a>
     </div>
@@ -1132,9 +1160,9 @@ async function openInAIOStreams() {
   const uuid   = (S.instanceUuid || '').trim();
   const pwd    = S.instancePassword;
 
-  // "Get Manifest URL" tab + known UUID → construct directly, no API call (avoids CORS)
-  if (aioTab === 'manifest' && uuid && !isAuto) {
-    result.innerHTML = manifestCard(base, uuid, false);
+  // Known UUID → construct manifest URL directly, no API call needed (avoids CORS)
+  if (uuid && !isAuto) {
+    result.innerHTML = manifestCard(base, uuid, pwd);
     showToast('Manifest URL ready — click to copy');
     return;
   }
@@ -1157,7 +1185,7 @@ async function openInAIOStreams() {
       }
 
       if (ok) {
-        result.innerHTML = manifestCard(ok.base, ok.uuid, aioTab === 'direct');
+        result.innerHTML = manifestCard(ok.base, ok.uuid, pwd);
         showToast(uuid && !isAuto ? 'Config updated — manifest ready' : 'Config created — manifest ready');
         btn.disabled = false; btn.innerHTML = origHtml;
         return;


### PR DESCRIPTION
## Summary

- **Fix Stremio web install URL** — was `#/?addon=` (broken), now `#/addons?addon=` (correct per AIOStreams source)
- **Add stremio:// desktop install button** — opens manifest directly in the Stremio desktop app alongside the existing web install button
- **Fix manifest URL path** — was `/api/stremio/{uuid}/manifest.json`, now `/stremio/{uuid}/{password}/manifest.json` (correct AIOStreams route)
- **Always show both install buttons** — removed the `showInstall` conditional; Install (App) + Install (Web) always visible
- **UUID shortcut works on both tabs** — previously only triggered on "Get Manifest URL" tab; now works regardless, avoiding unnecessary CORS API calls
- **Expand host dropdown from 2 → 7 public instances**: ElfHosted, ForthewWeak, Midnight's, Viren's, Kuu's, ATBP, Omni's
- **Update PUBLIC_HOSTS** for Auto mode to try all 7 hosts
- **UUID row** only shown for ElfHosted (only pre-provisioned service)
- **Clear result card** when host selection changes

## Test plan

- [ ] Select ElfHosted, enter UUID + password → manifest card appears with both Install (App) and Install (Web) buttons, no API call made
- [ ] Click Install (App) → `stremio://` link fires (Stremio desktop must be installed)
- [ ] Click Install (Web) → opens `https://web.stremio.com/#/addons?addon=...`
- [ ] Click manifest URL → copies to clipboard, toast confirms
- [ ] Switch to ForthewWeak host → UUID row disappears, result clears
- [ ] Select Auto → all 7 hosts tried in sequence on API attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_