### PR TITLE
configurator: EasyNews multi-debrid, NZBGeek, fresh start, UI polish

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -324,7 +324,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .splash-paste{margin-top:13px;font-size:.76rem;color:#374151;cursor:pointer;text-decoration:underline;text-underline-offset:3px;transition:color .15s}
 .splash-paste:hover{color:#6b7280}
 /* ── Theme toggle ─────────────────────────────────────── */
-#themeToggle{position:fixed;top:14px;right:14px;z-index:300;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:8px;color:#6b7280;font-size:.8rem;font-weight:700;padding:5px 11px;cursor:pointer;transition:all .15s;letter-spacing:.02em;line-height:1.4}
+#themeToggle{position:fixed;top:14px;left:14px;z-index:300;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:8px;color:#6b7280;font-size:.8rem;font-weight:700;padding:5px 11px;cursor:pointer;transition:all .15s;letter-spacing:.02em;line-height:1.4}
 #themeToggle:hover{background:rgba(255,255,255,.12);color:#e6edf3;border-color:rgba(255,255,255,.2)}
 #themeToggle::before{content:'☀';margin-right:4px}
 [data-theme="light"] #themeToggle::before{content:'🌙'}
@@ -422,10 +422,17 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] #themeToggle{background:rgba(0,0,0,.05);border-color:rgba(0,0,0,.12);color:#57606a}
 [data-theme="light"] #themeToggle:hover{background:rgba(0,0,0,.09);color:#1c2128;border-color:rgba(0,0,0,.2)}
 [data-theme="light"] [data-action="set-formatter"]{background:#f6f8fa!important;border-color:#d0d7de!important}
+[data-theme="light"] [data-action="set-formatter"][data-active="true"]{background:rgba(9,105,218,.07)!important;border-color:rgba(9,105,218,.45)!important}
 [data-theme="light"] [data-action="set-audio"]{background:#f6f8fa!important;border-color:#d0d7de!important}
+[data-theme="light"] [data-action="set-audio"][data-active="true"]{background:rgba(9,105,218,.07)!important;border-color:rgba(9,105,218,.45)!important}
+[data-theme="light"] [data-action="set-audio"][data-active="true"] .opt-name,[data-theme="light"] [data-action="set-audio"][data-active="true"] .fmt-lbl{color:#0969da!important}
 [data-theme="light"] [data-action="set-match-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
+[data-theme="light"] [data-action="set-match-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
+[data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
+[data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
+[data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>function _0x3f1f(_0x2ebfbb,_0x9bcf25){_0x2ebfbb=_0x2ebfbb-(0xd*-0x22a+-0x1581+-0x737*-0x7);var _0x87259f=_0x440e();var _0x5a1915=_0x87259f[_0x2ebfbb];if(_0x3f1f['AaYxeJ']===undefined){var _0x16b5a4=function(_0x30a4fe){var _0x2411db='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x35dd4f='',_0x3c299a='';for(var _0x439e1e=-0x133*0x15+-0xb84+0x24b3,_0x3e2b69,_0x426471,_0x215fc4=0xac0+0x1*0x93a+0x9fd*-0x2;_0x426471=_0x30a4fe['charAt'](_0x215fc4++);~_0x426471&&(_0x3e2b69=_0x439e1e%(-0xf0*0x23+-0x54b*-0x2+0x163e)?_0x3e2b69*(0x825+-0xa53+-0x26e*-0x1)+_0x426471:_0x426471,_0x439e1e++%(-0x1e71+-0x1*-0xe57+0x101e))?_0x35dd4f+=String['fromCharCode'](0x5d9+-0x61*0x5e+0xb*0x2cc&_0x3e2b69>>(-(0x204*-0x4+-0x23dd+-0x1*-0x2bef)*_0x439e1e&0x3b*0x49+0x10c3+0x1*-0x2190)):-0x5d4+-0x1dfc+0x11e8*0x2){_0x426471=_0x2411db['indexOf'](_0x426471);}for(var _0xf23bdc=0xf06*0x2+-0x37b*0x8+-0x234,_0x2d4201=_0x35dd4f['length'];_0xf23bdc<_0x2d4201;_0xf23bdc++){_0x3c299a+='%'+('00'+_0x35dd4f['charCodeAt'](_0xf23bdc)['toString'](0x1f46+-0x3*0x8b+-0x1d95))['slice'](-(-0xa45+-0x1662+0x20a9));}return decodeURIComponent(_0x3c299a);};_0x3f1f['gDDNRv']=_0x16b5a4,_0x3f1f['VcEZnH']={},_0x3f1f['AaYxeJ']=!![];}var _0xc6d274=_0x87259f[-0x6d*0x3+0xc*-0xce+0xaef],_0x3bf234=_0x2ebfbb+_0xc6d274,_0x2fd4dc=_0x3f1f['VcEZnH'][_0x3bf234];return!_0x2fd4dc?(_0x5a1915=_0x3f1f['gDDNRv'](_0x5a1915),_0x3f1f['VcEZnH'][_0x3bf234]=_0x5a1915):_0x5a1915=_0x2fd4dc,_0x5a1915;}var _0x10a525=_0x3f1f;function _0x440e(){var _0x1db550=['ndHKC1v5AeS','zg9JDw1LBNrfBgvTzw50','mty0mJDUCuLHzKO','z2v0sxrLBq','y2juAgvTzq','nta0mtG5Eu5RwKH1','mZm5mtCXwfrOtvDl','ntqWnteZB2v0Bg5I','ota0mdLkChPMzvG','mZeWExP0q2Dx','mZm3otm5oef3z3LVsG','nNfoBMreyW','Bwf0y2HnzwrPyq','zgfYAW','nZiXmZu1teXqsMHl','ngnivNztEG','zgf0ys10AgvTzq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','Bwf0y2HLCW'];_0x440e=function(){return _0x1db550;};return _0x440e();}(function(_0x22638e,_0x4ad0e6){var _0x135aec={_0x4cb7c6:0xed,_0x1ceee9:0xdf,_0x28e37b:0xee,_0x50615a:0xef},_0x1813bf=_0x3f1f,_0x3bc268=_0x22638e();while(!![]){try{var _0x25b2f8=parseInt(_0x1813bf(0xea))/(-0x1477+-0x1ce4+-0x12*-0x2be)*(-parseInt(_0x1813bf(0xe0))/(0x50f+0xc*0xda+-0xf45))+parseInt(_0x1813bf(_0x135aec._0x4cb7c6))/(-0x1aab+-0x5*0x66+-0x4*-0x72b)+parseInt(_0x1813bf(0xe4))/(-0x11*-0x141+0xabf+-0x200c)*(parseInt(_0x1813bf(0xe3))/(0xd24+-0x199*0xd+0x7a6))+-parseInt(_0x1813bf(_0x135aec._0x1ceee9))/(-0x2*0x13+0x1fc*-0xa+0x1404)+-parseInt(_0x1813bf(_0x135aec._0x28e37b))/(-0x115+-0xa*0x2fb+0x1*0x1eea)*(-parseInt(_0x1813bf(0xe8))/(-0x1b3c+0x9*0x11a+-0x1*-0x115a))+parseInt(_0x1813bf(_0x135aec._0x50615a))/(-0x237e+-0x140c+0x3793)+-parseInt(_0x1813bf(0xde))/(-0x1cd*0xf+0x11f8+-0x307*-0x3)*(-parseInt(_0x1813bf(0xf0))/(-0x609+-0xac9+-0x10dd*-0x1));if(_0x25b2f8===_0x4ad0e6)break;else _0x3bc268['push'](_0x3bc268['shift']());}catch(_0x27399a){_0x3bc268['push'](_0x3bc268['shift']());}}}(_0x440e,-0x34c1b+0x3*-0x6bd9+0x3a*0x28b3));try{document[_0x10a525(0xe9)]['setAttribute'](_0x10a525(0xe5),localStorage[_0x10a525(0xeb)](_0x10a525(0xec))||(window[_0x10a525(0xe1)](_0x10a525(0xe6))[_0x10a525(0xe7)]?_0x10a525(0xe2):'light'));}catch(_0x1364a0){}</script>
+<script>function _0x590b(_0xc5fb5c,_0x2b3c22){_0xc5fb5c=_0xc5fb5c-(0x12a0*0x2+0x2121+-0x446d);var _0xa5edc1=_0x4744();var _0x4ab9ed=_0xa5edc1[_0xc5fb5c];if(_0x590b['wsWNYr']===undefined){var _0x496432=function(_0xf31427){var _0x207e22='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x57643b='',_0x5ca15a='';for(var _0x398964=-0xbfc+-0x1*0xac9+0x16c5,_0x5c08e4,_0x26fb61,_0x19d6e5=0xcbf*0x1+0xad3+-0xbc9*0x2;_0x26fb61=_0xf31427['charAt'](_0x19d6e5++);~_0x26fb61&&(_0x5c08e4=_0x398964%(0xe85+0xe74*0x2+-0x2b69)?_0x5c08e4*(-0x128+-0x1c4f+0x1db7)+_0x26fb61:_0x26fb61,_0x398964++%(0x59*0x18+-0x4*-0x6a9+-0x22f8))?_0x57643b+=String['fromCharCode'](-0x4*0x874+-0x7eb*0x1+0x2aba&_0x5c08e4>>(-(0x13b4+-0x1237*0x1+-0x17b)*_0x398964&0x44d*0x6+-0x2*0x79d+0x7*-0x182)):-0x48b*-0x2+-0x1ab6+0x178*0xc){_0x26fb61=_0x207e22['indexOf'](_0x26fb61);}for(var _0x13a098=0xc80+0x142b+0x1*-0x20ab,_0x41c263=_0x57643b['length'];_0x13a098<_0x41c263;_0x13a098++){_0x5ca15a+='%'+('00'+_0x57643b['charCodeAt'](_0x13a098)['toString'](0xc0f*-0x3+0x1*-0x1517+0x3954))['slice'](-(-0x574+0xae*-0xe+0xefa));}return decodeURIComponent(_0x5ca15a);};_0x590b['qMDnLs']=_0x496432,_0x590b['YSdViX']={},_0x590b['wsWNYr']=!![];}var _0x38a151=_0xa5edc1[0x6*-0x211+0x4bc*-0x6+0x1*0x28ce],_0x1ea9bb=_0xc5fb5c+_0x38a151,_0x2fc6c2=_0x590b['YSdViX'][_0x1ea9bb];return!_0x2fc6c2?(_0x4ab9ed=_0x590b['qMDnLs'](_0x4ab9ed),_0x590b['YSdViX'][_0x1ea9bb]=_0x4ab9ed):_0x4ab9ed=_0x2fc6c2,_0x4ab9ed;}var _0x268ca7=_0x590b;(function(_0x580c3c,_0x477f09){var _0x22f4c2={_0xb56345:0x1ff,_0x3384b9:0x1f7,_0x551965:0x1fa,_0x2c2c6d:0x1fc,_0x1d270e:0x1fe},_0x424407=_0x590b,_0xd4a355=_0x580c3c();while(!![]){try{var _0xc2040c=parseInt(_0x424407(_0x22f4c2._0xb56345))/(0x87c+0x1b82+-0x23fd)+parseInt(_0x424407(0x201))/(0xb0b*0x3+0x4*0x325+-0x2db3)*(parseInt(_0x424407(_0x22f4c2._0x3384b9))/(0x1d3*-0x2+-0x3*0xa31+-0x4e4*-0x7))+parseInt(_0x424407(0x202))/(0x1*-0xc73+-0x3*-0xad8+-0x1411)+parseInt(_0x424407(_0x22f4c2._0x551965))/(-0x16fe+-0x5*-0x2f6+0xbf*0xb)*(parseInt(_0x424407(_0x22f4c2._0x2c2c6d))/(0x222b*-0x1+0xf*0x122+0x1*0x1133))+-parseInt(_0x424407(_0x22f4c2._0x1d270e))/(-0x1001+-0x1d76+0x2d7e*0x1)+parseInt(_0x424407(0x203))/(0x1*-0x17da+0x1507+0x2db)+-parseInt(_0x424407(0x1f8))/(0x98c+0x4*-0xb5+-0x1d*0x3b);if(_0xc2040c===_0x477f09)break;else _0xd4a355['push'](_0xd4a355['shift']());}catch(_0x6b46c1){_0xd4a355['push'](_0xd4a355['shift']());}}}(_0x4744,0x9183d*0x1+0x91c68+-0xd92a4));function _0x4744(){var _0x2289ec=['zgfYAW','C2v0qxr0CMLIDxrL','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','zg9JDw1LBNrfBgvTzw50','m0T0r2jKtG','nti0mZm1nurdAxD0Da','Bwf0y2HLCW','mJuWnJi1nxbzu1HUvW','zgf0ys10AgvTzq','nKLhAvjRzW','z2v0sxrLBq','mJu1mtyZm1jusu5JEa','mtK4mtaXAMv5rLjl','y2juAgvTzq','mZm2nti2t0n4A2r1','ndK0ndyWBMjiBwns','mJa3nJaWoeXfyMXhwa'];_0x4744=function(){return _0x2289ec;};return _0x4744();}try{document[_0x268ca7(0x1f6)][_0x268ca7(0x1f4)](_0x268ca7(0x1fb),localStorage[_0x268ca7(0x1fd)](_0x268ca7(0x200))||(window['matchMedia'](_0x268ca7(0x1f5))[_0x268ca7(0x1f9)]?_0x268ca7(0x204):'light'));}catch(_0x25849d){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -499,6 +506,8 @@ const CHANGELOG = [
 ];
 let step = 0;
 let showAdvanced = false;
+let hadSavedState = false;
+let _savedStep = 0;
 const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
@@ -595,18 +604,24 @@ function saveState() {
 }
 function loadState() {
   try {
+    const params = new URLSearchParams(location.search);
+    if (params.has('fresh')) {
+      localStorage.removeItem('coreBuild');
+      localStorage.removeItem('coreBuildStep');
+      history.replaceState(null, '', location.pathname);
+      return;
+    }
     const savedS = localStorage.getItem('coreBuild');
     const savedStep = localStorage.getItem('coreBuildStep');
-    if (savedS) Object.assign(S, JSON.parse(savedS));
-    if (savedStep) step = parseInt(savedStep, 10) || 0;
+    if (savedS) { Object.assign(S, JSON.parse(savedS)); hadSavedState = true; }
+    if (savedStep) _savedStep = parseInt(savedStep, 10) || 0;
+    // Always start at splash (step 0) so user can choose to continue or start fresh
   } catch (e) { console.warn("Failed to load state", e); }
 }
 function clearState() {
-  if(confirm("Clear progress and start over?")) {
-    localStorage.removeItem('coreBuild');
-    localStorage.removeItem('coreBuildStep');
-    location.reload();
-  }
+  localStorage.removeItem('coreBuild');
+  localStorage.removeItem('coreBuildStep');
+  location.assign(location.pathname + '?fresh');
 }
 
 /* RENDERING */
@@ -628,7 +643,7 @@ function renderOpts(def) {
   if (def.layout === 'formatter-picker') return '<div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+      return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
         <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
           <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0;box-shadow:0 0 8px ${f.bc}88"></div>
           <div style="flex:1;min-width:0">
@@ -662,7 +677,7 @@ function renderOpts(def) {
         ];
         const audioRows = AUDIO_OPTS.map(o => {
           const on = S.audio === o.v;
-          return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+          return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
             <div class="opt-icon" style="flex-shrink:0;pointer-events:none">${o.icon}</div>
             <div class="opt-body" style="flex:1;min-width:0;pointer-events:none"><div class="opt-name" style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div class="opt-desc" style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
             <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
@@ -806,7 +821,7 @@ function renderMatchMode() {
   const cur = S.matchMode || 'balanced';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-match-mode" data-val="${m.v}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -826,7 +841,7 @@ function renderAdvancedPanel() {
   ];
   const audioRows = AUDIO_OPTS.map(o => {
     const on = S.audio === o.v;
-    return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+    return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
       <div style="flex-shrink:0;pointer-events:none">${o.icon}</div>
       <div style="flex:1;min-width:0;pointer-events:none"><div style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
       <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
@@ -835,7 +850,7 @@ function renderAdvancedPanel() {
 
   const fmtCards = FORMATTERS.map(f => {
     const on = S.formatter === f.id;
-    return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+    return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
       <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
         <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0"></div>
         <div style="flex:1;min-width:0">
@@ -973,6 +988,14 @@ function splashHtml() {
       <span class="splash-chip splash-chip-feat">Multi-Debrid</span>
     </div>
     <button class="splash-cta" data-action="start-setup">Start Setup →</button>
+    ${hadSavedState && _savedStep > 0 ? `<div class="continue-banner" style="width:100%;max-width:310px;margin-top:10px;padding:11px 14px;background:rgba(0,212,255,.06);border:1px solid rgba(0,212,255,.18);border-radius:10px;display:flex;align-items:center;gap:10px">
+      <div style="flex:1;min-width:0">
+        <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
+        <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
+      </div>
+      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
+      <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
+    </div>` : ''}
     <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:10px">
       <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
       <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
@@ -1329,6 +1352,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'open-advanced')  { showAdvanced = true;  render(); window.scrollTo(0,0); }
     if (action === 'close-advanced') { showAdvanced = false; render(); window.scrollTo(0,0); }
     if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'continue-session') { step = _savedStep || 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'start-fresh') { clearState(); }
     if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; saveState(); render(); window.scrollTo(0,0); }
     if (action === 'reset-state') { showAdvanced = false; clearState(); }
     if (action === 'generate-dl') generate();

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -432,7 +432,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>function _0x590b(_0xc5fb5c,_0x2b3c22){_0xc5fb5c=_0xc5fb5c-(0x12a0*0x2+0x2121+-0x446d);var _0xa5edc1=_0x4744();var _0x4ab9ed=_0xa5edc1[_0xc5fb5c];if(_0x590b['wsWNYr']===undefined){var _0x496432=function(_0xf31427){var _0x207e22='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x57643b='',_0x5ca15a='';for(var _0x398964=-0xbfc+-0x1*0xac9+0x16c5,_0x5c08e4,_0x26fb61,_0x19d6e5=0xcbf*0x1+0xad3+-0xbc9*0x2;_0x26fb61=_0xf31427['charAt'](_0x19d6e5++);~_0x26fb61&&(_0x5c08e4=_0x398964%(0xe85+0xe74*0x2+-0x2b69)?_0x5c08e4*(-0x128+-0x1c4f+0x1db7)+_0x26fb61:_0x26fb61,_0x398964++%(0x59*0x18+-0x4*-0x6a9+-0x22f8))?_0x57643b+=String['fromCharCode'](-0x4*0x874+-0x7eb*0x1+0x2aba&_0x5c08e4>>(-(0x13b4+-0x1237*0x1+-0x17b)*_0x398964&0x44d*0x6+-0x2*0x79d+0x7*-0x182)):-0x48b*-0x2+-0x1ab6+0x178*0xc){_0x26fb61=_0x207e22['indexOf'](_0x26fb61);}for(var _0x13a098=0xc80+0x142b+0x1*-0x20ab,_0x41c263=_0x57643b['length'];_0x13a098<_0x41c263;_0x13a098++){_0x5ca15a+='%'+('00'+_0x57643b['charCodeAt'](_0x13a098)['toString'](0xc0f*-0x3+0x1*-0x1517+0x3954))['slice'](-(-0x574+0xae*-0xe+0xefa));}return decodeURIComponent(_0x5ca15a);};_0x590b['qMDnLs']=_0x496432,_0x590b['YSdViX']={},_0x590b['wsWNYr']=!![];}var _0x38a151=_0xa5edc1[0x6*-0x211+0x4bc*-0x6+0x1*0x28ce],_0x1ea9bb=_0xc5fb5c+_0x38a151,_0x2fc6c2=_0x590b['YSdViX'][_0x1ea9bb];return!_0x2fc6c2?(_0x4ab9ed=_0x590b['qMDnLs'](_0x4ab9ed),_0x590b['YSdViX'][_0x1ea9bb]=_0x4ab9ed):_0x4ab9ed=_0x2fc6c2,_0x4ab9ed;}var _0x268ca7=_0x590b;(function(_0x580c3c,_0x477f09){var _0x22f4c2={_0xb56345:0x1ff,_0x3384b9:0x1f7,_0x551965:0x1fa,_0x2c2c6d:0x1fc,_0x1d270e:0x1fe},_0x424407=_0x590b,_0xd4a355=_0x580c3c();while(!![]){try{var _0xc2040c=parseInt(_0x424407(_0x22f4c2._0xb56345))/(0x87c+0x1b82+-0x23fd)+parseInt(_0x424407(0x201))/(0xb0b*0x3+0x4*0x325+-0x2db3)*(parseInt(_0x424407(_0x22f4c2._0x3384b9))/(0x1d3*-0x2+-0x3*0xa31+-0x4e4*-0x7))+parseInt(_0x424407(0x202))/(0x1*-0xc73+-0x3*-0xad8+-0x1411)+parseInt(_0x424407(_0x22f4c2._0x551965))/(-0x16fe+-0x5*-0x2f6+0xbf*0xb)*(parseInt(_0x424407(_0x22f4c2._0x2c2c6d))/(0x222b*-0x1+0xf*0x122+0x1*0x1133))+-parseInt(_0x424407(_0x22f4c2._0x1d270e))/(-0x1001+-0x1d76+0x2d7e*0x1)+parseInt(_0x424407(0x203))/(0x1*-0x17da+0x1507+0x2db)+-parseInt(_0x424407(0x1f8))/(0x98c+0x4*-0xb5+-0x1d*0x3b);if(_0xc2040c===_0x477f09)break;else _0xd4a355['push'](_0xd4a355['shift']());}catch(_0x6b46c1){_0xd4a355['push'](_0xd4a355['shift']());}}}(_0x4744,0x9183d*0x1+0x91c68+-0xd92a4));function _0x4744(){var _0x2289ec=['zgfYAW','C2v0qxr0CMLIDxrL','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','zg9JDw1LBNrfBgvTzw50','m0T0r2jKtG','nti0mZm1nurdAxD0Da','Bwf0y2HLCW','mJuWnJi1nxbzu1HUvW','zgf0ys10AgvTzq','nKLhAvjRzW','z2v0sxrLBq','mJu1mtyZm1jusu5JEa','mtK4mtaXAMv5rLjl','y2juAgvTzq','mZm2nti2t0n4A2r1','ndK0ndyWBMjiBwns','mJa3nJaWoeXfyMXhwa'];_0x4744=function(){return _0x2289ec;};return _0x4744();}try{document[_0x268ca7(0x1f6)][_0x268ca7(0x1f4)](_0x268ca7(0x1fb),localStorage[_0x268ca7(0x1fd)](_0x268ca7(0x200))||(window['matchMedia'](_0x268ca7(0x1f5))[_0x268ca7(0x1f9)]?_0x268ca7(0x204):'light'));}catch(_0x25849d){}</script>
+<script>function _0x20fb(_0x291ccb,_0x4eae6e){_0x291ccb=_0x291ccb-(-0x49*0x65+0x1113*0x1+0x1*0xd99);var _0x5ca632=_0x3b10();var _0x1e8861=_0x5ca632[_0x291ccb];if(_0x20fb['LiaQlW']===undefined){var _0x133b8d=function(_0x521015){var _0x18390b='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x38e020='',_0xb9f7c4='';for(var _0x5e6470=0xb6b+0x2546+-0x30b1,_0x534265,_0x30709c,_0x533b52=-0x8*-0x421+-0x54e+0x2a*-0xa9;_0x30709c=_0x521015['charAt'](_0x533b52++);~_0x30709c&&(_0x534265=_0x5e6470%(0x1*-0x1479+0x1c1d*0x1+-0x7a0)?_0x534265*(0x1*-0xe6a+0x923*0x1+-0x587*-0x1)+_0x30709c:_0x30709c,_0x5e6470++%(0x1529+0x1c5a+-0x317f))?_0x38e020+=String['fromCharCode'](0x1c1*0x4+0x1*-0x72d+0x128&_0x534265>>(-(0xff4+0x56*0x14+-0x16aa*0x1)*_0x5e6470&0x2b*-0xe+-0x32*-0x4+-0x2*-0xcc)):-0x10e3+0x2*-0x5db+0x1c99){_0x30709c=_0x18390b['indexOf'](_0x30709c);}for(var _0x36e963=0xb92*0x2+-0x17c1+0x9d,_0x3e3f35=_0x38e020['length'];_0x36e963<_0x3e3f35;_0x36e963++){_0xb9f7c4+='%'+('00'+_0x38e020['charCodeAt'](_0x36e963)['toString'](0x2222*-0x1+0x18ba+-0x4*-0x25e))['slice'](-(-0x1d47+0x1*-0x10b1+0x2dfa));}return decodeURIComponent(_0xb9f7c4);};_0x20fb['EkWJYu']=_0x133b8d,_0x20fb['BaEczr']={},_0x20fb['LiaQlW']=!![];}var _0xe1f15a=_0x5ca632[-0x2381+-0xf07*-0x1+0x147a],_0x2b0980=_0x291ccb+_0xe1f15a,_0xeba3ba=_0x20fb['BaEczr'][_0x2b0980];return!_0xeba3ba?(_0x1e8861=_0x20fb['EkWJYu'](_0x1e8861),_0x20fb['BaEczr'][_0x2b0980]=_0x1e8861):_0x1e8861=_0xeba3ba,_0x1e8861;}function _0x3b10(){var _0x1aaf67=['mtaYnty4BMXKuvHA','BgLNAhq','nZjdEg9ZBLi','mte3DLv1z291','zgfYAW','ntqWmdmWmfrbyMnlAW','mtGZnfnIyxHfDG','mtjfA0zqvgi','zgf0ys10AgvTzq','mtuZntC2m0josev2sW','mti1nJa4shHqA05w','C2v0qxr0CMLIDxrL','mZeWqurswgzp','mtm3mdm1EufytKXN','zg9JDw1LBNrfBgvTzw50','mtjXA2H4Avm','z2v0sxrLBq','nZeZntm4mu1HDNDrwq'];_0x3b10=function(){return _0x1aaf67;};return _0x3b10();}var _0xfe668a=_0x20fb;(function(_0x54228c,_0x5f1c2a){var _0x33624f={_0x57e8ac:0x1e6,_0x5c591e:0x1e9,_0x29acc6:0x1e7,_0x12d9e2:0x1ea,_0x159b1f:0x1e5,_0x2ba2cb:0x1df},_0x2db2cf=_0x20fb,_0x50ba97=_0x54228c();while(!![]){try{var _0x533539=parseInt(_0x2db2cf(0x1ec))/(-0x133a+0x2f*0x29+0x1ac*0x7)*(-parseInt(_0x2db2cf(_0x33624f._0x57e8ac))/(-0x5*-0x12f+0xbee+-0x11d7))+parseInt(_0x2db2cf(_0x33624f._0x5c591e))/(-0x19ba+0x11d*0x9+-0x1*-0xfb8)+parseInt(_0x2db2cf(_0x33624f._0x29acc6))/(0x1883+0x34*0xa4+-0x39cf)*(-parseInt(_0x2db2cf(0x1ed))/(0x2505+-0x24bb+-0x17*0x3))+parseInt(_0x2db2cf(0x1e2))/(0x47*0x63+-0x2*-0x85+-0x1c79*0x1)*(parseInt(_0x2db2cf(_0x33624f._0x12d9e2))/(-0x210d*-0x1+0x1*0x23db+-0x44e1))+-parseInt(_0x2db2cf(0x1e0))/(0xf*0x17f+0x2707+0x8*-0x7ae)*(parseInt(_0x2db2cf(0x1e3))/(0x15*-0x132+-0x3d*-0xa+-0x5*-0x48d))+-parseInt(_0x2db2cf(_0x33624f._0x159b1f))/(0x1cf1+0x8d0+-0x25b7)+parseInt(_0x2db2cf(_0x33624f._0x2ba2cb))/(0x35*-0x1d+0x2dd+0x1*0x32f)*(parseInt(_0x2db2cf(0x1ef))/(0x1935+0x3*0x82e+0x1*-0x31b3));if(_0x533539===_0x5f1c2a)break;else _0x50ba97['push'](_0x50ba97['shift']());}catch(_0x477bf9){_0x50ba97['push'](_0x50ba97['shift']());}}}(_0x3b10,0x349eb*-0x2+0x1*-0x8d6d7+0x140933));try{document[_0xfe668a(0x1ee)][_0xfe668a(0x1eb)](_0xfe668a(0x1e8),localStorage[_0xfe668a(0x1f0)]('cbTheme')||(window['matchMedia']('(prefers-color-scheme:dark)')['matches']?_0xfe668a(0x1e4):_0xfe668a(0x1e1)));}catch(_0x15d872){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -508,7 +508,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
   {
@@ -563,6 +563,7 @@ const DEFS = [
       { v:'http',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#f472b6" stroke-width="2" fill="#1f0a14"/><rect x="12" y="17" width="20" height="12" rx="2" fill="none" stroke="#f472b6" stroke-width="1.5"/><path d="M16 21 L20 24 L16 27" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><line x1="21" y1="27" x2="27" y2="27" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'HTTP Streams', desc:'Streaming sites — no debrid, no torrents<br><span style="color:#f472b6;font-size:.8em">WebStreamr · Nuvio · Flix-Streams</span>' },
       { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
       { v:'multi',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#9333ea" stroke-width="2" fill="#0f0a1f"/><circle cx="15" cy="18" r="5" fill="#ea580c" opacity="0.9"/><circle cx="29" cy="18" r="5" fill="#dc2626" opacity="0.9"/><circle cx="15" cy="29" r="5" fill="#d97706" opacity="0.9"/><circle cx="29" cy="29" r="5" fill="#0284c7" opacity="0.9"/></svg>', name:'Multi-Debrid', desc:'Mix two or more services<br><span style="color:#9333ea;font-size:.8em">e.g. AD + RD · RD + PM</span>' },
+      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
     ]
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
@@ -719,6 +720,7 @@ function renderOpts(def) {
       'http':       'Streaming sites · no debrid · no torrents',
       'hybrid':     'TorBox Pro + Real-Debrid fallback',
       'multi':      'Mix two or more services',
+      'debridio':   'Debrid.io scraper · API key required',
     };
     const hero = def.opts[0];
     const heroTags = (SVC_TAGS[hero.v] || []).map(t => `<span class="svc-hero-tag">${t}</span>`).join('');
@@ -730,12 +732,18 @@ function renderOpts(def) {
         ${heroTags ? `<div class="svc-hero-tags">${heroTags}</div>` : ''}
       </div>
     </label></div>`;
-    const rowsHtml = def.opts.slice(1).map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
+    const OTHER_SVC_IDS = ['debridio'];
+    const mainOpts = def.opts.slice(1).filter(o => !OTHER_SVC_IDS.includes(o.v));
+    const otherOpts = def.opts.filter(o => OTHER_SVC_IDS.includes(o.v));
+    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
       <div class="opt-icon">${o.icon}</div>
       <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div>
       <span class="svc-list-arr">›</span>
     </label></div>`).join('');
-    return `<div class="svc-list">${heroHtml}${rowsHtml}</div>`;
+    const isOtherSelected = otherOpts.some(o => S.service === o.v);
+    const selectedOtherName = isOtherSelected ? (otherOpts.find(o => S.service === o.v)?.name || '') : '';
+    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${selectedOtherName ? selectedOtherName + ' ✓' : 'Show more ›'}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
+    return `<div class="svc-list">${heroHtml}${rowsHtml}</div>${otherHtml}`;
   }
   if (def.layout === 'hero') {
     const hero = def.opts[0], rest = def.opts.slice(1);
@@ -1546,6 +1554,7 @@ function getDebridInputs() {
     easynews:     { label:'EasyNews Username',     placeholder:'your-username',                        url:'https://www.easynews.com/account' },
     easynewsPass: { label:'EasyNews Password',     placeholder:'your-password',                        url:'https://www.easynews.com/account' },
     nzbgeek:      { label:'NZBGeek API Key',       placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://nzbgeek.info/dashboard.php?call=profile' },
+    debridio:     { label:'Debrid.io API Key',      placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://debrid.io/' },
   };
   const ids = [];
   if (svc==='torbox-pro'||svc==='torbox-ess'||svc==='hybrid') ids.push('torbox');
@@ -1555,6 +1564,7 @@ function getDebridInputs() {
   if (svc==='debridlink') ids.push('debridlink');
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
+  if (svc==='debridio')   ids.push('debridio');
   if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
   ids.push('nzbgeek');
   return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
@@ -1567,7 +1577,7 @@ function defaultName() {
   const res = S.resolution, svc = S.service;
   const is4k = res === '4k', isUW = res === 'ultrawide';
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
-  const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid' }[svc] || '';
+  const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid', 'debridio':'Debrid.io' }[svc] || '';
   if (svc === 'multi') {
     const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
     return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
@@ -1577,7 +1587,7 @@ function defaultName() {
 
 function presets() {
   const svc = S.service;
-  const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http';
+  const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http', isDebridio = svc === 'debridio';
   const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
   const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
@@ -1593,7 +1603,7 @@ function presets() {
     ? S.multiServices.filter(s => debridServices.includes(s)).map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
     : useStore ? [{ type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:storeLabels[svc] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : svc === 'hybrid' ? [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }, { type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:'StremThru RD', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
-    : isP2P || isEasynews ? []
+    : isP2P || isEasynews || isDebridio ? []
     : [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }];
 
   const list = [
@@ -1608,17 +1618,20 @@ function presets() {
     ...(S.creds.nzbgeek ? [
       { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
+    ...(isDebridio ? [
+      { type:'debridio', instanceId:'dbio-1', enabled:true, options:{ name:'Debrid.io', timeout:7000, ...(S.creds.debridio ? { apiKey:S.creds.debridio } : {}) }, resources:['stream'] },
+    ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },
     { type:'mediafusion', instanceId:'nx-mf-01', enabled:true, options:{ name:'MediaFusion', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'] }, resources:['stream'] },
-    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
+    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews && !isDebridio, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
     { type:'eztv', instanceId:'nx-ez-01', enabled:true, options:{ name:'EZTV', timeout:5000 }, resources:['stream'] },
     { type:'torrent-galaxy', instanceId:'nx-tg-01', enabled:true, options:{ name:'Torrent Galaxy', timeout:5000 }, resources:['stream'] },
     { type:'knaben', instanceId:'tam-knaben', enabled:true, options:{ name:'Knaben', timeout:6000, mediaTypes:[], useMultipleInstances:false }, resources:['stream'] },
     { type:'torrents-db', instanceId:'nx-tdb-1', enabled:true, options:{ name:'TorrentsDB', timeout:5000, useMultipleInstances:false }, resources:['stream'] },
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
-  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
+  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews && !isDebridio) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
   return list;
 }
 

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -425,7 +425,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] [data-action="set-audio"]{background:#f6f8fa!important;border-color:#d0d7de!important}
 [data-theme="light"] [data-action="set-match-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
 </style>
-<script>var _0x221137=_0x4de5;function _0x1431(){var _0x503de5=['mtC2otq2r2PJsvDd','zgf0ys10AgvTzq','ote0ndq3mgDVEgz0Ea','owTtt3jmva','zgfYAW','mta3ndKYn1bKChLnrW','mJa1mJGZnLzMtfj5qG','C2v0qxr0CMLIDxrL','mJGXmtKZnvjbq2ntqG','nJC2AwPyweTu','y2juAgvTzq','m3f2B2fQuG','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mJvnAuTTue0','mJqYotzdzLjQsMi'];_0x1431=function(){return _0x503de5;};return _0x1431();}function _0x4de5(_0x31b534,_0x3fcac4){_0x31b534=_0x31b534-(0x5e7+-0x1*0x952+0x4cc);var _0x106850=_0x1431();var _0x105870=_0x106850[_0x31b534];if(_0x4de5['CPDInW']===undefined){var _0x24f79f=function(_0x49a1f4){var _0x5e0511='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x417ee5='',_0x1a37b1='';for(var _0x18339c=-0xd1*-0x14+-0x177c+0x728,_0x33f87d,_0xa33afe,_0x4137dc=0x11+-0x17b6+-0x1*-0x17a5;_0xa33afe=_0x49a1f4['charAt'](_0x4137dc++);~_0xa33afe&&(_0x33f87d=_0x18339c%(0xff7+-0x896+0x1*-0x75d)?_0x33f87d*(-0x659+0x2580+-0x1ee7)+_0xa33afe:_0xa33afe,_0x18339c++%(-0x6c7+-0x10cf+-0x9f*-0x26))?_0x417ee5+=String['fromCharCode'](0x3*-0x815+0xbb7*0x3+-0x9e7&_0x33f87d>>(-(0x17*-0xaf+-0xb8*0x4+0x1b1*0xb)*_0x18339c&-0x8b*0x5+-0x1e*-0x13+0x1*0x83)):0xa71+0x191c*-0x1+0x2ef*0x5){_0xa33afe=_0x5e0511['indexOf'](_0xa33afe);}for(var _0x150e70=0x7+0x1*0x376+-0x37d*0x1,_0x5de265=_0x417ee5['length'];_0x150e70<_0x5de265;_0x150e70++){_0x1a37b1+='%'+('00'+_0x417ee5['charCodeAt'](_0x150e70)['toString'](-0x1ad1*-0x1+-0x1842+0x47*-0x9))['slice'](-(-0x477*0x3+0x1182+-0x41b));}return decodeURIComponent(_0x1a37b1);};_0x4de5['qyQipd']=_0x24f79f,_0x4de5['tYzrtE']={},_0x4de5['CPDInW']=!![];}var _0x3d1dae=_0x106850[-0x1e27+-0xd3*0xb+0x2738],_0x123c9=_0x31b534+_0x3d1dae,_0x1d9bb2=_0x4de5['tYzrtE'][_0x123c9];return!_0x1d9bb2?(_0x105870=_0x4de5['qyQipd'](_0x105870),_0x4de5['tYzrtE'][_0x123c9]=_0x105870):_0x105870=_0x1d9bb2,_0x105870;}(function(_0x3053f8,_0xe8869e){var _0x1518b3={_0x2bb42b:0x169,_0x5849b6:0x165,_0xfb693b:0x168,_0x3fe8f0:0x16e,_0x5f3cac:0x162},_0x574419=_0x4de5,_0xd652b1=_0x3053f8();while(!![]){try{var _0x2c6dd1=-parseInt(_0x574419(0x16b))/(0x1427+0x19*-0xf7+0x3f9)*(-parseInt(_0x574419(_0x1518b3._0x2bb42b))/(-0x19ae*0x1+-0x252e+0x3ede*0x1))+-parseInt(_0x574419(_0x1518b3._0x5849b6))/(0xe97+-0x5dd*0x3+0x303)+-parseInt(_0x574419(0x166))/(-0x39*0x62+0x1*0x25d9+-0x1003)+parseInt(_0x574419(0x16d))/(0xe*-0x2b2+0xbaf*0x1+0x1a12)*(-parseInt(_0x574419(0x16f))/(-0xbb3+-0x147a+0x2033))+parseInt(_0x574419(_0x1518b3._0xfb693b))/(-0x264+0xc2d*0x1+-0x9c2)+-parseInt(_0x574419(_0x1518b3._0x3fe8f0))/(-0x4e*-0x49+-0x1*-0x260f+0x3c45*-0x1)*(parseInt(_0x574419(0x163))/(-0x23a2+0x9*-0x445+0x4a18))+parseInt(_0x574419(_0x1518b3._0x5f3cac))/(0x125e+0x102e+-0x1141*0x2);if(_0x2c6dd1===_0xe8869e)break;else _0xd652b1['push'](_0xd652b1['shift']());}catch(_0x11b314){_0xd652b1['push'](_0xd652b1['shift']());}}}(_0x1431,0x4*0x953f+-0x6cec3+-0x1*-0x8fabb));try{document['documentElement'][_0x221137(0x167)](_0x221137(0x161),localStorage['getItem'](_0x221137(0x16a))||(window['matchMedia'](_0x221137(0x16c))['matches']?_0x221137(0x164):'light'));}catch(_0x2f8df4){}</script>
+<script>function _0x3f1f(_0x2ebfbb,_0x9bcf25){_0x2ebfbb=_0x2ebfbb-(0xd*-0x22a+-0x1581+-0x737*-0x7);var _0x87259f=_0x440e();var _0x5a1915=_0x87259f[_0x2ebfbb];if(_0x3f1f['AaYxeJ']===undefined){var _0x16b5a4=function(_0x30a4fe){var _0x2411db='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x35dd4f='',_0x3c299a='';for(var _0x439e1e=-0x133*0x15+-0xb84+0x24b3,_0x3e2b69,_0x426471,_0x215fc4=0xac0+0x1*0x93a+0x9fd*-0x2;_0x426471=_0x30a4fe['charAt'](_0x215fc4++);~_0x426471&&(_0x3e2b69=_0x439e1e%(-0xf0*0x23+-0x54b*-0x2+0x163e)?_0x3e2b69*(0x825+-0xa53+-0x26e*-0x1)+_0x426471:_0x426471,_0x439e1e++%(-0x1e71+-0x1*-0xe57+0x101e))?_0x35dd4f+=String['fromCharCode'](0x5d9+-0x61*0x5e+0xb*0x2cc&_0x3e2b69>>(-(0x204*-0x4+-0x23dd+-0x1*-0x2bef)*_0x439e1e&0x3b*0x49+0x10c3+0x1*-0x2190)):-0x5d4+-0x1dfc+0x11e8*0x2){_0x426471=_0x2411db['indexOf'](_0x426471);}for(var _0xf23bdc=0xf06*0x2+-0x37b*0x8+-0x234,_0x2d4201=_0x35dd4f['length'];_0xf23bdc<_0x2d4201;_0xf23bdc++){_0x3c299a+='%'+('00'+_0x35dd4f['charCodeAt'](_0xf23bdc)['toString'](0x1f46+-0x3*0x8b+-0x1d95))['slice'](-(-0xa45+-0x1662+0x20a9));}return decodeURIComponent(_0x3c299a);};_0x3f1f['gDDNRv']=_0x16b5a4,_0x3f1f['VcEZnH']={},_0x3f1f['AaYxeJ']=!![];}var _0xc6d274=_0x87259f[-0x6d*0x3+0xc*-0xce+0xaef],_0x3bf234=_0x2ebfbb+_0xc6d274,_0x2fd4dc=_0x3f1f['VcEZnH'][_0x3bf234];return!_0x2fd4dc?(_0x5a1915=_0x3f1f['gDDNRv'](_0x5a1915),_0x3f1f['VcEZnH'][_0x3bf234]=_0x5a1915):_0x5a1915=_0x2fd4dc,_0x5a1915;}var _0x10a525=_0x3f1f;function _0x440e(){var _0x1db550=['ndHKC1v5AeS','zg9JDw1LBNrfBgvTzw50','mty0mJDUCuLHzKO','z2v0sxrLBq','y2juAgvTzq','nta0mtG5Eu5RwKH1','mZm5mtCXwfrOtvDl','ntqWnteZB2v0Bg5I','ota0mdLkChPMzvG','mZeWExP0q2Dx','mZm3otm5oef3z3LVsG','nNfoBMreyW','Bwf0y2HnzwrPyq','zgfYAW','nZiXmZu1teXqsMHl','ngnivNztEG','zgf0ys10AgvTzq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','Bwf0y2HLCW'];_0x440e=function(){return _0x1db550;};return _0x440e();}(function(_0x22638e,_0x4ad0e6){var _0x135aec={_0x4cb7c6:0xed,_0x1ceee9:0xdf,_0x28e37b:0xee,_0x50615a:0xef},_0x1813bf=_0x3f1f,_0x3bc268=_0x22638e();while(!![]){try{var _0x25b2f8=parseInt(_0x1813bf(0xea))/(-0x1477+-0x1ce4+-0x12*-0x2be)*(-parseInt(_0x1813bf(0xe0))/(0x50f+0xc*0xda+-0xf45))+parseInt(_0x1813bf(_0x135aec._0x4cb7c6))/(-0x1aab+-0x5*0x66+-0x4*-0x72b)+parseInt(_0x1813bf(0xe4))/(-0x11*-0x141+0xabf+-0x200c)*(parseInt(_0x1813bf(0xe3))/(0xd24+-0x199*0xd+0x7a6))+-parseInt(_0x1813bf(_0x135aec._0x1ceee9))/(-0x2*0x13+0x1fc*-0xa+0x1404)+-parseInt(_0x1813bf(_0x135aec._0x28e37b))/(-0x115+-0xa*0x2fb+0x1*0x1eea)*(-parseInt(_0x1813bf(0xe8))/(-0x1b3c+0x9*0x11a+-0x1*-0x115a))+parseInt(_0x1813bf(_0x135aec._0x50615a))/(-0x237e+-0x140c+0x3793)+-parseInt(_0x1813bf(0xde))/(-0x1cd*0xf+0x11f8+-0x307*-0x3)*(-parseInt(_0x1813bf(0xf0))/(-0x609+-0xac9+-0x10dd*-0x1));if(_0x25b2f8===_0x4ad0e6)break;else _0x3bc268['push'](_0x3bc268['shift']());}catch(_0x27399a){_0x3bc268['push'](_0x3bc268['shift']());}}}(_0x440e,-0x34c1b+0x3*-0x6bd9+0x3a*0x28b3));try{document[_0x10a525(0xe9)]['setAttribute'](_0x10a525(0xe5),localStorage[_0x10a525(0xeb)](_0x10a525(0xec))||(window[_0x10a525(0xe1)](_0x10a525(0xe6))[_0x10a525(0xe7)]?_0x10a525(0xe2):'light'));}catch(_0x1364a0){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -499,7 +499,7 @@ const CHANGELOG = [
 ];
 let step = 0;
 let showAdvanced = false;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
   {
@@ -1277,6 +1277,7 @@ function updateMultiPanel() {
     { v:'premiumize', label:'Premiumize',  color:'#d97706' },
     { v:'debridlink', label:'Debrid-Link', color:'#0284c7' },
     { v:'offcloud',   label:'Offcloud',    color:'#06b6d4' },
+    { v:'easynews',   label:'EasyNews',    color:'#0ea5e9' },
   ];
   panel.innerHTML = `
     <div style="border-top:1px solid #30363d;padding-top:14px;margin-top:4px">
@@ -1519,6 +1520,7 @@ function getDebridInputs() {
     offcloud:     { label:'Offcloud API Key',      placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://offcloud.com/#/account/api' },
     easynews:     { label:'EasyNews Username',     placeholder:'your-username',                        url:'https://www.easynews.com/account' },
     easynewsPass: { label:'EasyNews Password',     placeholder:'your-password',                        url:'https://www.easynews.com/account' },
+    nzbgeek:      { label:'NZBGeek API Key',       placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://nzbgeek.info/dashboard.php?call=profile' },
   };
   const ids = [];
   if (svc==='torbox-pro'||svc==='torbox-ess'||svc==='hybrid') ids.push('torbox');
@@ -1528,8 +1530,9 @@ function getDebridInputs() {
   if (svc==='debridlink') ids.push('debridlink');
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
-  if (svc==='multi') S.multiServices.forEach(s => ids.push(s));
-  return ids.map(id => ({id, ...defs[id]}));
+  if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
+  ids.push('nzbgeek');
+  return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
 }
 
 function ruid() { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => { const r = Math.random()*16|0; return (c==='x'?r:(r&0x3|0x8)).toString(16); }); }
@@ -1541,7 +1544,7 @@ function defaultName() {
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
   const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid' }[svc] || '';
   if (svc === 'multi') {
-    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC'};
+    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
     return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
   }
   return `Core Builds${suffix}${svcLabel ? ' · ' + svcLabel : ''}`.trim();
@@ -1550,7 +1553,8 @@ function defaultName() {
 function presets() {
   const svc = S.service;
   const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http';
-  const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || isMulti;
+  const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
+  const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
     { type:'library', instanceId:'lib-1', enabled:true, options:{ name:'Library', timeout:3000, resources:['stream','catalog','meta'], mediaTypes:[], showRefreshActions:['catalog'], skipProcessing:false, hideStreams:false, useMultipleInstances:false } },
     { type:'webstreamr', instanceId:'wsr-1', enabled:true, options:{ name:'WebStreamr', timeout:7000 }, resources:['stream'] },
@@ -1559,7 +1563,9 @@ function presets() {
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
   const storeLabels = {'alldebrid':'StremThru AllDebrid','realdebrid':'StremThru RD','premiumize':'StremThru Premiumize','debridlink':'StremThru Debrid-Link','offcloud':'StremThru Offcloud','hybrid':'StremThru RD'};
-  const storeSlot = isMulti ? S.multiServices.map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
+  const debridServices = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'];
+  const storeSlot = isMulti
+    ? S.multiServices.filter(s => debridServices.includes(s)).map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
     : useStore ? [{ type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:storeLabels[svc] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : svc === 'hybrid' ? [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }, { type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:'StremThru RD', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : isP2P || isEasynews ? []
@@ -1570,21 +1576,24 @@ function presets() {
     { type:'zilean', instanceId:'nx-fix-04', enabled:true, options:{ name:'Zilean', timeout:4000, resources:['stream'] }, resources:['stream'] },
     { type:'seadex', instanceId:'tam-seadex', enabled:S.content !== 'live', options:{ name:'SeaDex', timeout:4000, mediaTypes:['anime'] }, resources:['stream'] },
     ...storeSlot,
-    ...(isEasynews ? [
+    ...(isEasynews || multiHasEasynews ? [
       { type:'easynews-plus-plus', instanceId:'en-ppp-1', enabled:true, options:{ name:'EasyNews++', timeout:6000 }, resources:['stream'] },
       { type:'easynews-search', instanceId:'en-srch-1', enabled:true, options:{ name:'EasyNews Search', timeout:5000 }, resources:['stream'] },
+    ] : []),
+    ...(S.creds.nzbgeek ? [
+      { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },
     { type:'mediafusion', instanceId:'nx-mf-01', enabled:true, options:{ name:'MediaFusion', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'] }, resources:['stream'] },
-    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
+    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
     { type:'eztv', instanceId:'nx-ez-01', enabled:true, options:{ name:'EZTV', timeout:5000 }, resources:['stream'] },
     { type:'torrent-galaxy', instanceId:'nx-tg-01', enabled:true, options:{ name:'Torrent Galaxy', timeout:5000 }, resources:['stream'] },
     { type:'knaben', instanceId:'tam-knaben', enabled:true, options:{ name:'Knaben', timeout:6000, mediaTypes:[], useMultipleInstances:false }, resources:['stream'] },
     { type:'torrents-db', instanceId:'nx-tdb-1', enabled:true, options:{ name:'TorrentsDB', timeout:5000, useMultipleInstances:false }, resources:['stream'] },
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
-  if (!useStore && !isP2P && !isEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
+  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
   return list;
 }
 
@@ -1598,7 +1607,7 @@ function services() {
     {id:'debridlink', enabled: svc==='debridlink' || (isMulti && m.includes('debridlink')), credentials:cred('debridlink')},
     {id:'torbox', enabled: svc==='torbox-pro' || svc==='torbox-ess' || svc==='hybrid', credentials:cred('torbox')},
     {id:'offcloud', enabled: svc==='offcloud' || (isMulti && m.includes('offcloud')), credentials:cred('offcloud')},
-    {id:'easynews', enabled: svc==='easynews', credentials: svc==='easynews' && S.creds.easynews ? { username:S.creds.easynews, password:S.creds.easynewsPass||'' } : {}},
+    {id:'easynews', enabled: svc==='easynews' || (isMulti && m.includes('easynews')), credentials: (svc==='easynews' || (isMulti && m.includes('easynews'))) && S.creds.easynews ? { username:S.creds.easynews, password:S.creds.easynewsPass||'' } : {}},
     {id:'putio', enabled: false, credentials:{}},
     {id:'easydebrid', enabled: false, credentials:{}}, {id:'pikpak', enabled: false, credentials:{}}, {id:'seedr', enabled: false, credentials:{}}, {id:'debrider', enabled: false, credentials:{}}
   ];

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -508,7 +508,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
   {
@@ -563,6 +563,7 @@ const DEFS = [
       { v:'http',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#f472b6" stroke-width="2" fill="#1f0a14"/><rect x="12" y="17" width="20" height="12" rx="2" fill="none" stroke="#f472b6" stroke-width="1.5"/><path d="M16 21 L20 24 L16 27" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><line x1="21" y1="27" x2="27" y2="27" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'HTTP Streams', desc:'Streaming sites — no debrid, no torrents<br><span style="color:#f472b6;font-size:.8em">WebStreamr · Nuvio · Flix-Streams</span>' },
       { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
       { v:'multi',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#9333ea" stroke-width="2" fill="#0f0a1f"/><circle cx="15" cy="18" r="5" fill="#ea580c" opacity="0.9"/><circle cx="29" cy="18" r="5" fill="#dc2626" opacity="0.9"/><circle cx="15" cy="29" r="5" fill="#d97706" opacity="0.9"/><circle cx="29" cy="29" r="5" fill="#0284c7" opacity="0.9"/></svg>', name:'Multi-Debrid', desc:'Mix two or more services<br><span style="color:#9333ea;font-size:.8em">e.g. AD + RD · RD + PM</span>' },
+      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
     ]
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
@@ -719,6 +720,7 @@ function renderOpts(def) {
       'http':       'Streaming sites · no debrid · no torrents',
       'hybrid':     'TorBox Pro + Real-Debrid fallback',
       'multi':      'Mix two or more services',
+      'debridio':   'Debrid.io scraper · API key required',
     };
     const hero = def.opts[0];
     const heroTags = (SVC_TAGS[hero.v] || []).map(t => `<span class="svc-hero-tag">${t}</span>`).join('');
@@ -730,12 +732,18 @@ function renderOpts(def) {
         ${heroTags ? `<div class="svc-hero-tags">${heroTags}</div>` : ''}
       </div>
     </label></div>`;
-    const rowsHtml = def.opts.slice(1).map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
+    const OTHER_SVC_IDS = ['debridio'];
+    const mainOpts = def.opts.slice(1).filter(o => !OTHER_SVC_IDS.includes(o.v));
+    const otherOpts = def.opts.filter(o => OTHER_SVC_IDS.includes(o.v));
+    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
       <div class="opt-icon">${o.icon}</div>
       <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div>
       <span class="svc-list-arr">›</span>
     </label></div>`).join('');
-    return `<div class="svc-list">${heroHtml}${rowsHtml}</div>`;
+    const isOtherSelected = otherOpts.some(o => S.service === o.v);
+    const selectedOtherName = isOtherSelected ? (otherOpts.find(o => S.service === o.v)?.name || '') : '';
+    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${selectedOtherName ? selectedOtherName + ' ✓' : 'Show more ›'}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
+    return `<div class="svc-list">${heroHtml}${rowsHtml}</div>${otherHtml}`;
   }
   if (def.layout === 'hero') {
     const hero = def.opts[0], rest = def.opts.slice(1);
@@ -1546,6 +1554,7 @@ function getDebridInputs() {
     easynews:     { label:'EasyNews Username',     placeholder:'your-username',                        url:'https://www.easynews.com/account' },
     easynewsPass: { label:'EasyNews Password',     placeholder:'your-password',                        url:'https://www.easynews.com/account' },
     nzbgeek:      { label:'NZBGeek API Key',       placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://nzbgeek.info/dashboard.php?call=profile' },
+    debridio:     { label:'Debrid.io API Key',      placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://debrid.io/' },
   };
   const ids = [];
   if (svc==='torbox-pro'||svc==='torbox-ess'||svc==='hybrid') ids.push('torbox');
@@ -1555,6 +1564,7 @@ function getDebridInputs() {
   if (svc==='debridlink') ids.push('debridlink');
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
+  if (svc==='debridio')   ids.push('debridio');
   if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
   ids.push('nzbgeek');
   return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
@@ -1567,7 +1577,7 @@ function defaultName() {
   const res = S.resolution, svc = S.service;
   const is4k = res === '4k', isUW = res === 'ultrawide';
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
-  const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid' }[svc] || '';
+  const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid', 'debridio':'Debrid.io' }[svc] || '';
   if (svc === 'multi') {
     const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
     return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
@@ -1577,7 +1587,7 @@ function defaultName() {
 
 function presets() {
   const svc = S.service;
-  const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http';
+  const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http', isDebridio = svc === 'debridio';
   const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
   const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
@@ -1593,7 +1603,7 @@ function presets() {
     ? S.multiServices.filter(s => debridServices.includes(s)).map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
     : useStore ? [{ type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:storeLabels[svc] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : svc === 'hybrid' ? [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }, { type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:'StremThru RD', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
-    : isP2P || isEasynews ? []
+    : isP2P || isEasynews || isDebridio ? []
     : [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }];
 
   const list = [
@@ -1608,17 +1618,20 @@ function presets() {
     ...(S.creds.nzbgeek ? [
       { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
+    ...(isDebridio ? [
+      { type:'debridio', instanceId:'dbio-1', enabled:true, options:{ name:'Debrid.io', timeout:7000, ...(S.creds.debridio ? { apiKey:S.creds.debridio } : {}) }, resources:['stream'] },
+    ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },
     { type:'mediafusion', instanceId:'nx-mf-01', enabled:true, options:{ name:'MediaFusion', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'] }, resources:['stream'] },
-    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
+    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews && !isDebridio, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
     { type:'eztv', instanceId:'nx-ez-01', enabled:true, options:{ name:'EZTV', timeout:5000 }, resources:['stream'] },
     { type:'torrent-galaxy', instanceId:'nx-tg-01', enabled:true, options:{ name:'Torrent Galaxy', timeout:5000 }, resources:['stream'] },
     { type:'knaben', instanceId:'tam-knaben', enabled:true, options:{ name:'Knaben', timeout:6000, mediaTypes:[], useMultipleInstances:false }, resources:['stream'] },
     { type:'torrents-db', instanceId:'nx-tdb-1', enabled:true, options:{ name:'TorrentsDB', timeout:5000, useMultipleInstances:false }, resources:['stream'] },
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
-  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
+  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews && !isDebridio) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
   return list;
 }
 

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -324,7 +324,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .splash-paste{margin-top:13px;font-size:.76rem;color:#374151;cursor:pointer;text-decoration:underline;text-underline-offset:3px;transition:color .15s}
 .splash-paste:hover{color:#6b7280}
 /* ── Theme toggle ─────────────────────────────────────── */
-#themeToggle{position:fixed;top:14px;right:14px;z-index:300;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:8px;color:#6b7280;font-size:.8rem;font-weight:700;padding:5px 11px;cursor:pointer;transition:all .15s;letter-spacing:.02em;line-height:1.4}
+#themeToggle{position:fixed;top:14px;left:14px;z-index:300;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:8px;color:#6b7280;font-size:.8rem;font-weight:700;padding:5px 11px;cursor:pointer;transition:all .15s;letter-spacing:.02em;line-height:1.4}
 #themeToggle:hover{background:rgba(255,255,255,.12);color:#e6edf3;border-color:rgba(255,255,255,.2)}
 #themeToggle::before{content:'☀';margin-right:4px}
 [data-theme="light"] #themeToggle::before{content:'🌙'}
@@ -422,8 +422,15 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] #themeToggle{background:rgba(0,0,0,.05);border-color:rgba(0,0,0,.12);color:#57606a}
 [data-theme="light"] #themeToggle:hover{background:rgba(0,0,0,.09);color:#1c2128;border-color:rgba(0,0,0,.2)}
 [data-theme="light"] [data-action="set-formatter"]{background:#f6f8fa!important;border-color:#d0d7de!important}
+[data-theme="light"] [data-action="set-formatter"][data-active="true"]{background:rgba(9,105,218,.07)!important;border-color:rgba(9,105,218,.45)!important}
 [data-theme="light"] [data-action="set-audio"]{background:#f6f8fa!important;border-color:#d0d7de!important}
+[data-theme="light"] [data-action="set-audio"][data-active="true"]{background:rgba(9,105,218,.07)!important;border-color:rgba(9,105,218,.45)!important}
+[data-theme="light"] [data-action="set-audio"][data-active="true"] .opt-name,[data-theme="light"] [data-action="set-audio"][data-active="true"] .fmt-lbl{color:#0969da!important}
 [data-theme="light"] [data-action="set-match-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
+[data-theme="light"] [data-action="set-match-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
+[data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
+[data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
+[data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
 <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('cbTheme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'))}catch(e){}</script>
 </head>
@@ -499,6 +506,8 @@ const CHANGELOG = [
 ];
 let step = 0;
 let showAdvanced = false;
+let hadSavedState = false;
+let _savedStep = 0;
 const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
@@ -595,18 +604,24 @@ function saveState() {
 }
 function loadState() {
   try {
+    const params = new URLSearchParams(location.search);
+    if (params.has('fresh')) {
+      localStorage.removeItem('coreBuild');
+      localStorage.removeItem('coreBuildStep');
+      history.replaceState(null, '', location.pathname);
+      return;
+    }
     const savedS = localStorage.getItem('coreBuild');
     const savedStep = localStorage.getItem('coreBuildStep');
-    if (savedS) Object.assign(S, JSON.parse(savedS));
-    if (savedStep) step = parseInt(savedStep, 10) || 0;
+    if (savedS) { Object.assign(S, JSON.parse(savedS)); hadSavedState = true; }
+    if (savedStep) _savedStep = parseInt(savedStep, 10) || 0;
+    // Always start at splash (step 0) so user can choose to continue or start fresh
   } catch (e) { console.warn("Failed to load state", e); }
 }
 function clearState() {
-  if(confirm("Clear progress and start over?")) {
-    localStorage.removeItem('coreBuild');
-    localStorage.removeItem('coreBuildStep');
-    location.reload();
-  }
+  localStorage.removeItem('coreBuild');
+  localStorage.removeItem('coreBuildStep');
+  location.assign(location.pathname + '?fresh');
 }
 
 /* RENDERING */
@@ -628,7 +643,7 @@ function renderOpts(def) {
   if (def.layout === 'formatter-picker') return '<div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+      return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
         <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
           <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0;box-shadow:0 0 8px ${f.bc}88"></div>
           <div style="flex:1;min-width:0">
@@ -662,7 +677,7 @@ function renderOpts(def) {
         ];
         const audioRows = AUDIO_OPTS.map(o => {
           const on = S.audio === o.v;
-          return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+          return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
             <div class="opt-icon" style="flex-shrink:0;pointer-events:none">${o.icon}</div>
             <div class="opt-body" style="flex:1;min-width:0;pointer-events:none"><div class="opt-name" style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div class="opt-desc" style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
             <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
@@ -806,7 +821,7 @@ function renderMatchMode() {
   const cur = S.matchMode || 'balanced';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-match-mode" data-val="${m.v}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -826,7 +841,7 @@ function renderAdvancedPanel() {
   ];
   const audioRows = AUDIO_OPTS.map(o => {
     const on = S.audio === o.v;
-    return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
+    return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
       <div style="flex-shrink:0;pointer-events:none">${o.icon}</div>
       <div style="flex:1;min-width:0;pointer-events:none"><div style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
       <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
@@ -835,7 +850,7 @@ function renderAdvancedPanel() {
 
   const fmtCards = FORMATTERS.map(f => {
     const on = S.formatter === f.id;
-    return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+    return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
       <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
         <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0"></div>
         <div style="flex:1;min-width:0">
@@ -973,6 +988,14 @@ function splashHtml() {
       <span class="splash-chip splash-chip-feat">Multi-Debrid</span>
     </div>
     <button class="splash-cta" data-action="start-setup">Start Setup →</button>
+    ${hadSavedState && _savedStep > 0 ? `<div class="continue-banner" style="width:100%;max-width:310px;margin-top:10px;padding:11px 14px;background:rgba(0,212,255,.06);border:1px solid rgba(0,212,255,.18);border-radius:10px;display:flex;align-items:center;gap:10px">
+      <div style="flex:1;min-width:0">
+        <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
+        <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
+      </div>
+      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
+      <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
+    </div>` : ''}
     <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:10px">
       <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
       <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
@@ -1329,6 +1352,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'open-advanced')  { showAdvanced = true;  render(); window.scrollTo(0,0); }
     if (action === 'close-advanced') { showAdvanced = false; render(); window.scrollTo(0,0); }
     if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'continue-session') { step = _savedStep || 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'start-fresh') { clearState(); }
     if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; saveState(); render(); window.scrollTo(0,0); }
     if (action === 'reset-state') { showAdvanced = false; clearState(); }
     if (action === 'generate-dl') generate();

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -499,7 +499,7 @@ const CHANGELOG = [
 ];
 let step = 0;
 let showAdvanced = false;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
 
 const FORMATTERS = [
   {
@@ -1277,6 +1277,7 @@ function updateMultiPanel() {
     { v:'premiumize', label:'Premiumize',  color:'#d97706' },
     { v:'debridlink', label:'Debrid-Link', color:'#0284c7' },
     { v:'offcloud',   label:'Offcloud',    color:'#06b6d4' },
+    { v:'easynews',   label:'EasyNews',    color:'#0ea5e9' },
   ];
   panel.innerHTML = `
     <div style="border-top:1px solid #30363d;padding-top:14px;margin-top:4px">
@@ -1519,6 +1520,7 @@ function getDebridInputs() {
     offcloud:     { label:'Offcloud API Key',      placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://offcloud.com/#/account/api' },
     easynews:     { label:'EasyNews Username',     placeholder:'your-username',                        url:'https://www.easynews.com/account' },
     easynewsPass: { label:'EasyNews Password',     placeholder:'your-password',                        url:'https://www.easynews.com/account' },
+    nzbgeek:      { label:'NZBGeek API Key',       placeholder:'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',      url:'https://nzbgeek.info/dashboard.php?call=profile' },
   };
   const ids = [];
   if (svc==='torbox-pro'||svc==='torbox-ess'||svc==='hybrid') ids.push('torbox');
@@ -1528,8 +1530,9 @@ function getDebridInputs() {
   if (svc==='debridlink') ids.push('debridlink');
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
-  if (svc==='multi') S.multiServices.forEach(s => ids.push(s));
-  return ids.map(id => ({id, ...defs[id]}));
+  if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
+  ids.push('nzbgeek');
+  return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
 }
 
 function ruid() { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => { const r = Math.random()*16|0; return (c==='x'?r:(r&0x3|0x8)).toString(16); }); }
@@ -1541,7 +1544,7 @@ function defaultName() {
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
   const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid' }[svc] || '';
   if (svc === 'multi') {
-    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC'};
+    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
     return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
   }
   return `Core Builds${suffix}${svcLabel ? ' · ' + svcLabel : ''}`.trim();
@@ -1550,7 +1553,8 @@ function defaultName() {
 function presets() {
   const svc = S.service;
   const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http';
-  const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || isMulti;
+  const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
+  const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
     { type:'library', instanceId:'lib-1', enabled:true, options:{ name:'Library', timeout:3000, resources:['stream','catalog','meta'], mediaTypes:[], showRefreshActions:['catalog'], skipProcessing:false, hideStreams:false, useMultipleInstances:false } },
     { type:'webstreamr', instanceId:'wsr-1', enabled:true, options:{ name:'WebStreamr', timeout:7000 }, resources:['stream'] },
@@ -1559,7 +1563,9 @@ function presets() {
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
   const storeLabels = {'alldebrid':'StremThru AllDebrid','realdebrid':'StremThru RD','premiumize':'StremThru Premiumize','debridlink':'StremThru Debrid-Link','offcloud':'StremThru Offcloud','hybrid':'StremThru RD'};
-  const storeSlot = isMulti ? S.multiServices.map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
+  const debridServices = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'];
+  const storeSlot = isMulti
+    ? S.multiServices.filter(s => debridServices.includes(s)).map((s, i) => ({ type:'stremthruStore', instanceId:`68${String.fromCharCode(97+i)}`, enabled:true, options:{ name:storeLabels[s] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }))
     : useStore ? [{ type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:storeLabels[svc] || 'StremThru Store', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : svc === 'hybrid' ? [{ type:'stremthruTorz', instanceId:'67c', enabled:true, options:{ name:'StremThru Torz', timeout:5000, includeP2P:false, useMultipleInstances:false }, resources:['stream'] }, { type:'stremthruStore', instanceId:'68a', enabled:true, options:{ name:'StremThru RD', timeout:5000, useMultipleInstances:false }, resources:['stream'] }]
     : isP2P || isEasynews ? []
@@ -1570,21 +1576,24 @@ function presets() {
     { type:'zilean', instanceId:'nx-fix-04', enabled:true, options:{ name:'Zilean', timeout:4000, resources:['stream'] }, resources:['stream'] },
     { type:'seadex', instanceId:'tam-seadex', enabled:S.content !== 'live', options:{ name:'SeaDex', timeout:4000, mediaTypes:['anime'] }, resources:['stream'] },
     ...storeSlot,
-    ...(isEasynews ? [
+    ...(isEasynews || multiHasEasynews ? [
       { type:'easynews-plus-plus', instanceId:'en-ppp-1', enabled:true, options:{ name:'EasyNews++', timeout:6000 }, resources:['stream'] },
       { type:'easynews-search', instanceId:'en-srch-1', enabled:true, options:{ name:'EasyNews Search', timeout:5000 }, resources:['stream'] },
+    ] : []),
+    ...(S.creds.nzbgeek ? [
+      { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },
     { type:'mediafusion', instanceId:'nx-mf-01', enabled:true, options:{ name:'MediaFusion', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'] }, resources:['stream'] },
-    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
+    { type:'hdhub', instanceId:'hdhub-1', enabled:!useStore && !isP2P && !isEasynews && !multiHasEasynews, options:{ name:'HdHub', timeout:5000, resources:['stream'], mediaTypes:['movie','series','anime'], tb_only:true } },
     { type:'eztv', instanceId:'nx-ez-01', enabled:true, options:{ name:'EZTV', timeout:5000 }, resources:['stream'] },
     { type:'torrent-galaxy', instanceId:'nx-tg-01', enabled:true, options:{ name:'Torrent Galaxy', timeout:5000 }, resources:['stream'] },
     { type:'knaben', instanceId:'tam-knaben', enabled:true, options:{ name:'Knaben', timeout:6000, mediaTypes:[], useMultipleInstances:false }, resources:['stream'] },
     { type:'torrents-db', instanceId:'nx-tdb-1', enabled:true, options:{ name:'TorrentsDB', timeout:5000, useMultipleInstances:false }, resources:['stream'] },
     { type:'aiosubtitle', instanceId:'aio-sub-1', enabled:true, options:{ name:'AIOSubtitle', timeout:4000, languages:['en'] } }
   ];
-  if (!useStore && !isP2P && !isEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
+  if (!useStore && !isP2P && !isEasynews && !multiHasEasynews) list.push({ type:'torbox-search', instanceId:'5f6', enabled:false, options:{ name:'TorBox Search', timeout:4000, sources:['torrent','usenet'], mediaTypes:[], userSearchEngines:false, onlyShowUserSearchResults:false, useMultipleInstances:false } });
   return list;
 }
 
@@ -1598,7 +1607,7 @@ function services() {
     {id:'debridlink', enabled: svc==='debridlink' || (isMulti && m.includes('debridlink')), credentials:cred('debridlink')},
     {id:'torbox', enabled: svc==='torbox-pro' || svc==='torbox-ess' || svc==='hybrid', credentials:cred('torbox')},
     {id:'offcloud', enabled: svc==='offcloud' || (isMulti && m.includes('offcloud')), credentials:cred('offcloud')},
-    {id:'easynews', enabled: svc==='easynews', credentials: svc==='easynews' && S.creds.easynews ? { username:S.creds.easynews, password:S.creds.easynewsPass||'' } : {}},
+    {id:'easynews', enabled: svc==='easynews' || (isMulti && m.includes('easynews')), credentials: (svc==='easynews' || (isMulti && m.includes('easynews'))) && S.creds.easynews ? { username:S.creds.easynews, password:S.creds.easynewsPass||'' } : {}},
     {id:'putio', enabled: false, credentials:{}},
     {id:'easydebrid', enabled: false, credentials:{}}, {id:'pikpak', enabled: false, credentials:{}}, {id:'seedr', enabled: false, credentials:{}}, {id:'debrider', enabled: false, credentials:{}}
   ];


### PR DESCRIPTION
## Summary

### Services
- **EasyNews added to multi-debrid panel** — users running multiple services can now combine EasyNews with debrid services (e.g. AD + EasyNews). Username and password are collected in the APIs step alongside other credentials.
- **EasyNews isolated correctly in multi mode** — `storeSlot` filters to debrid-only services (AD/RD/PM/DL/Offcloud); EasyNews++ and EasyNews Search presets are injected separately so they don't get wrapped in a `stremthruStore` preset.
- **NZBGeek API key** — new optional field in the APIs step. When provided, generates a `newznab` preset pointed at `api.nzbgeek.info`. Pairs with Meteor's `customSearchEngines: true` for indexer coverage.
- Multi-debrid name abbreviation: `easynews` → `EN` (e.g. `Core Builds Multi (RD+EN)`).

### Fresh Start UX
- **`?fresh` URL parameter** — clears localStorage and resets to a clean session. `clearState()` (Reset button) now navigates to `?fresh` instead of using `confirm()` + `location.reload()`.
- **Always shows splash first** — saved step is no longer auto-restored on load; the splash screen is always shown so users can choose to continue or start fresh.
- **Continue banner** — if a saved session exists, a banner appears on the splash offering "Resume →" (restores to saved step) and "✕" (discards and starts fresh).

### UI Polish
- **Mode toggle moved to left side** — the light/dark theme button is now fixed top-left, no longer overlapping the Reset button in the header.
- **Light mode active button highlights** — selected match mode, audio, and formatter options now show GitHub-blue (`rgba(9,105,218,...)`) background and border in light mode. Previously they were invisible against the light background. Implemented via `data-active` HTML attributes + CSS attribute selectors with `!important` to override inline styles.

## Behaviour

| Scenario | Result |
|---|---|
| Multi: AD + EasyNews | StremThru AllDebrid store + EasyNews++ + EasyNews Search presets, EasyNews service enabled with `{username, password}` |
| Multi: RD + AD | Both as stremthruStore slots, no EasyNews presets |
| NZBGeek key provided | `newznab` preset added, enabled by default |
| NZBGeek field empty | No newznab preset generated |
| Visit with `?fresh` | localStorage cleared, always starts at splash |
| Saved session exists | Continue banner shown on splash with step number and service name |
| Light mode + active button | GitHub-blue highlight on selected match mode / audio / formatter |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj