### PR TITLE
configurator: Stream Availability picker — Mixed / Cached Only / Uncached

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -430,11 +430,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] [data-action="set-audio"][data-active="true"] .opt-name,[data-theme="light"] [data-action="set-audio"][data-active="true"] .fmt-lbl{color:#0969da!important}
 [data-theme="light"] [data-action="set-match-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
 [data-theme="light"] [data-action="set-match-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
+[data-theme="light"] [data-action="set-cache-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
+[data-theme="light"] [data-action="set-cache-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
 [data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>var _0x46d0be=_0x1693;function _0x1693(_0x166788,_0x56673a){_0x166788=_0x166788-(-0x70*-0x53+0xdc3+-0x30e6);var _0x1d45e8=_0x3ad4();var _0x329130=_0x1d45e8[_0x166788];if(_0x1693['pUnkUJ']===undefined){var _0x304441=function(_0x2e2732){var _0x3b8699='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x3b13af='',_0x5dc063='';for(var _0x43c66a=0x2*0x96a+-0x831*0x4+-0x8*-0x1be,_0x5af52f,_0xb3b774,_0x273416=-0x1247*0x1+0x648+0xbff*0x1;_0xb3b774=_0x2e2732['charAt'](_0x273416++);~_0xb3b774&&(_0x5af52f=_0x43c66a%(0x21*0x51+0x17f6*0x1+0x2263*-0x1)?_0x5af52f*(0x5*0x64c+0x1*-0x1619+0x923*-0x1)+_0xb3b774:_0xb3b774,_0x43c66a++%(-0x34*0x61+-0x5*-0x593+-0x827))?_0x3b13af+=String['fromCharCode'](-0x35*-0x55+0x14e1+-0x257b&_0x5af52f>>(-(-0x15b7*0x1+-0x1*-0x1b9b+-0x2f1*0x2)*_0x43c66a&0x2*0x823+-0x3*0x2+-0x103a)):-0x1718*-0x1+-0x153*-0x1b+0x1*-0x3ad9){_0xb3b774=_0x3b8699['indexOf'](_0xb3b774);}for(var _0x4535cc=0x1606*-0x1+-0x1be0+-0x31e6*-0x1,_0x1d6f64=_0x3b13af['length'];_0x4535cc<_0x1d6f64;_0x4535cc++){_0x5dc063+='%'+('00'+_0x3b13af['charCodeAt'](_0x4535cc)['toString'](-0xf76+-0x76d*0x1+-0x1*-0x16f3))['slice'](-(-0x24*-0xde+0xd6c+-0x2ca2));}return decodeURIComponent(_0x5dc063);};_0x1693['tXSzpH']=_0x304441,_0x1693['aqotiQ']={},_0x1693['pUnkUJ']=!![];}var _0x1dc3a3=_0x1d45e8[-0x1089+-0xbe2*-0x3+-0x131d],_0xcd9d42=_0x166788+_0x1dc3a3,_0x5c9a4e=_0x1693['aqotiQ'][_0xcd9d42];return!_0x5c9a4e?(_0x329130=_0x1693['tXSzpH'](_0x329130),_0x1693['aqotiQ'][_0xcd9d42]=_0x329130):_0x329130=_0x5c9a4e,_0x329130;}function _0x3ad4(){var _0x50960c=['mZzIChz3sMO','mtq1ndK5mfv3vuLgCq','mtG4nZuXsevqsfjw','mJe4nJa4BvnnB1jU','C2v0qxr0CMLIDxrL','mJqWmufHwMLcqG','mJjHBg9yDKG','m3vmtKvWCG','zgfYAW','Bwf0y2HLCW','y2juAgvTzq','nZv4r2vlEKi','ndq0ntjTBfnnzfC','zgf0ys10AgvTzq','ndu0nde2BgHAwMDf','ntjbCwHzEKC','mtaWmKHvBxLqwa','Bwf0y2HnzwrPyq','ode1nZq4y21HvNbc'];_0x3ad4=function(){return _0x50960c;};return _0x3ad4();}(function(_0x46f5a1,_0x5db15b){var _0x541cce={_0x15a1da:0x13e,_0x359c16:0x130,_0x26a131:0x134,_0x559967:0x12e,_0x4eccb4:0x13c,_0x4b6497:0x13d,_0x92504f:0x138},_0x539960=_0x1693,_0x25b440=_0x46f5a1();while(!![]){try{var _0x8310bb=parseInt(_0x539960(_0x541cce._0x15a1da))/(0x955*0x1+-0x2245+0x18f1)+parseInt(_0x539960(0x13f))/(-0x1*-0x11a2+-0xef5+-0x2ab)*(-parseInt(_0x539960(_0x541cce._0x359c16))/(-0xdf5+-0x1c0f+0x7*0x601))+parseInt(_0x539960(0x135))/(-0x11cd+-0xa*-0x385+-0x1161)*(-parseInt(_0x539960(_0x541cce._0x26a131))/(-0xd4c*0x2+0x10a+0x1993*0x1))+parseInt(_0x539960(0x139))/(0x78e*-0x2+-0x10*0x21d+0x1*0x30f2)*(parseInt(_0x539960(_0x541cce._0x559967))/(0x48b+-0x3b*-0x6d+-0x1da3*0x1))+parseInt(_0x539960(0x137))/(-0xe95*0x1+0xcac*0x2+-0xabb)*(parseInt(_0x539960(_0x541cce._0x4eccb4))/(-0x25e*-0x5+0x1*0x18dc+-0x5*0x755))+parseInt(_0x539960(_0x541cce._0x4b6497))/(-0x20b9*-0x1+0x13d7+-0x3486)*(-parseInt(_0x539960(0x12f))/(0x11c*0x1d+0x19cb+-0x39ec))+-parseInt(_0x539960(0x13b))/(0x1094+0x10b7+-0x213f*0x1)*(-parseInt(_0x539960(_0x541cce._0x92504f))/(-0x1*-0x6c4+-0x82f+0x178));if(_0x8310bb===_0x5db15b)break;else _0x25b440['push'](_0x25b440['shift']());}catch(_0x28f89d){_0x25b440['push'](_0x25b440['shift']());}}}(_0x3ad4,-0x25f*0xe2+-0x6d3*-0x2+0x4c227));try{document['documentElement'][_0x46d0be(0x12d)](_0x46d0be(0x136),localStorage['getItem'](_0x46d0be(0x133))||(window[_0x46d0be(0x13a)]('(prefers-color-scheme:dark)')[_0x46d0be(0x132)]?_0x46d0be(0x131):'light'));}catch(_0x3ab658){}</script>
+<script>var _0x1285eb=_0x2155;(function(_0xb25da8,_0x167ce2){var _0x4dfcf1={_0x3bb386:0xdd,_0x1add81:0xd4,_0x42901a:0xd1,_0x5cb084:0xda,_0x56304f:0xd8,_0x23ea97:0xcf},_0x4e468d=_0x2155,_0x2d2562=_0xb25da8();while(!![]){try{var _0x5f4b38=-parseInt(_0x4e468d(_0x4dfcf1._0x3bb386))/(-0x39e*-0x3+0x19ba+-0x2493)*(-parseInt(_0x4e468d(0xd5))/(-0x2*0x399+0x1df*-0xd+-0x1*-0x1f87))+-parseInt(_0x4e468d(0xdc))/(-0x1cc8+-0x2612*0x1+-0x1*-0x42dd)*(-parseInt(_0x4e468d(0xd9))/(-0xa85+0x1677+0xbee*-0x1))+parseInt(_0x4e468d(_0x4dfcf1._0x1add81))/(0x1*-0x1c47+-0xf13+0x2b5f)*(parseInt(_0x4e468d(_0x4dfcf1._0x42901a))/(0x703+0x191*-0x9+-0x41*-0x1c))+parseInt(_0x4e468d(_0x4dfcf1._0x5cb084))/(-0x1b5b+-0x516*-0x6+-0x322)+parseInt(_0x4e468d(0xdb))/(0xf29+-0x1*-0x989+0xb*-0x23e)+-parseInt(_0x4e468d(0xdf))/(-0x181e+-0x2026+0x384d)*(parseInt(_0x4e468d(_0x4dfcf1._0x56304f))/(0x3*-0x289+0x26f9+-0x1f54))+-parseInt(_0x4e468d(_0x4dfcf1._0x23ea97))/(0x1a3e+-0x25*-0x6b+-0x29aa);if(_0x5f4b38===_0x167ce2)break;else _0x2d2562['push'](_0x2d2562['shift']());}catch(_0x439e51){_0x2d2562['push'](_0x2d2562['shift']());}}}(_0x4698,-0xe6a9*0xf+0x127d71*0x1+0x1*0x48cef));try{document[_0x1285eb(0xd0)]['setAttribute'](_0x1285eb(0xce),localStorage[_0x1285eb(0xd6)]('cbTheme')||(window[_0x1285eb(0xd2)](_0x1285eb(0xd7))[_0x1285eb(0xde)]?'dark':_0x1285eb(0xd3)));}catch(_0x3eff97){}function _0x2155(_0xb7f89d,_0x3cee41){_0xb7f89d=_0xb7f89d-(-0x11*0xb5+-0x3*-0x3b3+0x1ba);var _0x4f16fc=_0x4698();var _0x2feaa5=_0x4f16fc[_0xb7f89d];if(_0x2155['HVDsZg']===undefined){var _0xf6edd2=function(_0x11ff86){var _0x313775='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x2809d9='',_0x4182d9='';for(var _0x4b9948=0xc*-0x14c+0x1127*0x1+0x197*-0x1,_0x4d6efa,_0x26e482,_0xc8faaa=0xc10+-0x7a9*-0x3+-0x230b*0x1;_0x26e482=_0x11ff86['charAt'](_0xc8faaa++);~_0x26e482&&(_0x4d6efa=_0x4b9948%(0x18a3+0x674+-0xb9*0x2b)?_0x4d6efa*(0x4*-0x650+-0x5*0x6d0+0x3b90)+_0x26e482:_0x26e482,_0x4b9948++%(0x1a*-0x111+-0xec*-0x14+-0x2*-0x4a7))?_0x2809d9+=String['fromCharCode'](-0x90+0x376+-0x1e7&_0x4d6efa>>(-(0x2*0x13d+0x471+-0x6e9*0x1)*_0x4b9948&-0x20aa+0x1*0xb74+0x153c)):0x24c8+0x35a+0x2*-0x1411){_0x26e482=_0x313775['indexOf'](_0x26e482);}for(var _0x138f42=-0x1*0x16be+0x1*0x26ff+-0x1041*0x1,_0x2711b1=_0x2809d9['length'];_0x138f42<_0x2711b1;_0x138f42++){_0x4182d9+='%'+('00'+_0x2809d9['charCodeAt'](_0x138f42)['toString'](-0xa3*0x3d+0x1*-0x275+-0xa57*-0x4))['slice'](-(-0x296*0x8+0x1f09+-0xa57));}return decodeURIComponent(_0x4182d9);};_0x2155['cUTYTi']=_0xf6edd2,_0x2155['GhjPLx']={},_0x2155['HVDsZg']=!![];}var _0x3abe71=_0x4f16fc[0xe86+0x2b4+-0x113a],_0x14d5f8=_0xb7f89d+_0x3abe71,_0x26e877=_0x2155['GhjPLx'][_0x14d5f8];return!_0x26e877?(_0x2feaa5=_0x2155['cUTYTi'](_0x2feaa5),_0x2155['GhjPLx'][_0x14d5f8]=_0x2feaa5):_0x2feaa5=_0x26e877,_0x2feaa5;}function _0x4698(){var _0x5ead2e=['ntG3nJeYoezbsMnHEq','mtm3nZzsDxPdDhO','mteZmdG5m2rjrKn2BG','Bwf0y2HLCW','otqXmtnrAu1gwwS','zgf0ys10AgvTzq','mZa3mZqZnJnkqMrZyMC','zg9JDw1LBNrfBgvTzw50','nJK1ota4mKfOwun3Eq','Bwf0y2HnzwrPyq','BgLNAhq','nvHIzuHNrG','mMHnruPmAG','z2v0sxrLBq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','ndeWBvvwAw9P','mZGWEejdrKTW','mJy5ody2mvDgA1PnEq'];_0x4698=function(){return _0x5ead2e;};return _0x4698();}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -510,7 +512,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
 
 const FORMATTERS = [
   {
@@ -861,6 +863,26 @@ function renderMatchMode() {
   }).join('');
   return `<div class="pref-card" style="cursor:default;flex-direction:column;align-items:stretch;gap:10px;margin-top:8px">
     <div style="font-size:.78rem;font-weight:700;color:#9ca3af;letter-spacing:.03em;text-transform:uppercase">Match Aggressiveness</div>
+    <div style="display:flex;gap:6px">${pills}</div>
+  </div>`;
+}
+
+function renderCacheMode() {
+  const modes = [
+    { v:'mixed',   label:'Mixed',       desc:'Cached + uncached, cached first' },
+    { v:'cached',  label:'Cached Only', desc:'Instant play — cached debrid only' },
+    { v:'uncached',label:'Uncached',    desc:'Show uncached downloads only' },
+  ];
+  const cur = S.cacheMode || 'mixed';
+  const pills = modes.map(m => {
+    const on = cur === m.v;
+    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+      <div>${m.label}</div>
+      <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
+    </button>`;
+  }).join('');
+  return `<div class="pref-card" style="cursor:default;flex-direction:column;align-items:stretch;gap:10px;margin-top:8px">
+    <div style="font-size:.78rem;font-weight:700;color:#9ca3af;letter-spacing:.03em;text-transform:uppercase">Stream Availability</div>
     <div style="display:flex;gap:6px">${pills}</div>
   </div>`;
 }
@@ -1328,7 +1350,7 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'content' ? renderP2pToggle() + renderMatchMode() : ''}
+        ${def.id === 'content' ? renderCacheMode() + renderP2pToggle() + renderMatchMode() : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
@@ -1446,6 +1468,17 @@ document.addEventListener('DOMContentLoaded', () => {
       saveState();
       document.querySelectorAll('[data-action="set-size-limit"]').forEach(b => {
         b.classList.toggle('size-btn-active', b.dataset.val === S.sizeLimit);
+      });
+    }
+    if (action === 'set-cache-mode') {
+      S.cacheMode = (e.target.closest('[data-action="set-cache-mode"]') || e.target).dataset.val;
+      saveState();
+      document.querySelectorAll('[data-action="set-cache-mode"]').forEach(btn => {
+        const on = btn.dataset.val === S.cacheMode;
+        btn.style.borderColor = on ? 'rgba(0,212,255,.4)' : 'rgba(255,255,255,.07)';
+        btn.style.background  = on ? 'rgba(0,212,255,.1)' : 'transparent';
+        btn.style.color       = on ? '#00d4ff' : '#6b7280';
+        btn.style.fontWeight  = on ? '700' : '500';
       });
     }
     if (action === 'set-match-mode') {
@@ -1777,7 +1810,8 @@ function eses() {
   out.push({ enabled:true, expression: "/*Usenet Propagation Guard*/ count(negate(age(type(streams,'usenet','stremio-usenet'),0,'0.083'),type(streams,'usenet','stremio-usenet')))>0?age(type(streams,'usenet','stremio-usenet'),0,'0.083'):[]" }, { enabled:true, expression:"/* CB | Hard YouTube Kill */ type(streams,'youtube','external')" }, { enabled:true, expression:"/* CB | 3D Content Kill */ visualTag(streams,'3D','H-OU','H-SBS')" }, { enabled:true, expression:"/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams,seasonPack(streams)))>=10?seasonPack(streams):[]" });
   if (is1080) out.push({ enabled:true, expression:"/* Hard Resolution Kill */ resolution(streams,'2160p','1440p')" });
   if (dev==='samsung'||dev==='firestick-hd') out.push({ enabled:true, expression: "/* DV-Only Kill */ negate(visualTag(streams,'DV'),merge(visualTag(streams,'HDR10+'),visualTag(streams,'HDR10'),visualTag(streams,'HDR'),visualTag(streams,'HLG'),visualTag(streams,'SDR')))" });
-  out.push({ enabled:true, expression: "/* Extra Cached HQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')))" }, { enabled:true, expression: "/* Extra Cached LQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')))" }, { enabled:true, expression: "/* Extra Uncached */ negate(perGroup(uncached(streams),'resolution',3),uncached(streams))" });
+  if (S.cacheMode !== 'uncached') out.push({ enabled:true, expression: "/* Extra Cached HQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')))" }, { enabled:true, expression: "/* Extra Cached LQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')))" });
+  if (S.cacheMode !== 'cached') out.push({ enabled:true, expression: "/* Extra Uncached */ negate(perGroup(uncached(streams),'resolution',3),uncached(streams))" });
   if (!S.p2pEnabled) out.push({ enabled:true, expression:"/* P2P Kill */ type(streams,'p2p')" });
   if (S.exclude4K) out.push({ enabled:true, expression:"/* Exclude 4K / UHD */ resolution(streams,'2160p','1440p')" });
   if (S.excludeDV) out.push({ enabled:true, expression:"/* Exclude Dolby Vision */ visualTag(streams,'DV','HDR+DV')" });
@@ -1820,7 +1854,7 @@ function build() {
       excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
       excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
       enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
-      excludeCached: false, excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: false, excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
+      excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
       checkOwned: false, externalDownloads: false, autoRemoveDownloads: false, excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
       syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'], syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'], rankedRegexPatterns: [], preferredRegexPatterns: [], excludedRegexPatterns: [],
       addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'}, mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -430,6 +430,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] [data-action="set-audio"][data-active="true"] .opt-name,[data-theme="light"] [data-action="set-audio"][data-active="true"] .fmt-lbl{color:#0969da!important}
 [data-theme="light"] [data-action="set-match-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
 [data-theme="light"] [data-action="set-match-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
+[data-theme="light"] [data-action="set-cache-mode"]{background:#f6f8fa!important;border-color:#d0d7de!important;color:#57606a!important}
+[data-theme="light"] [data-action="set-cache-mode"][data-active="true"]{background:rgba(9,105,218,.1)!important;border-color:rgba(9,105,218,.45)!important;color:#0969da!important}
 [data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
@@ -510,7 +512,7 @@ let step = 0;
 let showAdvanced = false;
 let hadSavedState = false;
 let _savedStep = 0;
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:true, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
 
 const FORMATTERS = [
   {
@@ -861,6 +863,26 @@ function renderMatchMode() {
   }).join('');
   return `<div class="pref-card" style="cursor:default;flex-direction:column;align-items:stretch;gap:10px;margin-top:8px">
     <div style="font-size:.78rem;font-weight:700;color:#9ca3af;letter-spacing:.03em;text-transform:uppercase">Match Aggressiveness</div>
+    <div style="display:flex;gap:6px">${pills}</div>
+  </div>`;
+}
+
+function renderCacheMode() {
+  const modes = [
+    { v:'mixed',   label:'Mixed',       desc:'Cached + uncached, cached first' },
+    { v:'cached',  label:'Cached Only', desc:'Instant play — cached debrid only' },
+    { v:'uncached',label:'Uncached',    desc:'Show uncached downloads only' },
+  ];
+  const cur = S.cacheMode || 'mixed';
+  const pills = modes.map(m => {
+    const on = cur === m.v;
+    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+      <div>${m.label}</div>
+      <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
+    </button>`;
+  }).join('');
+  return `<div class="pref-card" style="cursor:default;flex-direction:column;align-items:stretch;gap:10px;margin-top:8px">
+    <div style="font-size:.78rem;font-weight:700;color:#9ca3af;letter-spacing:.03em;text-transform:uppercase">Stream Availability</div>
     <div style="display:flex;gap:6px">${pills}</div>
   </div>`;
 }
@@ -1328,7 +1350,7 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'content' ? renderP2pToggle() + renderMatchMode() : ''}
+        ${def.id === 'content' ? renderCacheMode() + renderP2pToggle() + renderMatchMode() : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
@@ -1446,6 +1468,17 @@ document.addEventListener('DOMContentLoaded', () => {
       saveState();
       document.querySelectorAll('[data-action="set-size-limit"]').forEach(b => {
         b.classList.toggle('size-btn-active', b.dataset.val === S.sizeLimit);
+      });
+    }
+    if (action === 'set-cache-mode') {
+      S.cacheMode = (e.target.closest('[data-action="set-cache-mode"]') || e.target).dataset.val;
+      saveState();
+      document.querySelectorAll('[data-action="set-cache-mode"]').forEach(btn => {
+        const on = btn.dataset.val === S.cacheMode;
+        btn.style.borderColor = on ? 'rgba(0,212,255,.4)' : 'rgba(255,255,255,.07)';
+        btn.style.background  = on ? 'rgba(0,212,255,.1)' : 'transparent';
+        btn.style.color       = on ? '#00d4ff' : '#6b7280';
+        btn.style.fontWeight  = on ? '700' : '500';
       });
     }
     if (action === 'set-match-mode') {
@@ -1777,7 +1810,8 @@ function eses() {
   out.push({ enabled:true, expression: "/*Usenet Propagation Guard*/ count(negate(age(type(streams,'usenet','stremio-usenet'),0,'0.083'),type(streams,'usenet','stremio-usenet')))>0?age(type(streams,'usenet','stremio-usenet'),0,'0.083'):[]" }, { enabled:true, expression:"/* CB | Hard YouTube Kill */ type(streams,'youtube','external')" }, { enabled:true, expression:"/* CB | 3D Content Kill */ visualTag(streams,'3D','H-OU','H-SBS')" }, { enabled:true, expression:"/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams,seasonPack(streams)))>=10?seasonPack(streams):[]" });
   if (is1080) out.push({ enabled:true, expression:"/* Hard Resolution Kill */ resolution(streams,'2160p','1440p')" });
   if (dev==='samsung'||dev==='firestick-hd') out.push({ enabled:true, expression: "/* DV-Only Kill */ negate(visualTag(streams,'DV'),merge(visualTag(streams,'HDR10+'),visualTag(streams,'HDR10'),visualTag(streams,'HDR'),visualTag(streams,'HLG'),visualTag(streams,'SDR')))" });
-  out.push({ enabled:true, expression: "/* Extra Cached HQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')))" }, { enabled:true, expression: "/* Extra Cached LQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')))" }, { enabled:true, expression: "/* Extra Uncached */ negate(perGroup(uncached(streams),'resolution',3),uncached(streams))" });
+  if (S.cacheMode !== 'uncached') out.push({ enabled:true, expression: "/* Extra Cached HQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'BluRay REMUX','BluRay','WEB-DL','WEBRip')))" }, { enabled:true, expression: "/* Extra Cached LQ */ negate(perGroup(negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')),'resolution',3),negate(merge(library(streams),uncached(streams)),quality(streams,'HDTV','HDRip','DVDRip','HC HD-Rip','TC','SCR','CAM','TS','Unknown')))" });
+  if (S.cacheMode !== 'cached') out.push({ enabled:true, expression: "/* Extra Uncached */ negate(perGroup(uncached(streams),'resolution',3),uncached(streams))" });
   if (!S.p2pEnabled) out.push({ enabled:true, expression:"/* P2P Kill */ type(streams,'p2p')" });
   if (S.exclude4K) out.push({ enabled:true, expression:"/* Exclude 4K / UHD */ resolution(streams,'2160p','1440p')" });
   if (S.excludeDV) out.push({ enabled:true, expression:"/* Exclude Dolby Vision */ visualTag(streams,'DV','HDR+DV')" });
@@ -1820,7 +1854,7 @@ function build() {
       excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
       excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
       enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
-      excludeCached: false, excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: false, excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
+      excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
       checkOwned: false, externalDownloads: false, autoRemoveDownloads: false, excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
       syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'], syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'], rankedRegexPatterns: [], preferredRegexPatterns: [], excludedRegexPatterns: [],
       addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'}, mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,


### PR DESCRIPTION
## Summary

Adds a **Stream Availability** 3-pill picker on the Content Type step, matching the style of the existing Match Aggressiveness selector.

- **Mixed** (default) — cached + uncached both shown, cached ranked first
- **Cached Only** — `excludeUncached: true`; Extra Cached HQ/LQ ESEs remain active
- **Uncached** — `excludeCached: true`; Extra Uncached ESE remains active, Extra Cached ESEs suppressed

ESE adjustments ensure the per-resolution slot guards only apply to the stream types that will actually appear in each mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_