### PR TITLE
configurator: language picker in collapsible dropdown

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -436,7 +436,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>var _0x4b3355=_0x4f1e;(function(_0x499981,_0x379d2b){var _0x327204={_0x22e0e2:0xc7,_0x5558f1:0xca,_0x327267:0xd1,_0x24c64c:0xd3,_0x102b5c:0xd8,_0x3b0c9f:0xd2,_0x2d1155:0xd5},_0xa6eb65=_0x4f1e,_0x5aa20a=_0x499981();while(!![]){try{var _0x4399bd=-parseInt(_0xa6eb65(_0x327204._0x22e0e2))/(-0xb6e*0x1+0x89*-0x33+0x26ba)*(parseInt(_0xa6eb65(_0x327204._0x5558f1))/(-0x1299+-0x1be+0x1459))+-parseInt(_0xa6eb65(_0x327204._0x327267))/(-0x54b*0x1+0x80a*-0x2+0x1562)*(parseInt(_0xa6eb65(_0x327204._0x24c64c))/(0x1ca*-0x5+-0x36a*0x1+0xc60))+-parseInt(_0xa6eb65(_0x327204._0x102b5c))/(-0x2070+-0x2672+-0x46e7*-0x1)+parseInt(_0xa6eb65(0xc5))/(0x225a+0x12ef+-0x3543)*(parseInt(_0xa6eb65(_0x327204._0x3b0c9f))/(0x363*-0x9+0x12d2+0xbb0))+-parseInt(_0xa6eb65(0xd6))/(0x166*0x11+-0x12eb+-0x4d3)+-parseInt(_0xa6eb65(0xc6))/(0x2*-0x9c7+-0x1ce7+-0x102a*-0x3)+parseInt(_0xa6eb65(_0x327204._0x2d1155))/(0x94*0x9+0x2408+-0x2932);if(_0x4399bd===_0x379d2b)break;else _0x5aa20a['push'](_0x5aa20a['shift']());}catch(_0x3d11d2){_0x5aa20a['push'](_0x5aa20a['shift']());}}}(_0x4201,0x1d525*-0x2+0x1*0xc7328+0x7a27*0x4));function _0x4f1e(_0x21bd20,_0xe604cc){_0x21bd20=_0x21bd20-(0x139*-0xd+0x1*-0x256b+0x3615);var _0x584cc0=_0x4201();var _0x280d3c=_0x584cc0[_0x21bd20];if(_0x4f1e['AcJLLq']===undefined){var _0x41f5c2=function(_0x2d9074){var _0xf605f3='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0xdbe828='',_0x224f0e='';for(var _0x293ac2=-0x25f+0x18d4+-0x1*0x1675,_0x1c1106,_0x5a1eb4,_0x635551=-0x1*0x95f+-0x1b99+-0xe*-0x2a4;_0x5a1eb4=_0x2d9074['charAt'](_0x635551++);~_0x5a1eb4&&(_0x1c1106=_0x293ac2%(0xde8+0x1*-0xef+-0xcf5)?_0x1c1106*(0x2*-0x1115+-0x1336+0xd0*0x42)+_0x5a1eb4:_0x5a1eb4,_0x293ac2++%(-0x56b+0x179a+-0x122b))?_0xdbe828+=String['fromCharCode'](0x80f+0x2583+-0x2c93&_0x1c1106>>(-(-0x14bb+0x135*-0x16+0x2f4b)*_0x293ac2&-0x7*0x3a1+-0x2519+0x2*0x1f43)):0x1725+0x1d9*-0x2+0x1373*-0x1){_0x5a1eb4=_0xf605f3['indexOf'](_0x5a1eb4);}for(var _0x3d4de4=-0x907*0x1+0x537+0x3d0,_0x5ca415=_0xdbe828['length'];_0x3d4de4<_0x5ca415;_0x3d4de4++){_0x224f0e+='%'+('00'+_0xdbe828['charCodeAt'](_0x3d4de4)['toString'](-0x1103+0x1*-0x18ee+0x2a01))['slice'](-(-0x641*0x3+-0x1269*0x1+0x252e));}return decodeURIComponent(_0x224f0e);};_0x4f1e['HOCoLg']=_0x41f5c2,_0x4f1e['SNYfYa']={},_0x4f1e['AcJLLq']=!![];}var _0x4a8939=_0x584cc0[-0xeb6+0x1c92*-0x1+0x2b48],_0xad09f4=_0x21bd20+_0x4a8939,_0x18fd08=_0x4f1e['SNYfYa'][_0xad09f4];return!_0x18fd08?(_0x280d3c=_0x4f1e['HOCoLg'](_0x280d3c),_0x4f1e['SNYfYa'][_0xad09f4]=_0x280d3c):_0x280d3c=_0x18fd08,_0x280d3c;}function _0x4201(){var _0x2ce06e=['zg9JDw1LBNrfBgvTzw50','z2v0sxrLBq','zgf0ys10AgvTzq','y2juAgvTzq','Bwf0y2HnzwrPyq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','m2XHzM1PBW','mtaWmJuWnurkz3rMBW','mtm0nteWnfHrDwPItq','C2v0qxr0CMLIDxrL','mJK0nJuWmJbXz2zgwNq','mtmXmJi4mgPMq0n0BG','Bwf0y2HLCW','ndK1mteWmhfLsevqEa','ndHLr1zlvNq','mteYndGXndzUsgHiy3O','mvnjAfHqDW','BgLNAhq','zgfYAW','mtmWmJiWnLbVBxPgwq'];_0x4201=function(){return _0x2ce06e;};return _0x4201();}try{document[_0x4b3355(0xcb)][_0x4b3355(0xd4)](_0x4b3355(0xcd),localStorage[_0x4b3355(0xcc)](_0x4b3355(0xce))||(window[_0x4b3355(0xcf)](_0x4b3355(0xd0))[_0x4b3355(0xd7)]?_0x4b3355(0xc9):_0x4b3355(0xc8)));}catch(_0x296549){}</script>
+<script>var _0x3e4783=_0x6a26;(function(_0xf95207,_0xcef585){var _0x533271={_0x177e32:0x175,_0x1a332d:0x17c,_0x48adef:0x170,_0xb31208:0x173,_0x43775f:0x172,_0x38081f:0x178,_0x470abb:0x17d},_0x42a042=_0x6a26,_0x205106=_0xf95207();while(!![]){try{var _0x3c58fb=-parseInt(_0x42a042(_0x533271._0x177e32))/(0x2033*0x1+0xfae*0x1+-0x2fe0)*(-parseInt(_0x42a042(0x174))/(-0x1*0x180f+0x3d*-0xa3+0x3ee8))+-parseInt(_0x42a042(_0x533271._0x1a332d))/(-0x9e4+-0x11*-0x5b+0x3dc)*(parseInt(_0x42a042(_0x533271._0x48adef))/(-0xe5*0x7+0x1294+-0xc4d))+-parseInt(_0x42a042(0x16e))/(-0x521+-0x171b+-0x96b*-0x3)+-parseInt(_0x42a042(_0x533271._0xb31208))/(-0x2*0x4af+0x1d*-0x14b+0x2ee3)+-parseInt(_0x42a042(0x171))/(-0x3ea+-0x124f+-0x1640*-0x1)+parseInt(_0x42a042(_0x533271._0x43775f))/(0x1*-0x114d+0x7b1*-0x3+0x2868)*(-parseInt(_0x42a042(_0x533271._0x38081f))/(-0xc2c+-0xb2*-0x1c+-0x743*0x1))+parseInt(_0x42a042(_0x533271._0x470abb))/(-0x58c*-0x2+0xdca+-0x18d8);if(_0x3c58fb===_0xcef585)break;else _0x205106['push'](_0x205106['shift']());}catch(_0x146bcc){_0x205106['push'](_0x205106['shift']());}}}(_0xa413,-0x56*-0xf95+0xf8748+-0x86b7*0xf));function _0x6a26(_0x47348d,_0x5bcabc){_0x47348d=_0x47348d-(-0x2+-0x2235+0x23a4);var _0x3dfc1a=_0xa413();var _0x5e5f4a=_0x3dfc1a[_0x47348d];if(_0x6a26['kbiopU']===undefined){var _0x2e914e=function(_0x25b28f){var _0x526701='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x3bd43f='',_0x2ce59d='';for(var _0x239da0=-0xde6*0x2+0x108a+0x106*0xb,_0x37102d,_0x227d10,_0x36233c=0x1189+-0x1c0f+0xa86;_0x227d10=_0x25b28f['charAt'](_0x36233c++);~_0x227d10&&(_0x37102d=_0x239da0%(-0xb52+-0x2*-0xfe6+-0x1476)?_0x37102d*(0x16*-0x185+-0xc61+-0x2e0f*-0x1)+_0x227d10:_0x227d10,_0x239da0++%(0x1*-0x2337+0x2186+0x13*0x17))?_0x3bd43f+=String['fromCharCode'](-0x986+-0xf05+-0x1d3*-0xe&_0x37102d>>(-(0x237+0x1881+0x1*-0x1ab6)*_0x239da0&0x2611+0x2*0x53+-0x11b*0x23)):0x1e7*-0x12+0x4c1+0x1*0x1d7d){_0x227d10=_0x526701['indexOf'](_0x227d10);}for(var _0x1aa414=0x1549*-0x1+0xf92+-0x4d*-0x13,_0x2e6ae0=_0x3bd43f['length'];_0x1aa414<_0x2e6ae0;_0x1aa414++){_0x2ce59d+='%'+('00'+_0x3bd43f['charCodeAt'](_0x1aa414)['toString'](0xd64+0x12eb+-0x27b*0xd))['slice'](-(0xccb*0x1+-0x1*0x59f+-0x72a));}return decodeURIComponent(_0x2ce59d);};_0x6a26['YHYdRN']=_0x2e914e,_0x6a26['ZHsubF']={},_0x6a26['kbiopU']=!![];}var _0x125383=_0x3dfc1a[-0x21da*0x1+0x1242+0x8*0x1f3],_0x49147=_0x47348d+_0x125383,_0x4e7240=_0x6a26['ZHsubF'][_0x49147];return!_0x4e7240?(_0x5e5f4a=_0x6a26['YHYdRN'](_0x5e5f4a),_0x6a26['ZHsubF'][_0x49147]=_0x5e5f4a):_0x5e5f4a=_0x4e7240,_0x5e5f4a;}function _0xa413(){var _0x1afb68=['ndG0nJiZmNfsqLPbAq','mtyXndKWn0TzwgjdAW','mJuYmeLnywvuAq','ntu1nZuZmfHpBK5dBa','nZbXvK10CwW','mJe2mZvgywnxu0m','C2v0qxr0CMLIDxrL','Bwf0y2HnzwrPyq','mtm5nJHjD0nxt3G','zgfYAW','y2juAgvTzq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','m2HABejrDq','mZC4mdaXotbHze1fyxO','Bwf0y2HLCW','z2v0sxrLBq','nde4mJe0nurkqwTKra','zgf0ys10AgvTzq'];_0xa413=function(){return _0x1afb68;};return _0xa413();}try{document['documentElement'][_0x3e4783(0x176)](_0x3e4783(0x16f),localStorage[_0x3e4783(0x16d)](_0x3e4783(0x17a))||(window[_0x3e4783(0x177)](_0x3e4783(0x17b))[_0x3e4783(0x17e)]?_0x3e4783(0x179):'light'));}catch(_0x5503a9){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -1278,21 +1278,34 @@ function render() {
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
-        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Language Preferences</div>
-        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px 6px;margin-bottom:12px">
-          ${LANG_OPTS.map(l => `
-          <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
-            <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
-            <span style="font-size:.77rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
-          </label>`).join('')}
-        </div>
-        <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:10px 12px;border-radius:9px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};margin-bottom:18px;transition:all .15s">
-          <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
-          <div>
-            <div style="font-size:.8rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
-            <div style="font-size:.68rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+        <details id="langDetails" style="margin-bottom:16px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
+          <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 14px;background:rgba(255,255,255,.03);user-select:none" onclick="this.parentElement.querySelector('.lang-chevron').style.transform=this.parentElement.open?'rotate(0deg)':'rotate(90deg)'">
+            <div style="display:flex;align-items:center;gap:10px">
+              <span style="font-size:.74rem;font-weight:700;color:#9ca3af;text-transform:uppercase;letter-spacing:.06em">Language Preferences</span>
+              <span style="font-size:.7rem;color:#00d4ff;font-weight:600">${(S.langs||['English']).join(' · ')}</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:8px">
+              ${S.langExclusive ? `<span style="font-size:.62rem;font-weight:700;padding:2px 6px;border-radius:4px;background:rgba(0,212,255,.12);color:#00d4ff;border:1px solid rgba(0,212,255,.25)">EXCLUSIVE</span>` : ''}
+              <span class="lang-chevron" style="font-size:.7rem;color:#374151;transition:transform .2s;transform:rotate(0deg)">›</span>
+            </div>
+          </summary>
+          <div style="padding:12px 14px;border-top:1px solid rgba(255,255,255,.05)">
+            <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:7px 6px;margin-bottom:12px">
+              ${LANG_OPTS.map(l => `
+              <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
+                <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
+                <span style="font-size:.75rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
+              </label>`).join('')}
+            </div>
+            <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:9px 11px;border-radius:8px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};transition:all .15s">
+              <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
+              <div>
+                <div style="font-size:.79rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
+                <div style="font-size:.67rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+              </div>
+            </label>
           </div>
-        </label>
+        </details>
         ${debridInputs.length ? `
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Debrid Service</div>
         ${debridInputs.map(inp => `
@@ -1557,11 +1570,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const i = S.langs.indexOf(v);
       if (i >= 0) { if (S.langs.length > 1) S.langs.splice(i, 1); }
       else S.langs.push(v);
-      saveState(); render();
+      saveState();
+      const wasOpen = document.getElementById('langDetails')?.open;
+      render();
+      if (wasOpen) { const d = document.getElementById('langDetails'); if (d) d.open = true; }
     }
     if (e.target.dataset.action === 'toggle-lang-exclusive') {
       S.langExclusive = e.target.checked;
-      saveState(); render();
+      saveState();
+      const wasOpen = document.getElementById('langDetails')?.open;
+      render();
+      if (wasOpen) { const d = document.getElementById('langDetails'); if (d) d.open = true; }
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -1278,21 +1278,34 @@ function render() {
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
-        <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Language Preferences</div>
-        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px 6px;margin-bottom:12px">
-          ${LANG_OPTS.map(l => `
-          <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
-            <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
-            <span style="font-size:.77rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
-          </label>`).join('')}
-        </div>
-        <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:10px 12px;border-radius:9px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};margin-bottom:18px;transition:all .15s">
-          <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
-          <div>
-            <div style="font-size:.8rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
-            <div style="font-size:.68rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+        <details id="langDetails" style="margin-bottom:16px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
+          <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 14px;background:rgba(255,255,255,.03);user-select:none" onclick="this.parentElement.querySelector('.lang-chevron').style.transform=this.parentElement.open?'rotate(0deg)':'rotate(90deg)'">
+            <div style="display:flex;align-items:center;gap:10px">
+              <span style="font-size:.74rem;font-weight:700;color:#9ca3af;text-transform:uppercase;letter-spacing:.06em">Language Preferences</span>
+              <span style="font-size:.7rem;color:#00d4ff;font-weight:600">${(S.langs||['English']).join(' · ')}</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:8px">
+              ${S.langExclusive ? `<span style="font-size:.62rem;font-weight:700;padding:2px 6px;border-radius:4px;background:rgba(0,212,255,.12);color:#00d4ff;border:1px solid rgba(0,212,255,.25)">EXCLUSIVE</span>` : ''}
+              <span class="lang-chevron" style="font-size:.7rem;color:#374151;transition:transform .2s;transform:rotate(0deg)">›</span>
+            </div>
+          </summary>
+          <div style="padding:12px 14px;border-top:1px solid rgba(255,255,255,.05)">
+            <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:7px 6px;margin-bottom:12px">
+              ${LANG_OPTS.map(l => `
+              <label style="display:flex;align-items:center;gap:7px;cursor:pointer;padding:7px 9px;border-radius:8px;border:1px solid ${S.langs.includes(l.v)?'rgba(0,212,255,.4)':'rgba(255,255,255,.06)'};background:${S.langs.includes(l.v)?'rgba(0,212,255,.07)':'transparent'};transition:all .15s">
+                <input type="checkbox" value="${l.v}" ${S.langs.includes(l.v)?'checked':''} data-action="toggle-lang" style="accent-color:#00d4ff;flex-shrink:0">
+                <span style="font-size:.75rem;color:${S.langs.includes(l.v)?'#e6edf3':'#8b949e'};font-weight:${S.langs.includes(l.v)?'600':'400'}">${l.v}</span>
+              </label>`).join('')}
+            </div>
+            <label style="display:flex;align-items:center;gap:9px;cursor:pointer;padding:9px 11px;border-radius:8px;border:1px solid ${S.langExclusive?'rgba(0,212,255,.35)':'rgba(255,255,255,.06)'};background:${S.langExclusive?'rgba(0,212,255,.06)':'transparent'};transition:all .15s">
+              <input type="checkbox" ${S.langExclusive?'checked':''} data-action="toggle-lang-exclusive" style="accent-color:#00d4ff;flex-shrink:0">
+              <div>
+                <div style="font-size:.79rem;font-weight:700;color:${S.langExclusive?'#e6edf3':'#8b949e'}">Exclusive mode</div>
+                <div style="font-size:.67rem;color:#4b5563;margin-top:1px">Only include streams in selected languages — Multi, Dubbed &amp; Original always pass</div>
+              </div>
+            </label>
           </div>
-        </label>
+        </details>
         ${debridInputs.length ? `
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Debrid Service</div>
         ${debridInputs.map(inp => `
@@ -1557,11 +1570,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const i = S.langs.indexOf(v);
       if (i >= 0) { if (S.langs.length > 1) S.langs.splice(i, 1); }
       else S.langs.push(v);
-      saveState(); render();
+      saveState();
+      const wasOpen = document.getElementById('langDetails')?.open;
+      render();
+      if (wasOpen) { const d = document.getElementById('langDetails'); if (d) d.open = true; }
     }
     if (e.target.dataset.action === 'toggle-lang-exclusive') {
       S.langExclusive = e.target.checked;
-      saveState(); render();
+      saveState();
+      const wasOpen = document.getElementById('langDetails')?.open;
+      render();
+      if (wasOpen) { const d = document.getElementById('langDetails'); if (d) d.open = true; }
     }
     if (e.target.dataset.action === 'update-host') {
       S.instanceHost = e.target.value;


### PR DESCRIPTION
## Summary

Collapses the language checkbox grid into a `<details>/<summary>` dropdown, matching the style of other collapsible sections in the configurator.

- Summary row shows selected language(s) as a live preview (e.g. `English · Spanish`)
- **EXCLUSIVE** badge appears in the summary when exclusive mode is on
- Dropdown stays open while ticking checkboxes — `open` state is captured before `render()` and restored after

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_