### PR TITLE
configurator: Advanced options accordion for audio profiles in resolution step

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -336,7 +336,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   </div>
 </div>
 <script>
-const STEPS = 8;
+const STEPS = 7;
 let step = 0;
 const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'' };
 
@@ -409,14 +409,6 @@ const DEFS = [
       { v:'4k',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 40,16 22,42 4,16" stroke="#7c3aed" stroke-width="2" fill="#1a0a3a"/><polygon points="22,3 40,16 22,16 4,16" fill="#7c3aed" opacity="0.4"/><text x="22" y="34" text-anchor="middle" fill="#a78bfa" font-size="9" font-weight="800" font-family="system-ui,sans-serif">4K</text></svg>', name:'4K HDR',        desc:'2160p first · 1080p fallback · for 4K displays' },
       { v:'1080p',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="8" width="38" height="24" rx="3" stroke="#3b82f6" stroke-width="2" fill="#0a1428"/><text x="22" y="25" text-anchor="middle" fill="#3b82f6" font-size="11" font-weight="800" font-family="system-ui,sans-serif">1080p</text><rect x="17" y="32" width="10" height="4" rx="1" fill="#3b82f6"/><line x1="13" y1="40" x2="31" y2="40" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/></svg>', name:'1080p',          desc:'Hard lock · 2160p excluded · bandwidth-friendly' },
       { v:'ultrawide', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="11" width="40" height="22" rx="2" stroke="#8b5cf6" stroke-width="2" fill="#0e0a1f"/><text x="22" y="26" text-anchor="middle" fill="#8b5cf6" font-size="8" font-weight="700" font-family="system-ui,sans-serif">21 : 9</text><rect x="17" y="33" width="10" height="4" rx="1" fill="#8b5cf6"/><line x1="12" y1="41" x2="32" y2="41" stroke="#8b5cf6" stroke-width="2" stroke-linecap="round"/></svg>', name:'Ultrawide',      desc:'1080p → 1440p → 4K tiers · pair with Windows PC device' },
-    ]
-  },
-  { id:'audio', title:'Audio', desc:'What formats does your audio setup support?', key:'audio', cols:'c1', layout:'svc-list', noHero:true,
-    opts:[
-      { v:'lossless', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#10b981" stroke-width="1.5" stroke-linejoin="round" fill="#0a1f16"/><path d="M26 14 Q32 22 26 30" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M30 9 Q39 22 30 35" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M34 5 Q44 22 34 39" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Full Lossless',   desc:'TrueHD · Atmos · DTS-HD MA · FLAC · eARC required' },
-      { v:'standard', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#f59e0b" stroke-width="1.5" stroke-linejoin="round" fill="#1a1000"/><path d="M26 15 Q32 22 26 29" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><path d="M30 10 Q38 22 30 34" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><text x="38" y="15" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="800" font-family="system-ui,sans-serif">D+</text></svg>', name:'DD+ / Atmos',     desc:'Soundbar or smart TV · Dolby Digital Plus' },
-      { v:'limited',  icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><path d="M5 18 L5 26 L10 26 L18 31 L18 13 L10 18 Z" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round" fill="#111"/><path d="M23 17 Q26 22 23 27" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><circle cx="35" cy="22" r="7" stroke="#94a3b8" stroke-width="1.5" fill="#111"/><circle cx="35" cy="22" r="2.5" fill="#94a3b8"/><line x1="35" y1="13" x2="35" y2="16" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="35" y1="28" x2="35" y2="31" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="26" y1="22" x2="29" y2="22" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="41" y1="22" x2="44" y2="22" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Auto',             desc:'Let device profile decide · safe default' },
-      { v:'dolby',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><path d="M5 17 L5 27 L11 27 L19 33 L19 11 L11 17 Z" stroke="#818cf8" stroke-width="1.5" stroke-linejoin="round" fill="#0f0f2a"/><path d="M22 13 Q38 13 38 22 Q38 31 22 31 L22 13 Z" fill="#818cf8" opacity="0.75"/><text x="30" y="27" text-anchor="middle" fill="#e0e7ff" font-size="11" font-weight="900" font-family="system-ui,sans-serif">D</text></svg>', name:'Dolby Only',     desc:'Atmos · TrueHD · DD+ · no DTS — Bose / Dolby soundbars' },
     ]
   },
   { id:'content', title:'Content Type', desc:'What will you primarily watch? Not sure? Skip — it covers everything.', key:'content', cols:'c1', layout:'svc-list', noHero:true,
@@ -496,6 +488,32 @@ function renderOpts(def) {
         <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc.replace(/<[^>]*>/g,'')}</div></div>
         <span class="svc-list-arr">›</span>
       </label></div>`).join('');
+      if (def.id === 'resolution') {
+        const AUDIO_OPTS = [
+          { v:'lossless', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#10b981" stroke-width="1.5" stroke-linejoin="round" fill="#0a1f16"/><path d="M26 14 Q32 22 26 30" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M30 9 Q39 22 30 35" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M34 5 Q44 22 34 39" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Full Lossless', desc:'TrueHD · Atmos · DTS-HD MA · FLAC · eARC required' },
+          { v:'standard', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#f59e0b" stroke-width="1.5" stroke-linejoin="round" fill="#1a1000"/><path d="M26 15 Q32 22 26 29" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><path d="M30 10 Q38 22 30 34" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><text x="38" y="15" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="800" font-family="system-ui,sans-serif">D+</text></svg>', name:'DD+ / Atmos', desc:'Soundbar or smart TV · Dolby Digital Plus' },
+          { v:'limited',  icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M5 18 L5 26 L10 26 L18 31 L18 13 L10 18 Z" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round" fill="#111"/><path d="M23 17 Q26 22 23 27" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><circle cx="35" cy="22" r="7" stroke="#94a3b8" stroke-width="1.5" fill="#111"/><circle cx="35" cy="22" r="2.5" fill="#94a3b8"/><line x1="35" y1="13" x2="35" y2="16" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="35" y1="28" x2="35" y2="31" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="26" y1="22" x2="29" y2="22" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><line x1="41" y1="22" x2="44" y2="22" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Auto', desc:'Let device profile decide · safe default' },
+          { v:'dolby',    icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M5 17 L5 27 L11 27 L19 33 L19 11 L11 17 Z" stroke="#818cf8" stroke-width="1.5" stroke-linejoin="round" fill="#0f0f2a"/><path d="M22 13 Q38 13 38 22 Q38 31 22 31 L22 13 Z" fill="#818cf8" opacity="0.75"/><text x="30" y="27" text-anchor="middle" fill="#e0e7ff" font-size="11" font-weight="900" font-family="system-ui,sans-serif">D</text></svg>', name:'Dolby Only', desc:'Atmos · TrueHD · DD+ · no DTS' },
+        ];
+        const audioRows = AUDIO_OPTS.map(o => {
+          const on = S.audio === o.v;
+          return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+            <div class="opt-icon" style="flex-shrink:0;pointer-events:none">${o.icon}</div>
+            <div class="opt-body" style="flex:1;min-width:0;pointer-events:none"><div class="opt-name" style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div class="opt-desc" style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+            <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
+          </div>`;
+        }).join('');
+        const curAudioLabel = AUDIO_OPTS.find(o => o.v === S.audio)?.name || 'Auto';
+        const advOpen = !!S.audio && S.audio !== 'limited';
+        return `<div class="svc-list">${rows}</div>
+        <details class="adv-audio-details"${advOpen ? ' open' : ''} style="margin-top:10px">
+          <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.07);user-select:none;transition:background .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'">
+            <span style="font-size:.78rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase">Advanced options · Sound profile</span>
+            <span style="font-size:.76rem;color:#374151;font-weight:600">${curAudioLabel} ›</span>
+          </summary>
+          <div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${audioRows}</div>
+        </details>`;
+      }
       return `<div class="svc-list">${rows}</div>`;
     }
     const SVC_TAGS = {
@@ -620,7 +638,7 @@ function renderProgress() {
   if (progWrap) progWrap.style.display = '';
   if (nav) nav.style.display = '';
 
-  const keys  = ['service','device','resolution','audio','content','formatter',null,null];
+  const keys  = ['service','device','resolution','content','formatter',null,null];
 
   // Step bubble strip
   const bubbles = Array.from({length: STEPS}, (_, i) => {
@@ -1001,6 +1019,22 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('[data-action="set-size-limit"]').forEach(b => {
         b.classList.toggle('size-btn-active', b.dataset.val === S.sizeLimit);
       });
+    }
+    if (action === 'set-audio') {
+      S.audio = (e.target.closest('[data-action="set-audio"]') || e.target).dataset.val;
+      saveState();
+      document.querySelectorAll('[data-action="set-audio"]').forEach(row => {
+        const on = row.dataset.val === S.audio;
+        row.style.borderColor = on ? 'rgba(0,212,255,.35)' : 'rgba(255,255,255,.07)';
+        row.style.background  = on ? 'rgba(0,212,255,.05)' : 'rgba(13,17,23,.7)';
+        const nm = row.querySelector('.opt-name');
+        if (nm) nm.style.color = on ? '#00d4ff' : '#e6edf3';
+        const arr = row.querySelector('span:last-child');
+        if (arr) { arr.textContent = on ? '✓' : '›'; arr.style.color = on ? '#00d4ff' : '#374151'; }
+      });
+      const sum = document.querySelector('.adv-audio-details summary span:last-child');
+      const AUDIO_LABELS = { lossless:'Full Lossless', standard:'DD+ / Atmos', limited:'Auto', dolby:'Dolby Only' };
+      if (sum) sum.textContent = (AUDIO_LABELS[S.audio] || 'Auto') + ' ›';
     }
     if (action === 'set-formatter') {
       S.formatter = (e.target.closest('[data-action="set-formatter"]') || e.target).dataset.val;


### PR DESCRIPTION
## Summary

- Audio profile selection moved from a standalone step into a collapsed `<details>` accordion at the bottom of the resolution step, labelled **Advanced options · Sound profile**
- Four profiles render as svc-list rows inside the accordion: Full Lossless, DD+ / Atmos, Auto, Dolby Only
- Selecting a profile highlights the row (teal border + ✓) and updates the summary label in-place without a full re-render
- Standalone audio step removed — STEPS reduced from 8 to 7

## Test plan

- [ ] Resolution step shows collapsed "Advanced options · Sound profile" with current value on the right
- [ ] Tapping the summary expands all 4 audio profile rows
- [ ] Selecting a profile highlights it and updates the summary label
- [ ] Navigating forward skips the old audio step (now 7 steps total)
- [ ] Audio selection persists in state and appears in the review/template output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_