### PR TITLE
configurator: replace Multi-Debrid with multi-select service grid

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -432,7 +432,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>function _0x20fb(_0x291ccb,_0x4eae6e){_0x291ccb=_0x291ccb-(-0x49*0x65+0x1113*0x1+0x1*0xd99);var _0x5ca632=_0x3b10();var _0x1e8861=_0x5ca632[_0x291ccb];if(_0x20fb['LiaQlW']===undefined){var _0x133b8d=function(_0x521015){var _0x18390b='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x38e020='',_0xb9f7c4='';for(var _0x5e6470=0xb6b+0x2546+-0x30b1,_0x534265,_0x30709c,_0x533b52=-0x8*-0x421+-0x54e+0x2a*-0xa9;_0x30709c=_0x521015['charAt'](_0x533b52++);~_0x30709c&&(_0x534265=_0x5e6470%(0x1*-0x1479+0x1c1d*0x1+-0x7a0)?_0x534265*(0x1*-0xe6a+0x923*0x1+-0x587*-0x1)+_0x30709c:_0x30709c,_0x5e6470++%(0x1529+0x1c5a+-0x317f))?_0x38e020+=String['fromCharCode'](0x1c1*0x4+0x1*-0x72d+0x128&_0x534265>>(-(0xff4+0x56*0x14+-0x16aa*0x1)*_0x5e6470&0x2b*-0xe+-0x32*-0x4+-0x2*-0xcc)):-0x10e3+0x2*-0x5db+0x1c99){_0x30709c=_0x18390b['indexOf'](_0x30709c);}for(var _0x36e963=0xb92*0x2+-0x17c1+0x9d,_0x3e3f35=_0x38e020['length'];_0x36e963<_0x3e3f35;_0x36e963++){_0xb9f7c4+='%'+('00'+_0x38e020['charCodeAt'](_0x36e963)['toString'](0x2222*-0x1+0x18ba+-0x4*-0x25e))['slice'](-(-0x1d47+0x1*-0x10b1+0x2dfa));}return decodeURIComponent(_0xb9f7c4);};_0x20fb['EkWJYu']=_0x133b8d,_0x20fb['BaEczr']={},_0x20fb['LiaQlW']=!![];}var _0xe1f15a=_0x5ca632[-0x2381+-0xf07*-0x1+0x147a],_0x2b0980=_0x291ccb+_0xe1f15a,_0xeba3ba=_0x20fb['BaEczr'][_0x2b0980];return!_0xeba3ba?(_0x1e8861=_0x20fb['EkWJYu'](_0x1e8861),_0x20fb['BaEczr'][_0x2b0980]=_0x1e8861):_0x1e8861=_0xeba3ba,_0x1e8861;}function _0x3b10(){var _0x1aaf67=['mtaYnty4BMXKuvHA','BgLNAhq','nZjdEg9ZBLi','mte3DLv1z291','zgfYAW','ntqWmdmWmfrbyMnlAW','mtGZnfnIyxHfDG','mtjfA0zqvgi','zgf0ys10AgvTzq','mtuZntC2m0josev2sW','mti1nJa4shHqA05w','C2v0qxr0CMLIDxrL','mZeWqurswgzp','mtm3mdm1EufytKXN','zg9JDw1LBNrfBgvTzw50','mtjXA2H4Avm','z2v0sxrLBq','nZeZntm4mu1HDNDrwq'];_0x3b10=function(){return _0x1aaf67;};return _0x3b10();}var _0xfe668a=_0x20fb;(function(_0x54228c,_0x5f1c2a){var _0x33624f={_0x57e8ac:0x1e6,_0x5c591e:0x1e9,_0x29acc6:0x1e7,_0x12d9e2:0x1ea,_0x159b1f:0x1e5,_0x2ba2cb:0x1df},_0x2db2cf=_0x20fb,_0x50ba97=_0x54228c();while(!![]){try{var _0x533539=parseInt(_0x2db2cf(0x1ec))/(-0x133a+0x2f*0x29+0x1ac*0x7)*(-parseInt(_0x2db2cf(_0x33624f._0x57e8ac))/(-0x5*-0x12f+0xbee+-0x11d7))+parseInt(_0x2db2cf(_0x33624f._0x5c591e))/(-0x19ba+0x11d*0x9+-0x1*-0xfb8)+parseInt(_0x2db2cf(_0x33624f._0x29acc6))/(0x1883+0x34*0xa4+-0x39cf)*(-parseInt(_0x2db2cf(0x1ed))/(0x2505+-0x24bb+-0x17*0x3))+parseInt(_0x2db2cf(0x1e2))/(0x47*0x63+-0x2*-0x85+-0x1c79*0x1)*(parseInt(_0x2db2cf(_0x33624f._0x12d9e2))/(-0x210d*-0x1+0x1*0x23db+-0x44e1))+-parseInt(_0x2db2cf(0x1e0))/(0xf*0x17f+0x2707+0x8*-0x7ae)*(parseInt(_0x2db2cf(0x1e3))/(0x15*-0x132+-0x3d*-0xa+-0x5*-0x48d))+-parseInt(_0x2db2cf(_0x33624f._0x159b1f))/(0x1cf1+0x8d0+-0x25b7)+parseInt(_0x2db2cf(_0x33624f._0x2ba2cb))/(0x35*-0x1d+0x2dd+0x1*0x32f)*(parseInt(_0x2db2cf(0x1ef))/(0x1935+0x3*0x82e+0x1*-0x31b3));if(_0x533539===_0x5f1c2a)break;else _0x50ba97['push'](_0x50ba97['shift']());}catch(_0x477bf9){_0x50ba97['push'](_0x50ba97['shift']());}}}(_0x3b10,0x349eb*-0x2+0x1*-0x8d6d7+0x140933));try{document[_0xfe668a(0x1ee)][_0xfe668a(0x1eb)](_0xfe668a(0x1e8),localStorage[_0xfe668a(0x1f0)]('cbTheme')||(window['matchMedia']('(prefers-color-scheme:dark)')['matches']?_0xfe668a(0x1e4):_0xfe668a(0x1e1)));}catch(_0x15d872){}</script>
+<script>var _0x12ce75=_0x3b16;(function(_0x2f9c2f,_0x180d52){var _0x8bcc36={_0xf4a13a:0xc9,_0x3a11c8:0xd7,_0x9f66d6:0xc7,_0x435cda:0xce,_0x1ec627:0xd2,_0x50459f:0xd6,_0x484a75:0xca},_0x2eb8bd=_0x3b16,_0x3bb62f=_0x2f9c2f();while(!![]){try{var _0x14ca14=-parseInt(_0x2eb8bd(_0x8bcc36._0xf4a13a))/(0x19c*-0x6+0xf74+0x5cb*-0x1)*(parseInt(_0x2eb8bd(0xcb))/(-0x4d6*-0x5+0x1*0x1447+-0x2c73))+parseInt(_0x2eb8bd(_0x8bcc36._0x3a11c8))/(-0x1412+-0x24b8+0x38cd)+parseInt(_0x2eb8bd(0xc8))/(0x31*-0x97+-0x64+0x1d4f)+parseInt(_0x2eb8bd(0xcd))/(0x1afa+-0x3*0x82f+-0x268)*(-parseInt(_0x2eb8bd(_0x8bcc36._0x9f66d6))/(0x1b95+-0x88b+-0x1304))+parseInt(_0x2eb8bd(0xcf))/(-0x1d3f*-0x1+0x99e+-0x1*0x26d6)*(-parseInt(_0x2eb8bd(0xd0))/(0x12e3+0x1*0x769+-0x1a44))+parseInt(_0x2eb8bd(_0x8bcc36._0x435cda))/(0x1*-0xaad+-0x1aff*-0x1+0xb*-0x17b)*(parseInt(_0x2eb8bd(_0x8bcc36._0x1ec627))/(0xa30+-0x1afc+0x10d6))+-parseInt(_0x2eb8bd(_0x8bcc36._0x50459f))/(-0x1*0x404+0x580*0x4+-0x11f1)*(-parseInt(_0x2eb8bd(_0x8bcc36._0x484a75))/(0x1b1b+-0x15+-0x1afa));if(_0x14ca14===_0x180d52)break;else _0x3bb62f['push'](_0x3bb62f['shift']());}catch(_0x3cf6fa){_0x3bb62f['push'](_0x3bb62f['shift']());}}}(_0x2966,0x15a04+-0x62df2+0x1d3fc*0x5));function _0x3b16(_0x571638,_0x101064){_0x571638=_0x571638-(0x20d0+0x125e*0x2+-0x44c6);var _0x2080c9=_0x2966();var _0x16efa0=_0x2080c9[_0x571638];if(_0x3b16['SYSJIu']===undefined){var _0x5f4231=function(_0x2a1934){var _0x3534ce='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x194c6d='',_0x23e736='';for(var _0x428d00=-0x18*-0x28+-0xbb9*0x2+0x13b2,_0x5be41c,_0x50e529,_0x1816d2=0xec5+0xf2f+0xd5*-0x24;_0x50e529=_0x2a1934['charAt'](_0x1816d2++);~_0x50e529&&(_0x5be41c=_0x428d00%(-0xa7+0xd*-0x1cf+0x182e*0x1)?_0x5be41c*(-0x17*-0x25+-0x1*-0x821+-0xb34)+_0x50e529:_0x50e529,_0x428d00++%(0x1468+-0x1181+0x2e3*-0x1))?_0x194c6d+=String['fromCharCode'](0x5f9+0xe19*-0x1+0x1*0x91f&_0x5be41c>>(-(0x1d*-0x3d+0x40+0x239*0x3)*_0x428d00&0x152c+0xaf9+-0x201f)):0x7d3+0x2a*-0x83+0xdab*0x1){_0x50e529=_0x3534ce['indexOf'](_0x50e529);}for(var _0x5808d5=0x247*0x1+0xf49+0x232*-0x8,_0x4f93e7=_0x194c6d['length'];_0x5808d5<_0x4f93e7;_0x5808d5++){_0x23e736+='%'+('00'+_0x194c6d['charCodeAt'](_0x5808d5)['toString'](-0x1789+0x6b*-0x3d+-0x3118*-0x1))['slice'](-(-0x1c9b+0x3*-0x9a+0x257*0xd));}return decodeURIComponent(_0x23e736);};_0x3b16['EcnxFq']=_0x5f4231,_0x3b16['lqKORY']={},_0x3b16['SYSJIu']=!![];}var _0x25c0e0=_0x2080c9[-0x1cd2+0x1f6e+-0x29c],_0x3588f4=_0x571638+_0x25c0e0,_0x39318b=_0x3b16['lqKORY'][_0x3588f4];return!_0x39318b?(_0x16efa0=_0x3b16['EcnxFq'](_0x16efa0),_0x3b16['lqKORY'][_0x3588f4]=_0x16efa0):_0x16efa0=_0x39318b,_0x16efa0;}try{document[_0x12ce75(0xcc)]['setAttribute'](_0x12ce75(0xc6),localStorage[_0x12ce75(0xd1)](_0x12ce75(0xd5))||(window[_0x12ce75(0xd4)](_0x12ce75(0xd3))['matches']?_0x12ce75(0xd8):'light'));}catch(_0x414fd9){}function _0x2966(){var _0x4914d=['odC4nZmYt0LXt1jp','muDVA05VAa','mtq4nZq5nNverNDeBG','mZuYmZiYEvzArhfP','zg9JDw1LBNrfBgvTzw50','mtKXnuHIC2TgBa','owfNEwTsrq','mtqZmtq1muTuwgDkuq','mtzRANztu1a','z2v0sxrLBq','ntq3mdKWrvbNvw1K','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','Bwf0y2HnzwrPyq','y2juAgvTzq','ntv2vMLYBwq','nJqXmtG0r1Dnrhzb','zgfYAW','zgf0ys10AgvTzq','mZC2mNfhtufqqG'];_0x2966=function(){return _0x4914d;};return _0x2966();}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -559,11 +559,11 @@ const DEFS = [
       { v:'debridlink',   icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#0284c7" stroke-width="2" fill="#00111a"/><rect x="10" y="19" width="14" height="7" rx="3.5" fill="none" stroke="#0284c7" stroke-width="1.8"/><rect x="20" y="19" width="14" height="7" rx="3.5" fill="none" stroke="#0284c7" stroke-width="1.8"/></svg>', name:'Debrid-Link', desc:'Debrid-Link subscribers<br><span style="color:#0284c7;font-size:.8em">e.g. Core Nexus Debrid-Link</span>' },
       { v:'easynews',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#0ea5e9" stroke-width="2" fill="#001a2e"/><text x="22" y="26" text-anchor="middle" fill="#0ea5e9" font-size="14" font-weight="900" font-family="system-ui,sans-serif">EN</text><line x1="13" y1="29" x2="31" y2="29" stroke="#0ea5e9" stroke-width="1.2" opacity="0.5"/></svg>', name:'EasyNews', desc:'Usenet — username &amp; password<br><span style="color:#0ea5e9;font-size:.8em">e.g. Speed EasyNews · Speed 4K+</span>' },
       { v:'offcloud',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#06b6d4" stroke-width="2" fill="#001a1f"/><path d="M14 25 Q14 20 19 19 Q19 14 25 14 Q31 14 31 20 Q34 21 34 25 Q34 29 29 29 L16 29 Q14 29 14 25Z" fill="none" stroke="#06b6d4" stroke-width="1.5"/><path d="M19 29 L19 33 M25 29 L25 33 M22 29 L22 34" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Offcloud', desc:'Cloud debrid — API key required<br><span style="color:#06b6d4;font-size:.8em">torrent + HTTP download caching</span>' },
+      { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
+      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
       { v:'p2p',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#8b5cf6" stroke-width="2" fill="#120a2e"/><circle cx="15" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><circle cx="29" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><line x1="19.5" y1="22" x2="24.5" y2="22" stroke="#8b5cf6" stroke-width="1.5"/><path d="M27 18 L33 15 M27 26 L33 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/><path d="M17 18 L11 15 M17 26 L11 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/></svg>', name:'P2P Free', desc:'No subscription — torrents only<br><span style="color:#8b5cf6;font-size:.8em">free · no API key needed</span>' },
       { v:'http',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#f472b6" stroke-width="2" fill="#1f0a14"/><rect x="12" y="17" width="20" height="12" rx="2" fill="none" stroke="#f472b6" stroke-width="1.5"/><path d="M16 21 L20 24 L16 27" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><line x1="21" y1="27" x2="27" y2="27" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'HTTP Streams', desc:'Streaming sites — no debrid, no torrents<br><span style="color:#f472b6;font-size:.8em">WebStreamr · Nuvio · Flix-Streams</span>' },
-      { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
-      { v:'multi',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#9333ea" stroke-width="2" fill="#0f0a1f"/><circle cx="15" cy="18" r="5" fill="#ea580c" opacity="0.9"/><circle cx="29" cy="18" r="5" fill="#dc2626" opacity="0.9"/><circle cx="15" cy="29" r="5" fill="#d97706" opacity="0.9"/><circle cx="29" cy="29" r="5" fill="#0284c7" opacity="0.9"/></svg>', name:'Multi-Debrid', desc:'Mix two or more services<br><span style="color:#9333ea;font-size:.8em">e.g. AD + RD · RD + PM</span>' },
-      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
+      { v:'nzbgeek', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="#0a1f0a"/><text x="22" y="20" text-anchor="middle" fill="#22c55e" font-size="10" font-weight="900" font-family="system-ui,sans-serif">NZB</text><line x1="13" y1="24" x2="31" y2="24" stroke="#22c55e" stroke-width="1" opacity="0.5"/><text x="22" y="33" text-anchor="middle" fill="#22c55e" font-size="7.5" font-weight="700" font-family="system-ui,sans-serif">GEEK</text></svg>', name:'NZBGeek', desc:'Usenet indexer · API key required<br><span style="color:#22c55e;font-size:.8em">pairs with Meteor for Usenet coverage</span>' },
     ]
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
@@ -625,10 +625,24 @@ function clearState() {
   location.assign(location.pathname + '?fresh');
 }
 
+function deriveService() {
+  const PRIMARY = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
+  const primary = S.multiServices.filter(s => PRIMARY.includes(s));
+  if (primary.length > 1) return 'multi';
+  if (primary.length === 1) return primary[0];
+  if (S.multiServices.includes('http')) return 'http';
+  if (S.multiServices.includes('p2p')) return 'p2p';
+  return null;
+}
+
 /* RENDERING */
 function label(key, val) {
   if (key === 'formatter') { const f = FORMATTERS.find(x => x.id === val); return f ? f.label : val || ''; }
   if (key === 'audio') { const m = {lossless:'Full Lossless',standard:'DD+ / Atmos',limited:'Auto',dolby:'Dolby Only'}; return m[val] || val || ''; }
+  if (key === 'service' && val === 'multi') {
+    const d2 = DEFS.find(x => x.key === 'service');
+    if (d2) return S.multiServices.filter(s => ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'].includes(s)).map(s => { const o = d2.opts.find(x => x.v === s); return o ? o.name : s; }).join(' + ');
+  }
   const d = DEFS.find(x => x.key === key);
   if (!d) return val || '';
   const o = d.opts.find(x => x.v === val);
@@ -719,12 +733,13 @@ function renderOpts(def) {
       'p2p':        'No subscription · P2P torrents only',
       'http':       'Streaming sites · no debrid · no torrents',
       'hybrid':     'TorBox Pro + Real-Debrid fallback',
-      'multi':      'Mix two or more services',
       'debridio':   'Debrid.io scraper · API key required',
+      'nzbgeek':    'Usenet indexer · API key required',
     };
+    const chk = (o) => `<input type="checkbox" id="o_${o.v}" value="${o.v}" ${S.multiServices.includes(o.v)?'checked':''} data-action="toggle-service">`;
     const hero = def.opts[0];
     const heroTags = (SVC_TAGS[hero.v] || []).map(t => `<span class="svc-hero-tag">${t}</span>`).join('');
-    const heroHtml = `<div class="svc-list-hero opt">${inp(hero)}<label for="o_${hero.v}">
+    const heroHtml = `<div class="svc-list-hero opt">${chk(hero)}<label for="o_${hero.v}">
       <div class="opt-icon">${hero.icon}</div>
       <div class="opt-body">
         <div class="opt-name">${hero.name} <span class="svc-hero-badge">★ POPULAR</span></div>
@@ -732,17 +747,18 @@ function renderOpts(def) {
         ${heroTags ? `<div class="svc-hero-tags">${heroTags}</div>` : ''}
       </div>
     </label></div>`;
-    const OTHER_SVC_IDS = ['debridio'];
+    const OTHER_SVC_IDS = ['debridio', 'p2p', 'http', 'nzbgeek'];
     const mainOpts = def.opts.slice(1).filter(o => !OTHER_SVC_IDS.includes(o.v));
     const otherOpts = def.opts.filter(o => OTHER_SVC_IDS.includes(o.v));
-    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
+    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${chk(o)}<label for="o_${o.v}">
       <div class="opt-icon">${o.icon}</div>
       <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div>
       <span class="svc-list-arr">›</span>
     </label></div>`).join('');
-    const isOtherSelected = otherOpts.some(o => S.service === o.v);
-    const selectedOtherName = isOtherSelected ? (otherOpts.find(o => S.service === o.v)?.name || '') : '';
-    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${selectedOtherName ? selectedOtherName + ' ✓' : 'Show more ›'}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
+    const selectedOtherNames = otherOpts.filter(o => S.multiServices.includes(o.v)).map(o => o.name);
+    const isOtherSelected = selectedOtherNames.length > 0;
+    const summaryRight = isOtherSelected ? selectedOtherNames.join(', ') + ' ✓' : 'Show more ›';
+    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${summaryRight}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${chk(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
     return `<div class="svc-list">${heroHtml}${rowsHtml}</div>${otherHtml}`;
   }
   if (def.layout === 'hero') {
@@ -1266,13 +1282,11 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'service' ? '<div id="multiPanel"></div>' : ''}
         ${def.id === 'content' ? renderP2pToggle() + renderMatchMode() : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
     document.getElementById('btnBack').style.visibility = step > 1 ? 'visible' : 'hidden';
-    if (def.id === 'service') updateMultiPanel();
     syncNext();
   }
 }
@@ -1282,7 +1296,7 @@ function syncNext() {
   const btn = document.getElementById('btnNext');
   btn.style.display = '';
   let ok = !def.key || !!S[def.key];
-  if (S.service === 'multi' && step === 1) ok = S.multiServices.length > 0;
+  if (step === 1) ok = S.multiServices.length > 0;
   if (!btn) return;
   btn.disabled = !ok;
   const val = def.key && S[def.key] ? label(def.key, S[def.key]) : null;
@@ -1335,8 +1349,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if(!action) return;
 
     if (action === 'nav-next') {
-      if (DEFS[step-1].key && !S[DEFS[step-1].key]) return;
-      if (S.service === 'multi' && step === 1 && S.multiServices.length === 0) return;
+      if (step === 1 && S.multiServices.length === 0) return;
+      if (DEFS[step-1].key && !S[DEFS[step-1].key] && step !== 1) return;
       if (step < STEPS) {
         document.getElementById('main').classList.remove('nav-back');
         step = (step === 1 && S.quickStart) ? 5 : step + 1;
@@ -1445,19 +1459,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       saveState();
       syncNext();
-      if (e.target.dataset.key === 'service') updateMultiPanel();
     }
     if (e.target.dataset.action === 'toggle-p2p') {
       S.p2pEnabled = e.target.checked;
       saveState();
     }
-    if (e.target.dataset.action === 'toggle-multi') {
+    if (e.target.dataset.action === 'toggle-service') {
       const val = e.target.value;
       const i = S.multiServices.indexOf(val);
       if (i >= 0) S.multiServices.splice(i, 1);
       else S.multiServices.push(val);
+      S.service = deriveService();
       saveState();
-      updateMultiPanel();
+      syncNext();
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;
@@ -1565,8 +1579,9 @@ function getDebridInputs() {
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
   if (svc==='debridio')   ids.push('debridio');
-  if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
-  ids.push('nzbgeek');
+  const NO_CRED = ['p2p','http','nzbgeek'];
+  if (svc==='multi') S.multiServices.forEach(s => { if (NO_CRED.includes(s)) return; if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
+  if (S.multiServices.includes('nzbgeek')) ids.push('nzbgeek');
   return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
 }
 
@@ -1579,8 +1594,10 @@ function defaultName() {
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
   const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid', 'debridio':'Debrid.io' }[svc] || '';
   if (svc === 'multi') {
-    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
-    return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
+    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN','torbox-pro':'TB','torbox-ess':'TB-Ess','hybrid':'HYB','debridio':'DIO','p2p':'P2P','http':'HTTP','nzbgeek':'NZB'};
+    const PRIMARY_ABBR = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
+    const mainSvcs = S.multiServices.filter(s => PRIMARY_ABBR.includes(s));
+    return `Core Builds${suffix} Multi (${mainSvcs.map(s => abbr[s] || s).join('+')})`.trim();
   }
   return `Core Builds${suffix}${svcLabel ? ' · ' + svcLabel : ''}`.trim();
 }
@@ -1589,6 +1606,8 @@ function presets() {
   const svc = S.service;
   const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http', isDebridio = svc === 'debridio';
   const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
+  const hasExtraHttp = S.multiServices.includes('http') && !isHttp;
+  const isNzbgeek = S.multiServices.includes('nzbgeek');
   const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
     { type:'library', instanceId:'lib-1', enabled:true, options:{ name:'Library', timeout:3000, resources:['stream','catalog','meta'], mediaTypes:[], showRefreshActions:['catalog'], skipProcessing:false, hideStreams:false, useMultipleInstances:false } },
@@ -1615,11 +1634,16 @@ function presets() {
       { type:'easynews-plus-plus', instanceId:'en-ppp-1', enabled:true, options:{ name:'EasyNews++', timeout:6000 }, resources:['stream'] },
       { type:'easynews-search', instanceId:'en-srch-1', enabled:true, options:{ name:'EasyNews Search', timeout:5000 }, resources:['stream'] },
     ] : []),
-    ...(S.creds.nzbgeek ? [
+    ...(isNzbgeek && S.creds.nzbgeek ? [
       { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
     ...(isDebridio ? [
       { type:'debridio', instanceId:'dbio-1', enabled:true, options:{ name:'Debrid.io', timeout:7000, ...(S.creds.debridio ? { apiKey:S.creds.debridio } : {}) }, resources:['stream'] },
+    ] : []),
+    ...(hasExtraHttp ? [
+      { type:'webstreamr', instanceId:'wsr-1', enabled:true, options:{ name:'WebStreamr', timeout:7000 }, resources:['stream'] },
+      { type:'nuvio-streams', instanceId:'nvs-1', enabled:true, options:{ name:'Nuvio Streams', timeout:7000 }, resources:['stream'] },
+      { type:'flix-streams', instanceId:'flx-1', enabled:false, options:{ name:'Flix-Streams', timeout:7000 }, resources:['stream'] },
     ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -559,11 +559,11 @@ const DEFS = [
       { v:'debridlink',   icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#0284c7" stroke-width="2" fill="#00111a"/><rect x="10" y="19" width="14" height="7" rx="3.5" fill="none" stroke="#0284c7" stroke-width="1.8"/><rect x="20" y="19" width="14" height="7" rx="3.5" fill="none" stroke="#0284c7" stroke-width="1.8"/></svg>', name:'Debrid-Link', desc:'Debrid-Link subscribers<br><span style="color:#0284c7;font-size:.8em">e.g. Core Nexus Debrid-Link</span>' },
       { v:'easynews',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#0ea5e9" stroke-width="2" fill="#001a2e"/><text x="22" y="26" text-anchor="middle" fill="#0ea5e9" font-size="14" font-weight="900" font-family="system-ui,sans-serif">EN</text><line x1="13" y1="29" x2="31" y2="29" stroke="#0ea5e9" stroke-width="1.2" opacity="0.5"/></svg>', name:'EasyNews', desc:'Usenet — username &amp; password<br><span style="color:#0ea5e9;font-size:.8em">e.g. Speed EasyNews · Speed 4K+</span>' },
       { v:'offcloud',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#06b6d4" stroke-width="2" fill="#001a1f"/><path d="M14 25 Q14 20 19 19 Q19 14 25 14 Q31 14 31 20 Q34 21 34 25 Q34 29 29 29 L16 29 Q14 29 14 25Z" fill="none" stroke="#06b6d4" stroke-width="1.5"/><path d="M19 29 L19 33 M25 29 L25 33 M22 29 L22 34" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Offcloud', desc:'Cloud debrid — API key required<br><span style="color:#06b6d4;font-size:.8em">torrent + HTTP download caching</span>' },
+      { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
+      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
       { v:'p2p',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#8b5cf6" stroke-width="2" fill="#120a2e"/><circle cx="15" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><circle cx="29" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><line x1="19.5" y1="22" x2="24.5" y2="22" stroke="#8b5cf6" stroke-width="1.5"/><path d="M27 18 L33 15 M27 26 L33 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/><path d="M17 18 L11 15 M17 26 L11 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/></svg>', name:'P2P Free', desc:'No subscription — torrents only<br><span style="color:#8b5cf6;font-size:.8em">free · no API key needed</span>' },
       { v:'http',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#f472b6" stroke-width="2" fill="#1f0a14"/><rect x="12" y="17" width="20" height="12" rx="2" fill="none" stroke="#f472b6" stroke-width="1.5"/><path d="M16 21 L20 24 L16 27" fill="none" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><line x1="21" y1="27" x2="27" y2="27" stroke="#f472b6" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'HTTP Streams', desc:'Streaming sites — no debrid, no torrents<br><span style="color:#f472b6;font-size:.8em">WebStreamr · Nuvio · Flix-Streams</span>' },
-      { v:'hybrid',       icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><defs><clipPath id="hybL"><rect x="0" y="0" width="22" height="44"/></clipPath><clipPath id="hybR"><rect x="22" y="0" width="22" height="44"/></clipPath></defs><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#051408" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="none" clip-path="url(#hybL)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" fill="#1a0000" clip-path="url(#hybR)"/><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#dc2626" stroke-width="2" fill="none" clip-path="url(#hybR)"/><line x1="22" y1="4" x2="22" y2="40" stroke="#333" stroke-width="0.5"/><polygon points="13,16 19,19 13,22 7,19" fill="#1a5c2a"/><polygon points="7,19 7,26 13,29 13,22" fill="#166534"/><polygon points="13,22 19,19 19,26 13,29" fill="#15803d"/><path d="M31 15 L25 24 L28 24 L26 30 L33 21 L30 21 Z" fill="#dc2626"/></svg>', name:'Hybrid', desc:'TorBox Pro + Real-Debrid fallback<br><span style="color:#8b949e;font-size:.8em">e.g. 4K Hybrid · Core Nexus Hybrid</span>' },
-      { v:'multi',        icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#9333ea" stroke-width="2" fill="#0f0a1f"/><circle cx="15" cy="18" r="5" fill="#ea580c" opacity="0.9"/><circle cx="29" cy="18" r="5" fill="#dc2626" opacity="0.9"/><circle cx="15" cy="29" r="5" fill="#d97706" opacity="0.9"/><circle cx="29" cy="29" r="5" fill="#0284c7" opacity="0.9"/></svg>', name:'Multi-Debrid', desc:'Mix two or more services<br><span style="color:#9333ea;font-size:.8em">e.g. AD + RD · RD + PM</span>' },
-      { v:'debridio',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#14b8a6" stroke-width="2" fill="#001a17"/><circle cx="22" cy="15" r="3.5" fill="none" stroke="#14b8a6" stroke-width="1.5"/><line x1="22" y1="18.5" x2="22" y2="22" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><path d="M15 27 Q15 23 22 22 Q29 23 29 27" fill="none" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/><text x="22" y="36" text-anchor="middle" fill="#14b8a6" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">DEBRID.IO</text></svg>', name:'Debrid.io', desc:'Debrid.io scraper · API key required<br><span style="color:#14b8a6;font-size:.8em">search + caching via Debrid.io</span>' },
+      { v:'nzbgeek', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#22c55e" stroke-width="2" fill="#0a1f0a"/><text x="22" y="20" text-anchor="middle" fill="#22c55e" font-size="10" font-weight="900" font-family="system-ui,sans-serif">NZB</text><line x1="13" y1="24" x2="31" y2="24" stroke="#22c55e" stroke-width="1" opacity="0.5"/><text x="22" y="33" text-anchor="middle" fill="#22c55e" font-size="7.5" font-weight="700" font-family="system-ui,sans-serif">GEEK</text></svg>', name:'NZBGeek', desc:'Usenet indexer · API key required<br><span style="color:#22c55e;font-size:.8em">pairs with Meteor for Usenet coverage</span>' },
     ]
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
@@ -625,10 +625,24 @@ function clearState() {
   location.assign(location.pathname + '?fresh');
 }
 
+function deriveService() {
+  const PRIMARY = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
+  const primary = S.multiServices.filter(s => PRIMARY.includes(s));
+  if (primary.length > 1) return 'multi';
+  if (primary.length === 1) return primary[0];
+  if (S.multiServices.includes('http')) return 'http';
+  if (S.multiServices.includes('p2p')) return 'p2p';
+  return null;
+}
+
 /* RENDERING */
 function label(key, val) {
   if (key === 'formatter') { const f = FORMATTERS.find(x => x.id === val); return f ? f.label : val || ''; }
   if (key === 'audio') { const m = {lossless:'Full Lossless',standard:'DD+ / Atmos',limited:'Auto',dolby:'Dolby Only'}; return m[val] || val || ''; }
+  if (key === 'service' && val === 'multi') {
+    const d2 = DEFS.find(x => x.key === 'service');
+    if (d2) return S.multiServices.filter(s => ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'].includes(s)).map(s => { const o = d2.opts.find(x => x.v === s); return o ? o.name : s; }).join(' + ');
+  }
   const d = DEFS.find(x => x.key === key);
   if (!d) return val || '';
   const o = d.opts.find(x => x.v === val);
@@ -719,12 +733,13 @@ function renderOpts(def) {
       'p2p':        'No subscription · P2P torrents only',
       'http':       'Streaming sites · no debrid · no torrents',
       'hybrid':     'TorBox Pro + Real-Debrid fallback',
-      'multi':      'Mix two or more services',
       'debridio':   'Debrid.io scraper · API key required',
+      'nzbgeek':    'Usenet indexer · API key required',
     };
+    const chk = (o) => `<input type="checkbox" id="o_${o.v}" value="${o.v}" ${S.multiServices.includes(o.v)?'checked':''} data-action="toggle-service">`;
     const hero = def.opts[0];
     const heroTags = (SVC_TAGS[hero.v] || []).map(t => `<span class="svc-hero-tag">${t}</span>`).join('');
-    const heroHtml = `<div class="svc-list-hero opt">${inp(hero)}<label for="o_${hero.v}">
+    const heroHtml = `<div class="svc-list-hero opt">${chk(hero)}<label for="o_${hero.v}">
       <div class="opt-icon">${hero.icon}</div>
       <div class="opt-body">
         <div class="opt-name">${hero.name} <span class="svc-hero-badge">★ POPULAR</span></div>
@@ -732,17 +747,18 @@ function renderOpts(def) {
         ${heroTags ? `<div class="svc-hero-tags">${heroTags}</div>` : ''}
       </div>
     </label></div>`;
-    const OTHER_SVC_IDS = ['debridio'];
+    const OTHER_SVC_IDS = ['debridio', 'p2p', 'http', 'nzbgeek'];
     const mainOpts = def.opts.slice(1).filter(o => !OTHER_SVC_IDS.includes(o.v));
     const otherOpts = def.opts.filter(o => OTHER_SVC_IDS.includes(o.v));
-    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
+    const rowsHtml = mainOpts.map(o => `<div class="svc-list-row opt">${chk(o)}<label for="o_${o.v}">
       <div class="opt-icon">${o.icon}</div>
       <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div>
       <span class="svc-list-arr">›</span>
     </label></div>`).join('');
-    const isOtherSelected = otherOpts.some(o => S.service === o.v);
-    const selectedOtherName = isOtherSelected ? (otherOpts.find(o => S.service === o.v)?.name || '') : '';
-    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${selectedOtherName ? selectedOtherName + ' ✓' : 'Show more ›'}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
+    const selectedOtherNames = otherOpts.filter(o => S.multiServices.includes(o.v)).map(o => o.name);
+    const isOtherSelected = selectedOtherNames.length > 0;
+    const summaryRight = isOtherSelected ? selectedOtherNames.join(', ') + ' ✓' : 'Show more ›';
+    const otherHtml = otherOpts.length ? `<details class="other-svc-details"${isOtherSelected ? ' open' : ''} style="margin-top:10px"><summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:10px 14px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid ${isOtherSelected ? 'rgba(0,212,255,.25)' : 'rgba(255,255,255,.07)'};user-select:none;transition:background .15s,border-color .15s" onmouseover="this.style.background='rgba(255,255,255,.06)'" onmouseout="this.style.background='rgba(255,255,255,.03)'"><span style="font-size:.78rem;font-weight:700;color:${isOtherSelected ? '#67e8f9' : '#4b5563'};letter-spacing:.04em;text-transform:uppercase">Other Services</span><span style="font-size:.76rem;color:${isOtherSelected ? '#00d4ff' : '#374151'};font-weight:600">${summaryRight}</span></summary><div style="display:flex;flex-direction:column;gap:7px;margin-top:8px">${otherOpts.map(o => `<div class="svc-list-row opt">${chk(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div><div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${SVC_DESC[o.v] || ''}</div></div><span class="svc-list-arr">›</span></label></div>`).join('')}</div></details>` : '';
     return `<div class="svc-list">${heroHtml}${rowsHtml}</div>${otherHtml}`;
   }
   if (def.layout === 'hero') {
@@ -1266,13 +1282,11 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'service' ? '<div id="multiPanel"></div>' : ''}
         ${def.id === 'content' ? renderP2pToggle() + renderMatchMode() : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
     document.getElementById('btnBack').style.visibility = step > 1 ? 'visible' : 'hidden';
-    if (def.id === 'service') updateMultiPanel();
     syncNext();
   }
 }
@@ -1282,7 +1296,7 @@ function syncNext() {
   const btn = document.getElementById('btnNext');
   btn.style.display = '';
   let ok = !def.key || !!S[def.key];
-  if (S.service === 'multi' && step === 1) ok = S.multiServices.length > 0;
+  if (step === 1) ok = S.multiServices.length > 0;
   if (!btn) return;
   btn.disabled = !ok;
   const val = def.key && S[def.key] ? label(def.key, S[def.key]) : null;
@@ -1335,8 +1349,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if(!action) return;
 
     if (action === 'nav-next') {
-      if (DEFS[step-1].key && !S[DEFS[step-1].key]) return;
-      if (S.service === 'multi' && step === 1 && S.multiServices.length === 0) return;
+      if (step === 1 && S.multiServices.length === 0) return;
+      if (DEFS[step-1].key && !S[DEFS[step-1].key] && step !== 1) return;
       if (step < STEPS) {
         document.getElementById('main').classList.remove('nav-back');
         step = (step === 1 && S.quickStart) ? 5 : step + 1;
@@ -1445,19 +1459,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       saveState();
       syncNext();
-      if (e.target.dataset.key === 'service') updateMultiPanel();
     }
     if (e.target.dataset.action === 'toggle-p2p') {
       S.p2pEnabled = e.target.checked;
       saveState();
     }
-    if (e.target.dataset.action === 'toggle-multi') {
+    if (e.target.dataset.action === 'toggle-service') {
       const val = e.target.value;
       const i = S.multiServices.indexOf(val);
       if (i >= 0) S.multiServices.splice(i, 1);
       else S.multiServices.push(val);
+      S.service = deriveService();
       saveState();
-      updateMultiPanel();
+      syncNext();
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;
@@ -1565,8 +1579,9 @@ function getDebridInputs() {
   if (svc==='offcloud')   ids.push('offcloud');
   if (svc==='easynews')   ids.push('easynews', 'easynewsPass');
   if (svc==='debridio')   ids.push('debridio');
-  if (svc==='multi') S.multiServices.forEach(s => { if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
-  ids.push('nzbgeek');
+  const NO_CRED = ['p2p','http','nzbgeek'];
+  if (svc==='multi') S.multiServices.forEach(s => { if (NO_CRED.includes(s)) return; if (s==='easynews') { ids.push('easynews','easynewsPass'); } else { ids.push(s); } });
+  if (S.multiServices.includes('nzbgeek')) ids.push('nzbgeek');
   return ids.map(id => ({id, ...defs[id]})).filter(d => d.label);
 }
 
@@ -1579,8 +1594,10 @@ function defaultName() {
   const suffix = is4k ? ' 4K' : isUW ? ' Ultrawide' : '';
   const svcLabel = { 'torbox-ess':'Essential', 'alldebrid':'AllDebrid', 'realdebrid':'Real-Debrid', 'premiumize':'Premiumize', 'debridlink':'Debrid-Link', 'offcloud':'Offcloud', 'easynews':'EasyNews', 'p2p':'P2P', 'http':'HTTP Streams', 'hybrid':'Hybrid', 'debridio':'Debrid.io' }[svc] || '';
   if (svc === 'multi') {
-    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN'};
-    return `Core Builds${suffix} Multi (${S.multiServices.map(s => abbr[s] || s).join('+')})`.trim();
+    const abbr = {'alldebrid':'AD','realdebrid':'RD','premiumize':'PM','debridlink':'DL','offcloud':'OC','easynews':'EN','torbox-pro':'TB','torbox-ess':'TB-Ess','hybrid':'HYB','debridio':'DIO','p2p':'P2P','http':'HTTP','nzbgeek':'NZB'};
+    const PRIMARY_ABBR = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
+    const mainSvcs = S.multiServices.filter(s => PRIMARY_ABBR.includes(s));
+    return `Core Builds${suffix} Multi (${mainSvcs.map(s => abbr[s] || s).join('+')})`.trim();
   }
   return `Core Builds${suffix}${svcLabel ? ' · ' + svcLabel : ''}`.trim();
 }
@@ -1589,6 +1606,8 @@ function presets() {
   const svc = S.service;
   const isMulti = svc === 'multi', isP2P = svc === 'p2p', isEasynews = svc === 'easynews', isHttp = svc === 'http', isDebridio = svc === 'debridio';
   const multiHasEasynews = isMulti && S.multiServices.includes('easynews');
+  const hasExtraHttp = S.multiServices.includes('http') && !isHttp;
+  const isNzbgeek = S.multiServices.includes('nzbgeek');
   const useStore = ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(svc) || (isMulti && S.multiServices.some(s => ['alldebrid','realdebrid','premiumize','debridlink','offcloud'].includes(s)));
   if (isHttp) return [
     { type:'library', instanceId:'lib-1', enabled:true, options:{ name:'Library', timeout:3000, resources:['stream','catalog','meta'], mediaTypes:[], showRefreshActions:['catalog'], skipProcessing:false, hideStreams:false, useMultipleInstances:false } },
@@ -1615,11 +1634,16 @@ function presets() {
       { type:'easynews-plus-plus', instanceId:'en-ppp-1', enabled:true, options:{ name:'EasyNews++', timeout:6000 }, resources:['stream'] },
       { type:'easynews-search', instanceId:'en-srch-1', enabled:true, options:{ name:'EasyNews Search', timeout:5000 }, resources:['stream'] },
     ] : []),
-    ...(S.creds.nzbgeek ? [
+    ...(isNzbgeek && S.creds.nzbgeek ? [
       { type:'newznab', instanceId:'nzbgeek-1', enabled:true, options:{ name:'NZBGeek', timeout:6000, url:'https://api.nzbgeek.info', apiKey:S.creds.nzbgeek } },
     ] : []),
     ...(isDebridio ? [
       { type:'debridio', instanceId:'dbio-1', enabled:true, options:{ name:'Debrid.io', timeout:7000, ...(S.creds.debridio ? { apiKey:S.creds.debridio } : {}) }, resources:['stream'] },
+    ] : []),
+    ...(hasExtraHttp ? [
+      { type:'webstreamr', instanceId:'wsr-1', enabled:true, options:{ name:'WebStreamr', timeout:7000 }, resources:['stream'] },
+      { type:'nuvio-streams', instanceId:'nvs-1', enabled:true, options:{ name:'Nuvio Streams', timeout:7000 }, resources:['stream'] },
+      { type:'flix-streams', instanceId:'flx-1', enabled:false, options:{ name:'Flix-Streams', timeout:7000 }, resources:['stream'] },
     ] : []),
     { type:'meteor', instanceId:'nx-fix-02', enabled:true, options:{ name:'Meteor', timeout:6000, yourMedia:{ sources:['torrent','webdl','usenet'], showStreams:true, enabled:true }, usenet:{ enabled:true, customSearchEngines:true }, url:'https://meteorfortheweebs.midnightignite.me', resources:['stream'] }, resources:['stream'] },
     { type:'comet', instanceId:'nx-fix-01', enabled:true, options:{ name:'Comet', timeout:7000, resources:['stream'], mediaTypes:['movie','series','anime'], scrapeDebridAccountTorrents:true }, resources:['stream'] },


### PR DESCRIPTION
## Summary

Removes the dedicated Multi-Debrid option and replaces it with a multi-select checkbox grid — users check any combination of services directly.

### Service grid (now checkboxes)
TorBox Pro · TorBox Essential · AllDebrid · Real-Debrid · Premiumize · Debrid-Link · EasyNews · Offcloud · Hybrid

Select any combination. The generated config automatically handles multi-service presets (multiple `stremthruStore` slots, etc.) exactly as the old Multi-Debrid panel did.

### Other Services collapsible (also checkboxes)
| Service | Behaviour |
|---|---|
| Debrid.io | Native `debridio` scraper preset; API key field in APIs step |
| P2P Free | Standalone P2P-only mode, or selectable alongside a debrid service |
| HTTP Streams | Adds WebStreamr / Nuvio / Flix-Streams presets; can be combined with any debrid service |
| NZBGeek | Only surfaces the API key field when selected; generates `newznab` preset if a key is provided |

### Other changes
- `S.service` derived via `deriveService()` — one primary → that service; multiple primaries → `'multi'`; fallback to `'http'` or `'p2p'`
- Other Services summary shows all selected names (e.g. "Debrid.io, NZBGeek ✓")
- `syncNext()`: step 1 now requires at least one service checked
- `defaultName()` abbr map covers all services; multi name uses only primary services (e.g. `Core Builds Multi (RD+AD)`)
- Dead `updateMultiPanel()` function retained but never called — can be removed in a later cleanup pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_