### PR TITLE
configurator: Advanced Options panel (audio + video prefs + formatter) on service step

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -336,8 +336,9 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   </div>
 </div>
 <script>
-const STEPS = 7;
+const STEPS = 6;
 let step = 0;
+let showAdvanced = false;
 const S = { service:null, device:null, resolution:null, audio:null, content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'' };
 
 const FORMATTERS = [
@@ -419,7 +420,6 @@ const DEFS = [
       { v:'anime', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><circle cx="22" cy="13" r="5.5" fill="#f9a8d4"/><circle cx="31" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="28" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="16" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="13" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="22" cy="22" r="5.5" fill="#fce7f3"/><circle cx="22" cy="22" r="2" fill="#f472b6"/><line x1="37" y1="5" x2="37" y2="10" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/><line x1="34.5" y1="7.5" x2="39.5" y2="7.5" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Anime',            desc:'SeaDex Best-Only · confirmed best releases' },
     ]
   },
-  { id:'formatter', title:'Stream Layout', desc:'Pick how your streams are displayed in Stremio. Each card shows a real preview of that style.', key:'formatter', layout:'formatter-picker', cols:'c1', opts:[] },
   { id:'apis', title:'API Keys', desc:'Optional — bake your keys directly into the template. They are stored only in the downloaded JSON file and are never sent to any server.', key:null, cols:'c1', opts:[] },
   { id:'review', title:'Review & Download', desc:'Confirm your settings and generate the template JSON.', key:null, cols:'c2', opts:[] }
 ];
@@ -448,6 +448,7 @@ function clearState() {
 /* RENDERING */
 function label(key, val) {
   if (key === 'formatter') { const f = FORMATTERS.find(x => x.id === val); return f ? f.label : val || ''; }
+  if (key === 'audio') { const m = {lossless:'Full Lossless',standard:'DD+ / Atmos',limited:'Auto',dolby:'Dolby Only'}; return m[val] || val || ''; }
   const d = DEFS.find(x => x.key === key);
   if (!d) return val || '';
   const o = d.opts.find(x => x.v === val);
@@ -647,6 +648,88 @@ function renderMatchMode() {
   </div>`;
 }
 
+function renderAdvancedPanel() {
+  const AUDIO_OPTS = [
+    { v:'lossless', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#10b981" stroke-width="1.5" stroke-linejoin="round" fill="#0a1f16"/><path d="M26 14 Q32 22 26 30" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M30 9 Q39 22 30 35" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M34 5 Q44 22 34 39" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Full Lossless', desc:'TrueHD · Atmos · DTS-HD MA · FLAC · eARC required' },
+    { v:'standard', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#f59e0b" stroke-width="1.5" stroke-linejoin="round" fill="#1a1000"/><path d="M26 15 Q32 22 26 29" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><path d="M30 10 Q38 22 30 34" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/><text x="38" y="15" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="800" font-family="system-ui,sans-serif">D+</text></svg>', name:'DD+ / Atmos', desc:'Soundbar or smart TV · Dolby Digital Plus' },
+    { v:'limited',  icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M5 18 L5 26 L10 26 L18 31 L18 13 L10 18 Z" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round" fill="#111"/><path d="M23 17 Q26 22 23 27" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/><circle cx="35" cy="22" r="7" stroke="#94a3b8" stroke-width="1.5" fill="#111"/><circle cx="35" cy="22" r="2.5" fill="#94a3b8"/></svg>', name:'Auto', desc:'Let device profile decide · safe default' },
+    { v:'dolby',    icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M5 17 L5 27 L11 27 L19 33 L19 11 L11 17 Z" stroke="#818cf8" stroke-width="1.5" stroke-linejoin="round" fill="#0f0f2a"/><path d="M22 13 Q38 13 38 22 Q38 31 22 31 L22 13 Z" fill="#818cf8" opacity="0.75"/><text x="30" y="27" text-anchor="middle" fill="#e0e7ff" font-size="11" font-weight="900" font-family="system-ui,sans-serif">D</text></svg>', name:'Dolby Only', desc:'Atmos · TrueHD · DD+ · no DTS' },
+  ];
+  const audioRows = AUDIO_OPTS.map(o => {
+    const on = S.audio === o.v;
+    return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+      <div style="flex-shrink:0;pointer-events:none">${o.icon}</div>
+      <div style="flex:1;min-width:0;pointer-events:none"><div style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+      <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
+    </div>`;
+  }).join('');
+
+  const fmtCards = FORMATTERS.map(f => {
+    const on = S.formatter === f.id;
+    return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+      <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
+        <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0"></div>
+        <div style="flex:1;min-width:0">
+          <span class="fmt-lbl" style="font-weight:700;font-size:.9rem;color:${on?'#00d4ff':'#e6edf3'}">${f.label}</span>
+          <span style="margin-left:6px;background:rgba(255,255,255,.06);border-radius:4px;padding:2px 6px;font-size:.65rem;color:#6b7280">${f.badge}</span>
+          <div style="color:#6b7280;font-size:.72rem;margin-top:2px">${f.desc}</div>
+        </div>
+        ${on ? '<span style="color:#00d4ff;font-size:.85rem;flex-shrink:0">✓</span>' : '<span style="color:#374151;font-size:.85rem;flex-shrink:0">›</span>'}
+      </div>
+      <div class="fmt-preview-wrap" style="padding:0 13px 11px;${on?'':'display:none'}">${fmtPreviewHtml(f.id)}</div>
+    </div>`;
+  }).join('');
+
+  const sizeOpts = ['10GB','20GB','30GB','50GB','unlimited'];
+  const sizePills = sizeOpts.map(v => {
+    const on = (S.sizeLimit || 'unlimited') === v;
+    const lbl = v === 'unlimited' ? 'Unlimited' : v;
+    return `<button data-action="set-size-limit" data-val="${v}" class="size-btn${on?' size-btn-active':''}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.72rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s">${lbl}</button>`;
+  }).join('');
+
+  const prefCard = (key, title, desc) => {
+    const on = !!S[key];
+    return `<div class="pref-card${on?' pref-on':''}" data-action="toggle-pref" data-key="${key}" style="cursor:pointer">
+      <div class="pref-body-inner"><div class="pref-title">${title}</div><div class="pref-desc">${desc}</div></div>
+      <div class="pref-circle"></div>
+    </div>`;
+  };
+
+  return `<div class="card" style="padding:0">
+    <div style="display:flex;align-items:center;gap:12px;padding:18px 20px 14px;border-bottom:1px solid rgba(255,255,255,.06)">
+      <button data-action="close-advanced" style="background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.09);border-radius:8px;color:#9ca3af;font-size:.9rem;padding:6px 11px;cursor:pointer;transition:all .15s" onmouseover="this.style.background='rgba(255,255,255,.1)'" onmouseout="this.style.background='rgba(255,255,255,.05)'">← Back</button>
+      <div>
+        <div style="font-weight:800;font-size:1rem;color:#e6edf3">Advanced Options</div>
+        <div style="font-size:.72rem;color:#4b5563;margin-top:1px">Audio · Video · Formatter</div>
+      </div>
+    </div>
+    <div style="padding:18px 20px;display:flex;flex-direction:column;gap:20px">
+
+      <div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px">🔊 Sound Profile</div>
+        <div style="display:flex;flex-direction:column;gap:7px">${audioRows}</div>
+      </div>
+
+      <div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px">🎬 Video Preferences</div>
+        <div style="background:#0d1117;border:1.5px solid #30363d;border-radius:10px;padding:14px 16px;margin-bottom:8px">
+          <div style="font-size:.78rem;font-weight:600;color:#6b7280;margin-bottom:10px">Size Limit</div>
+          <div style="display:flex;gap:5px">${sizePills}</div>
+        </div>
+        ${prefCard('qualityFirst','Prioritize Quality over Resolution','Sorts by source quality (e.g. REMUX) before resolution.')}
+        ${prefCard('exclude4K','Exclude 4K / UHD','Removes 2160p streams. Good for bandwidth saving.')}
+        ${prefCard('excludeDV','Exclude Dolby Vision','Fixes purple/green tint on unsupported screens.')}
+      </div>
+
+      <div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px">🎨 Stream Layout (Formatter)</div>
+        <div style="display:flex;flex-direction:column;gap:8px">${fmtCards}</div>
+      </div>
+
+    </div>
+  </div>`;
+}
+
 function renderProgress() {
   const progWrap = document.querySelector('.prog-wrap');
   const nav = document.getElementById('nav');
@@ -658,7 +741,7 @@ function renderProgress() {
   if (progWrap) progWrap.style.display = '';
   if (nav) nav.style.display = '';
 
-  const keys  = ['service','device','resolution','content','formatter',null,null];
+  const keys  = ['service','device','resolution','audio','content',null];
 
   // Step bubble strip
   const bubbles = Array.from({length: STEPS}, (_, i) => {
@@ -736,6 +819,12 @@ function render() {
     return;
   }
   main.style.justifyContent = '';
+
+  if (showAdvanced) {
+    main.innerHTML = renderAdvancedPanel();
+    nav.style.display = 'none';
+    return;
+  }
 
   const def  = DEFS[step - 1];
 
@@ -943,6 +1032,7 @@ function render() {
         ${renderOpts(def)}
         ${def.id === 'service' ? '<div id="multiPanel"></div>' : ''}
         ${def.id === 'content' ? renderP2pToggle() + renderMatchMode() : ''}
+        ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:11px;color:#6b7280;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px" onmouseover="this.style.background='rgba(255,255,255,.07)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.85rem">⚙</span> Advanced Options</button>` : ''}
       </div>`;
     nav.style.display = 'flex';
     document.getElementById('btnBack').style.visibility = step > 1 ? 'visible' : 'hidden';
@@ -1013,9 +1103,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'nav-back') {
       if (step > 0) { document.getElementById('main').classList.add('nav-back'); step--; saveState(); render(); window.scrollTo(0,0); }
     }
+    if (action === 'open-advanced')  { showAdvanced = true;  render(); window.scrollTo(0,0); }
+    if (action === 'close-advanced') { showAdvanced = false; render(); window.scrollTo(0,0); }
     if (action === 'start-setup') { document.getElementById('main').classList.remove('nav-back'); step = 1; saveState(); render(); window.scrollTo(0,0); }
     if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; saveState(); render(); window.scrollTo(0,0); }
-    if (action === 'reset-state') clearState();
+    if (action === 'reset-state') { showAdvanced = false; clearState(); }
     if (action === 'generate-dl') generate();
     if (action === 'create-import') createImportUrl();
     if (action === 'gen-pwd') genPwd();


### PR DESCRIPTION
## Summary

- Adds **⚙ Advanced Options** button at the bottom of the service/debrid step
- Opens a dedicated panel (← Back header) with three sections:
  - **Sound Profile** — 4 audio rows (Full Lossless, DD+, Auto, Dolby Only)
  - **Video Preferences** — Size limit pills + Quality-first / Exclude 4K / Exclude DV toggles
  - **Stream Layout** — Full formatter picker with live inline preview
- Standalone formatter step removed (STEPS 7 → 6)
- Audio breadcrumb chip restored — shows in step strip after selection
- All settings from the panel persist in state and flow through to template generation

## Test plan

- [ ] Service step shows ⚙ Advanced Options button at bottom
- [ ] Tapping it opens the panel with all three sections
- [ ] ← Back returns to service step
- [ ] Audio selection from panel shows as ✓ chip on resolution step breadcrumb
- [ ] Formatter selection in panel carries through to generated template
- [ ] Wizard completes in 6 steps (no separate formatter step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_