### PR TITLE
configurator: language preference section with exclusive mode

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -434,7 +434,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>function _0x304e(_0x354abc,_0x1fee54){_0x354abc=_0x354abc-(-0x230f+0xdd*-0xf+0x31ca);var _0x532c69=_0x16c2();var _0x5344d7=_0x532c69[_0x354abc];if(_0x304e['vrcwkP']===undefined){var _0x43250d=function(_0x23b4cd){var _0x2055fd='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x398bef='',_0x5a5c75='';for(var _0x1ba27c=0xdbc+0x3b8+-0x1174,_0x3baaa0,_0x50bc4a,_0x38a778=0x48c+-0x242e+0x1fa2;_0x50bc4a=_0x23b4cd['charAt'](_0x38a778++);~_0x50bc4a&&(_0x3baaa0=_0x1ba27c%(-0xfa0+-0x1f13+0x2eb7)?_0x3baaa0*(-0x270f+-0x98b+0x30da)+_0x50bc4a:_0x50bc4a,_0x1ba27c++%(0xb40+0x151*0x1c+-0x3018))?_0x398bef+=String['fromCharCode'](-0x1fd4+0x9d*-0x2c+0x3bcf&_0x3baaa0>>(-(0x3*-0x4fc+-0x1967+0x285d)*_0x1ba27c&0xec0+0x1154*-0x2+0x13ee)):-0xbb3+0x19*0xc1+-0x726){_0x50bc4a=_0x2055fd['indexOf'](_0x50bc4a);}for(var _0x5a8900=0x363*0x5+-0x1*0x2702+-0x1613*-0x1,_0x577c02=_0x398bef['length'];_0x5a8900<_0x577c02;_0x5a8900++){_0x5a5c75+='%'+('00'+_0x398bef['charCodeAt'](_0x5a8900)['toString'](-0xfee+-0x8e*0x1+0x108c*0x1))['slice'](-(0x1fd*-0x7+0x4f3+-0x1*-0x8fa));}return decodeURIComponent(_0x5a5c75);};_0x304e['zLHcwo']=_0x43250d,_0x304e['uDcpsC']={},_0x304e['vrcwkP']=!![];}var _0x18b839=_0x532c69[-0x1cd*-0x15+0x1*0xef6+-0xe5*0x3b],_0x19b6f8=_0x354abc+_0x18b839,_0x29cc8e=_0x304e['uDcpsC'][_0x19b6f8];return!_0x29cc8e?(_0x5344d7=_0x304e['zLHcwo'](_0x5344d7),_0x304e['uDcpsC'][_0x19b6f8]=_0x5344d7):_0x5344d7=_0x29cc8e,_0x5344d7;}function _0x16c2(){var _0x34a13=['mZC4nti5mJD1vMrWENa','zg9JDw1LBNrfBgvTzw50','mZu1mZu5mgXXAK9dBa','Bwf0y2HnzwrPyq','mteXntGWnhniwxfvtW','zgfYAW','y2juAgvTzq','Bwf0y2HLCW','BgLNAhq','mZm2ote0mgLky2Ptvq','zgf0ys10AgvTzq','ntC1mdi5mM9myuzvqW','C2v0qxr0CMLIDxrL','mJqWotmZmgXZtwLrta','ndq0ntKYAgvPyK5p'];_0x16c2=function(){return _0x34a13;};return _0x16c2();}var _0x36f414=_0x304e;(function(_0x4f7c9a,_0x2f6558){var _0x364a65={_0x46a66a:0x1d1,_0x3d7504:0x1cc,_0x5260a5:0x1cb},_0x4503e7=_0x304e,_0xb5d3e=_0x4f7c9a();while(!![]){try{var _0x9cfa9a=-parseInt(_0x4503e7(_0x364a65._0x46a66a))/(0x251e*0x1+-0x1dc7+0x272*-0x3)+-parseInt(_0x4503e7(_0x364a65._0x3d7504))/(-0x1*-0x13a2+0x2*-0xe5+-0x2f9*0x6)+-parseInt(_0x4503e7(0x1cf))/(-0x52*-0x44+-0x3*-0xc1+0x602*-0x4)+-parseInt(_0x4503e7(0x1d6))/(0xff1+-0x12d2+0x2e5)+-parseInt(_0x4503e7(_0x364a65._0x5260a5))/(-0x23*0x5c+0xbc*0xb+-0x485*-0x1)+-parseInt(_0x4503e7(0x1c9))/(-0x11*-0x1eb+0x1*-0x103f+-0x1056)+parseInt(_0x4503e7(0x1cd))/(0x1695*-0x1+0x1e0+0xa5e*0x2);if(_0x9cfa9a===_0x2f6558)break;else _0xb5d3e['push'](_0xb5d3e['shift']());}catch(_0x2c1d87){_0xb5d3e['push'](_0xb5d3e['shift']());}}}(_0x16c2,0x9dd1b+-0x3a*-0x3205+-0xc011f*0x1));try{document[_0x36f414(0x1ce)][_0x36f414(0x1ca)](_0x36f414(0x1c8),localStorage['getItem'](_0x36f414(0x1d3))||(window[_0x36f414(0x1d0)]('(prefers-color-scheme:dark)')[_0x36f414(0x1d4)]?_0x36f414(0x1d2):_0x36f414(0x1d5)));}catch(_0x1e96bd){}</script>
+<script>var _0x46d0be=_0x1693;function _0x1693(_0x166788,_0x56673a){_0x166788=_0x166788-(-0x70*-0x53+0xdc3+-0x30e6);var _0x1d45e8=_0x3ad4();var _0x329130=_0x1d45e8[_0x166788];if(_0x1693['pUnkUJ']===undefined){var _0x304441=function(_0x2e2732){var _0x3b8699='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x3b13af='',_0x5dc063='';for(var _0x43c66a=0x2*0x96a+-0x831*0x4+-0x8*-0x1be,_0x5af52f,_0xb3b774,_0x273416=-0x1247*0x1+0x648+0xbff*0x1;_0xb3b774=_0x2e2732['charAt'](_0x273416++);~_0xb3b774&&(_0x5af52f=_0x43c66a%(0x21*0x51+0x17f6*0x1+0x2263*-0x1)?_0x5af52f*(0x5*0x64c+0x1*-0x1619+0x923*-0x1)+_0xb3b774:_0xb3b774,_0x43c66a++%(-0x34*0x61+-0x5*-0x593+-0x827))?_0x3b13af+=String['fromCharCode'](-0x35*-0x55+0x14e1+-0x257b&_0x5af52f>>(-(-0x15b7*0x1+-0x1*-0x1b9b+-0x2f1*0x2)*_0x43c66a&0x2*0x823+-0x3*0x2+-0x103a)):-0x1718*-0x1+-0x153*-0x1b+0x1*-0x3ad9){_0xb3b774=_0x3b8699['indexOf'](_0xb3b774);}for(var _0x4535cc=0x1606*-0x1+-0x1be0+-0x31e6*-0x1,_0x1d6f64=_0x3b13af['length'];_0x4535cc<_0x1d6f64;_0x4535cc++){_0x5dc063+='%'+('00'+_0x3b13af['charCodeAt'](_0x4535cc)['toString'](-0xf76+-0x76d*0x1+-0x1*-0x16f3))['slice'](-(-0x24*-0xde+0xd6c+-0x2ca2));}return decodeURIComponent(_0x5dc063);};_0x1693['tXSzpH']=_0x304441,_0x1693['aqotiQ']={},_0x1693['pUnkUJ']=!![];}var _0x1dc3a3=_0x1d45e8[-0x1089+-0xbe2*-0x3+-0x131d],_0xcd9d42=_0x166788+_0x1dc3a3,_0x5c9a4e=_0x1693['aqotiQ'][_0xcd9d42];return!_0x5c9a4e?(_0x329130=_0x1693['tXSzpH'](_0x329130),_0x1693['aqotiQ'][_0xcd9d42]=_0x329130):_0x329130=_0x5c9a4e,_0x329130;}function _0x3ad4(){var _0x50960c=['mZzIChz3sMO','mtq1ndK5mfv3vuLgCq','mtG4nZuXsevqsfjw','mJe4nJa4BvnnB1jU','C2v0qxr0CMLIDxrL','mJqWmufHwMLcqG','mJjHBg9yDKG','m3vmtKvWCG','zgfYAW','Bwf0y2HLCW','y2juAgvTzq','nZv4r2vlEKi','ndq0ntjTBfnnzfC','zgf0ys10AgvTzq','ndu0nde2BgHAwMDf','ntjbCwHzEKC','mtaWmKHvBxLqwa','Bwf0y2HnzwrPyq','ode1nZq4y21HvNbc'];_0x3ad4=function(){return _0x50960c;};return _0x3ad4();}(function(_0x46f5a1,_0x5db15b){var _0x541cce={_0x15a1da:0x13e,_0x359c16:0x130,_0x26a131:0x134,_0x559967:0x12e,_0x4eccb4:0x13c,_0x4b6497:0x13d,_0x92504f:0x138},_0x539960=_0x1693,_0x25b440=_0x46f5a1();while(!![]){try{var _0x8310bb=parseInt(_0x539960(_0x541cce._0x15a1da))/(0x955*0x1+-0x2245+0x18f1)+parseInt(_0x539960(0x13f))/(-0x1*-0x11a2+-0xef5+-0x2ab)*(-parseInt(_0x539960(_0x541cce._0x359c16))/(-0xdf5+-0x1c0f+0x7*0x601))+parseInt(_0x539960(0x135))/(-0x11cd+-0xa*-0x385+-0x1161)*(-parseInt(_0x539960(_0x541cce._0x26a131))/(-0xd4c*0x2+0x10a+0x1993*0x1))+parseInt(_0x539960(0x139))/(0x78e*-0x2+-0x10*0x21d+0x1*0x30f2)*(parseInt(_0x539960(_0x541cce._0x559967))/(0x48b+-0x3b*-0x6d+-0x1da3*0x1))+parseInt(_0x539960(0x137))/(-0xe95*0x1+0xcac*0x2+-0xabb)*(parseInt(_0x539960(_0x541cce._0x4eccb4))/(-0x25e*-0x5+0x1*0x18dc+-0x5*0x755))+parseInt(_0x539960(_0x541cce._0x4b6497))/(-0x20b9*-0x1+0x13d7+-0x3486)*(-parseInt(_0x539960(0x12f))/(0x11c*0x1d+0x19cb+-0x39ec))+-parseInt(_0x539960(0x13b))/(0x1094+0x10b7+-0x213f*0x1)*(-parseInt(_0x539960(_0x541cce._0x92504f))/(-0x1*-0x6c4+-0x82f+0x178));if(_0x8310bb===_0x5db15b)break;else _0x25b440['push'](_0x25b440['shift']());}catch(_0x28f89d){_0x25b440['push'](_0x25b440['shift']());}}}(_0x3ad4,-0x25f*0xe2+-0x6d3*-0x2+0x4c227));try{document['documentElement'][_0x46d0be(0x12d)](_0x46d0be(0x136),localStorage['getItem'](_0x46d0be(0x133))||(window[_0x46d0be(0x13a)]('(prefers-color-scheme:dark)')[_0x46d0be(0x132)]?_0x46d0be(0x131):'light'));}catch(_0x3ab658){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -510,7 +510,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false };
 
 const FORMATTERS = [
   {
@@ -548,6 +548,13 @@ const FORMATTERS = [
     name: `{stream.resolution::exists["{stream.resolution::replace('2160p','🔴 4K')::replace('1440p','🟣 2K')::replace('1080p','🔵 1080P')::replace('720p','🟢 720P')::replace('480p','⚫ 480P')::replace('Unknown','📺 HD')}  "||"📺 HD  "]{service.cached::istrue["⚡ "||"⏳ "]}{service.shortName::exists["{service.shortName::upper}  "||"P2P  "]}{stream.library::istrue["📚  "||""]} {stream.title::exists["{stream.title::upper}"||""]} {stream.formattedSeasons::exists["{stream.formattedSeasons::upper}"||""]} {stream.formattedEpisodes::exists["{stream.formattedEpisodes::upper}"||""]}`,
     d: ` {service.cached::istrue["🚀 INSTANT  "||"⚠️ UNCACHED  "]}{stream.nSeScore::>=75["💎 ELITE  "||""]} {stream.seadexBest::istrue["⭐ BEST  "||""]} {stream.seadex::istrue["✅ SEADEX  "||""]} {stream.releaseGroup::~(?i)(epsilon|framestor|qxr|tigole|ntb|flux|d-z0n3|playbd|hifi|don|huno|bmf)["👑 PREMIER  "||""]} {stream.filename::~(?i)IMAX["🎞️ IMAX  "||""]} \n 🎬 {stream.quality::exists["{stream.quality::upper}  "||""]} {stream.encode::exists["{stream.encode::upper}  "||""]} {stream.visualTags::exists["{stream.visualTags::join(' ')::upper}  "||"SDR  "]} {stream.bitrate::exists["{stream.bitrate::sbitrate::upper}  "||""]} {stream.size::exists["{stream.size::sbytes}"||""]} \n 🔊 {stream.audioTags::exists["{stream.audioTags::join(' ')::upper}  "||"AUDIO  "]}{stream.audioChannels::first::=2.0["🔈 "||""]} {stream.audioChannels::first::=5.1["🔉 "||""]} {stream.audioChannels::first::=7.1["🔊 "||""]} {stream.audioChannels::exists["{stream.audioChannels::first}  "||""]} 🌍 {stream.uLanguageEmojis::exists["{stream.uLanguageEmojis::join(' ')}"||"MULTI"]} {stream.dubbed::istrue["  🎙️ DUB"||""]} {stream.subbed::istrue["  📝 SUB"||""]}\n 🔌 {stream.type::exists["{stream.type::upper}  "||""]} {stream.seeders::exists["🌱 {stream.seeders}  "||""]} {stream.repack::istrue["🛠️ REPACK  "||""]} {stream.age::exists["📅 {stream.age::upper}  "||""]} {stream.indexer::exists["🔍 {stream.indexer::truncate(15)::upper}"||""]}`
   }
+];
+
+const LANG_OPTS = [
+  {v:'English'},{v:'Spanish'},{v:'French'},{v:'German'},{v:'Italian'},
+  {v:'Portuguese'},{v:'Japanese'},{v:'Korean'},{v:'Chinese (Simplified)'},
+  {v:'Chinese (Traditional)'},{v:'Arabic'},{v:'Hindi'},{v:'Russian'},
+  {v:'Dutch'},{v:'Polish'},{v:'Turkish'}
 ];
 
 const DEFS = [
@@ -1249,6 +1256,21 @@ function render() {
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
+        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Language Preferences</div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px 6px;margin-bottom:12px">
+          ${LANG_OPTS.map(l => `
+          <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
+            <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
+            <span style="font-size:.77rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
+          </label>`).join('')}
+        </div>
+        <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:10px 12px;border-radius:9px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};margin-bottom:18px;transition:all .15s">
+          <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
+          <div>
+            <div style="font-size:.8rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
+            <div style="font-size:.68rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+          </div>
+        </label>
         ${debridInputs.length ? `
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Debrid Service</div>
         ${debridInputs.map(inp => `
@@ -1496,6 +1518,17 @@ document.addEventListener('DOMContentLoaded', () => {
       S.service = deriveService();
       saveState();
       syncNext();
+    }
+    if (e.target.dataset.action === 'toggle-lang') {
+      const v = e.target.value;
+      const i = S.langs.indexOf(v);
+      if (i >= 0) { if (S.langs.length > 1) S.langs.splice(i, 1); }
+      else S.langs.push(v);
+      saveState(); render();
+    }
+    if (e.target.dataset.action === 'toggle-lang-exclusive') {
+      S.langExclusive = e.target.checked;
+      saveState(); render();
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;
@@ -1760,6 +1793,10 @@ function pses() {
   const audPinnArr = (S.audio === 'limited' || ['samsung','firestick-hd','firestick-4kmax'].includes(dev)) ? [] : S.audio === 'dolby' ? [{ enabled:true, expression:"/* Audio Pinnacle */ audioTag(streams,'TrueHD','Atmos')" }] : [{ enabled:true, expression:"/* Audio Pinnacle */ audioTag(streams,'TrueHD','Atmos','DTS-HD MA','DTS:X','FLAC')" }];
   const pin1080Elite = { enabled:true, expression:"/* Elite 1080p REMUX Pin */ pin(releaseGroup(quality(resolution(streams,'BluRay REMUX'),'1080p'),'NTb','FLUX','KiNGS','NTG','BHDStudio','FraMeSToR','SiC','126811'),'top')" }, pinLQ = { enabled:true, expression:"/* LQ Pin Bottom */ pin(releaseGroup(streams,'YIFY','RARBG','EVO','YTS','PSA','MeGusta','Tigole'),'bottom')" }, seasonPSE = { enabled:true, expression:"/* ongoingSeasonPack */ ((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired < -1 or daysUntilNextEpisode >= 0)) ? seasonPack(streams,'onlySeasons') : []" };
 
+  if (S.langs && S.langs.length) {
+    out.push({ enabled:true, expression:`/* Language Preference — ${(S.langs||['English']).join('/')} */ language(streams,${(S.langs||['English']).map(l=>`'${l}'`).join(',')})` });
+  }
+
   if (res === '4k') {
     out.push({ enabled:true, expression:"/* Elite 4K REMUX Pin */ pin(releaseGroup(quality(resolution(streams,'BluRay REMUX'),'2160p'),'FraMeSToR','DON','FLUX','HIFI','playBD','BMF','QxR','EPSiLON','BLURANiUM','PmP'),'top')" }, pin1080Elite, pinLQ, seasonPSE);
     if (dv) out.push({ enabled:true, expression:"/* S-Tier 4K REMUX DV */ visualTag(quality(resolution(streams,'2160p'),'BluRay REMUX'),'DV','HDR+DV')" });
@@ -1780,7 +1817,7 @@ function build() {
       trusted: false, showChanges: true, addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name, presets: presets(), services: services(),
       excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
       excludedQualities: [], includedQualities: [], requiredQualities: [], preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
-      excludedLanguages: [], includedLanguages: ['English','Original','Dual Audio','Multi','Dubbed','Unknown'],
+      excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
       excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
       enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
       excludeCached: false, excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: false, excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
@@ -1791,7 +1828,13 @@ function build() {
       ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
       usePosterRedirectApi: true, usePosterServiceForMeta: true,
       maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
-      excludedStreamExpressions: eses(), includedStreamExpressions: [{ enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" }], preferredStreamExpressions: pses(),
+      excludedStreamExpressions: eses(), includedStreamExpressions: [
+        { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
+        ...(S.langExclusive && S.langs && S.langs.length ? [{
+          enabled: true,
+          expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
+        }] : [])
+      ], preferredStreamExpressions: pses(),
       sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
       deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
       dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -510,7 +510,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false };
 
 const FORMATTERS = [
   {
@@ -548,6 +548,13 @@ const FORMATTERS = [
     name: `{stream.resolution::exists["{stream.resolution::replace('2160p','🔴 4K')::replace('1440p','🟣 2K')::replace('1080p','🔵 1080P')::replace('720p','🟢 720P')::replace('480p','⚫ 480P')::replace('Unknown','📺 HD')}  "||"📺 HD  "]{service.cached::istrue["⚡ "||"⏳ "]}{service.shortName::exists["{service.shortName::upper}  "||"P2P  "]}{stream.library::istrue["📚  "||""]} {stream.title::exists["{stream.title::upper}"||""]} {stream.formattedSeasons::exists["{stream.formattedSeasons::upper}"||""]} {stream.formattedEpisodes::exists["{stream.formattedEpisodes::upper}"||""]}`,
     d: ` {service.cached::istrue["🚀 INSTANT  "||"⚠️ UNCACHED  "]}{stream.nSeScore::>=75["💎 ELITE  "||""]} {stream.seadexBest::istrue["⭐ BEST  "||""]} {stream.seadex::istrue["✅ SEADEX  "||""]} {stream.releaseGroup::~(?i)(epsilon|framestor|qxr|tigole|ntb|flux|d-z0n3|playbd|hifi|don|huno|bmf)["👑 PREMIER  "||""]} {stream.filename::~(?i)IMAX["🎞️ IMAX  "||""]} \n 🎬 {stream.quality::exists["{stream.quality::upper}  "||""]} {stream.encode::exists["{stream.encode::upper}  "||""]} {stream.visualTags::exists["{stream.visualTags::join(' ')::upper}  "||"SDR  "]} {stream.bitrate::exists["{stream.bitrate::sbitrate::upper}  "||""]} {stream.size::exists["{stream.size::sbytes}"||""]} \n 🔊 {stream.audioTags::exists["{stream.audioTags::join(' ')::upper}  "||"AUDIO  "]}{stream.audioChannels::first::=2.0["🔈 "||""]} {stream.audioChannels::first::=5.1["🔉 "||""]} {stream.audioChannels::first::=7.1["🔊 "||""]} {stream.audioChannels::exists["{stream.audioChannels::first}  "||""]} 🌍 {stream.uLanguageEmojis::exists["{stream.uLanguageEmojis::join(' ')}"||"MULTI"]} {stream.dubbed::istrue["  🎙️ DUB"||""]} {stream.subbed::istrue["  📝 SUB"||""]}\n 🔌 {stream.type::exists["{stream.type::upper}  "||""]} {stream.seeders::exists["🌱 {stream.seeders}  "||""]} {stream.repack::istrue["🛠️ REPACK  "||""]} {stream.age::exists["📅 {stream.age::upper}  "||""]} {stream.indexer::exists["🔍 {stream.indexer::truncate(15)::upper}"||""]}`
   }
+];
+
+const LANG_OPTS = [
+  {v:'English'},{v:'Spanish'},{v:'French'},{v:'German'},{v:'Italian'},
+  {v:'Portuguese'},{v:'Japanese'},{v:'Korean'},{v:'Chinese (Simplified)'},
+  {v:'Chinese (Traditional)'},{v:'Arabic'},{v:'Hindi'},{v:'Russian'},
+  {v:'Dutch'},{v:'Polish'},{v:'Turkish'}
 ];
 
 const DEFS = [
@@ -1249,6 +1256,21 @@ function render() {
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
+        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Language Preferences</div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px 6px;margin-bottom:12px">
+          ${LANG_OPTS.map(l => `
+          <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
+            <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
+            <span style="font-size:.77rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
+          </label>`).join('')}
+        </div>
+        <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:10px 12px;border-radius:9px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};margin-bottom:18px;transition:all .15s">
+          <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
+          <div>
+            <div style="font-size:.8rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
+            <div style="font-size:.68rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+          </div>
+        </label>
         ${debridInputs.length ? `
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Debrid Service</div>
         ${debridInputs.map(inp => `
@@ -1496,6 +1518,17 @@ document.addEventListener('DOMContentLoaded', () => {
       S.service = deriveService();
       saveState();
       syncNext();
+    }
+    if (e.target.dataset.action === 'toggle-lang') {
+      const v = e.target.value;
+      const i = S.langs.indexOf(v);
+      if (i >= 0) { if (S.langs.length > 1) S.langs.splice(i, 1); }
+      else S.langs.push(v);
+      saveState(); render();
+    }
+    if (e.target.dataset.action === 'toggle-lang-exclusive') {
+      S.langExclusive = e.target.checked;
+      saveState(); render();
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;
@@ -1760,6 +1793,10 @@ function pses() {
   const audPinnArr = (S.audio === 'limited' || ['samsung','firestick-hd','firestick-4kmax'].includes(dev)) ? [] : S.audio === 'dolby' ? [{ enabled:true, expression:"/* Audio Pinnacle */ audioTag(streams,'TrueHD','Atmos')" }] : [{ enabled:true, expression:"/* Audio Pinnacle */ audioTag(streams,'TrueHD','Atmos','DTS-HD MA','DTS:X','FLAC')" }];
   const pin1080Elite = { enabled:true, expression:"/* Elite 1080p REMUX Pin */ pin(releaseGroup(quality(resolution(streams,'BluRay REMUX'),'1080p'),'NTb','FLUX','KiNGS','NTG','BHDStudio','FraMeSToR','SiC','126811'),'top')" }, pinLQ = { enabled:true, expression:"/* LQ Pin Bottom */ pin(releaseGroup(streams,'YIFY','RARBG','EVO','YTS','PSA','MeGusta','Tigole'),'bottom')" }, seasonPSE = { enabled:true, expression:"/* ongoingSeasonPack */ ((queryType=='series' or queryType=='anime.series') and ongoingSeason and (daysSinceLastAired < -1 or daysUntilNextEpisode >= 0)) ? seasonPack(streams,'onlySeasons') : []" };
 
+  if (S.langs && S.langs.length) {
+    out.push({ enabled:true, expression:`/* Language Preference — ${(S.langs||['English']).join('/')} */ language(streams,${(S.langs||['English']).map(l=>`'${l}'`).join(',')})` });
+  }
+
   if (res === '4k') {
     out.push({ enabled:true, expression:"/* Elite 4K REMUX Pin */ pin(releaseGroup(quality(resolution(streams,'BluRay REMUX'),'2160p'),'FraMeSToR','DON','FLUX','HIFI','playBD','BMF','QxR','EPSiLON','BLURANiUM','PmP'),'top')" }, pin1080Elite, pinLQ, seasonPSE);
     if (dv) out.push({ enabled:true, expression:"/* S-Tier 4K REMUX DV */ visualTag(quality(resolution(streams,'2160p'),'BluRay REMUX'),'DV','HDR+DV')" });
@@ -1780,7 +1817,7 @@ function build() {
       trusted: false, showChanges: true, addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name, presets: presets(), services: services(),
       excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
       excludedQualities: [], includedQualities: [], requiredQualities: [], preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
-      excludedLanguages: [], includedLanguages: ['English','Original','Dual Audio','Multi','Dubbed','Unknown'],
+      excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
       excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
       enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
       excludeCached: false, excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: false, excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
@@ -1791,7 +1828,13 @@ function build() {
       ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
       usePosterRedirectApi: true, usePosterServiceForMeta: true,
       maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
-      excludedStreamExpressions: eses(), includedStreamExpressions: [{ enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" }], preferredStreamExpressions: pses(),
+      excludedStreamExpressions: eses(), includedStreamExpressions: [
+        { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
+        ...(S.langExclusive && S.langs && S.langs.length ? [{
+          enabled: true,
+          expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
+        }] : [])
+      ], preferredStreamExpressions: pses(),
       sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
       deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
       dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },


### PR DESCRIPTION
## Summary

Adds a **Language Preferences** section to the API Keys step (step 5).

- **16-language checkbox grid** — English, Spanish, French, German, Italian, Portuguese, Japanese, Korean, Chinese (Simplified/Traditional), Arabic, Hindi, Russian, Dutch, Polish, Turkish. Checked items highlight with the cyan accent. At least one language must remain selected.
- **Exclusive mode toggle** — when enabled, injects an ISE (`includedStreamExpressions`) that restricts results to only the selected languages, with Multi / Dual Audio / Original / Dubbed / Unknown always passing as fallbacks.
- **Language preference PSE** — injected at the top of the PSE stack whenever any language is selected, so preferred-language streams rank above resolution/quality tiers.
- **`includedLanguages`** in `build()` is now driven by `S.langs` instead of a hardcoded array, so selecting e.g. Spanish adds Spanish to the AIOStreams whitelist automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_