### PR TITLE
configurator: v1.9 — 10 UX polish items

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -316,10 +316,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .step-unit{display:flex;flex-direction:column;align-items:center;flex:1;position:relative;min-width:0}
 .step-unit:not(:first-child)::before{content:'';position:absolute;top:50%;transform:translateY(-50%);right:50%;width:100%;height:1px;background:#2d333b;z-index:0;transition:background .3s}
 .step-unit.done::before{background:rgba(0,212,255,.4)}
-.step-bub{width:10px;height:10px;border-radius:50%;position:relative;z-index:1;flex-shrink:0;transition:all .25s}
+.step-bub{width:10px;height:10px;border-radius:50%;position:relative;z-index:1;flex-shrink:0;transition:all .25s;display:grid;place-items:center;font-size:0;color:transparent}
 .step-pending .step-bub{background:#2d333b}
 .step-active .step-bub{background:#00d4ff;box-shadow:0 0 10px rgba(0,212,255,.7);transform:scale(1.4)}
-.step-done .step-bub{background:#00d4ff;opacity:.45}
+.step-done .step-bub{width:14px;height:14px;background:#00d4ff;font-size:8px;color:#001a24;font-weight:900;line-height:1}
 .step-lbl{font-size:.52rem;font-weight:600;color:#374151;margin-top:4px;text-align:center;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:36px}
 .step-active .step-lbl{color:#00d4ff;font-weight:700}
 .step-done .step-lbl{color:#4b7c93}
@@ -467,7 +467,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
 </style>
-<script>function _0x7810(){var _0x4d6377=['z2v0sxrLBq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','zg9JDw1LBNrfBgvTzw50','odmYntC5v2TWsuHA','mJe0mtq4nZzWywvHEeW','mteWyK9xzev4','mZa5ndaYB0PowMTA','nde0mdeYm1vzCxr3wa','mZK3mteWnxH5DuDSEG','mZi4qNDgvKfv','zgf0ys10AgvTzq','mZjvwwzqwwu','nenyq3D1ra','nKnYDMLdCq','mJCXodzYt01WsM0','zgfYAW','Bwf0y2HLCW','mZC4mZmYnvjkvwrYsa'];_0x7810=function(){return _0x4d6377;};return _0x7810();}function _0x5516(_0x1c22ee,_0x401652){_0x1c22ee=_0x1c22ee-(-0x25a0+-0x7*0x556+0x262b*0x2);var _0x3d8416=_0x7810();var _0x5d905f=_0x3d8416[_0x1c22ee];if(_0x5516['IVxIoh']===undefined){var _0x1c7d96=function(_0x2ad613){var _0x44cd03='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x1b0d05='',_0x47585c='';for(var _0x226875=0xd*0xbe+-0x8*-0x20c+-0x1a06,_0x1777c8,_0x14114a,_0x173f31=-0x2c5*-0x7+-0xd31*0x1+-0x632*0x1;_0x14114a=_0x2ad613['charAt'](_0x173f31++);~_0x14114a&&(_0x1777c8=_0x226875%(0x145b+-0x10*-0x16d+-0x1*0x2b27)?_0x1777c8*(0x2*-0x116f+-0xd57+-0x33b*-0xf)+_0x14114a:_0x14114a,_0x226875++%(0x1f58+0x127c*0x2+-0x444c))?_0x1b0d05+=String['fromCharCode'](0x1eac+0x24bb+-0x4268&_0x1777c8>>(-(0x1*0x2397+0x324+-0x26b9)*_0x226875&0x5ed+-0x385+-0x3d*0xa)):-0xa8+0x3a0+-0x2f8){_0x14114a=_0x44cd03['indexOf'](_0x14114a);}for(var _0x367f1e=0x5*0xb3+-0x48e*0x3+0xa2b,_0x243627=_0x1b0d05['length'];_0x367f1e<_0x243627;_0x367f1e++){_0x47585c+='%'+('00'+_0x1b0d05['charCodeAt'](_0x367f1e)['toString'](0xaba+0x2c5*0x1+0xd6f*-0x1))['slice'](-(0x1205*-0x1+0xef4+-0x313*-0x1));}return decodeURIComponent(_0x47585c);};_0x5516['xWVLzm']=_0x1c7d96,_0x5516['MYadCX']={},_0x5516['IVxIoh']=!![];}var _0x828fd=_0x3d8416[0x1546+-0x1*-0x2217+-0x375d*0x1],_0x892882=_0x1c22ee+_0x828fd,_0x1b7a0=_0x5516['MYadCX'][_0x892882];return!_0x1b7a0?(_0x5d905f=_0x5516['xWVLzm'](_0x5d905f),_0x5516['MYadCX'][_0x892882]=_0x5d905f):_0x5d905f=_0x1b7a0,_0x5d905f;}var _0x42796b=_0x5516;(function(_0xf32f18,_0x5d447e){var _0x2050b4={_0x26f0e8:0x15e,_0x56dd09:0x16d,_0x5b3b0e:0x15c,_0x5b6c56:0x15d,_0x413031:0x168,_0x234729:0x165},_0x2cb675=_0x5516,_0x1c3128=_0xf32f18();while(!![]){try{var _0x51aa79=-parseInt(_0x2cb675(_0x2050b4._0x26f0e8))/(-0x10e9+0x1362+-0x278)*(parseInt(_0x2cb675(_0x2050b4._0x56dd09))/(-0x1407+0xd8*-0x2b+0xd*0x455))+-parseInt(_0x2cb675(0x169))/(-0xa1c*-0x1+-0xee*-0x1+-0xb07)*(parseInt(_0x2cb675(_0x2050b4._0x5b3b0e))/(-0x16*0x18a+-0x14cf+-0x36af*-0x1))+parseInt(_0x2cb675(0x16a))/(-0xe44*-0x1+-0x1af8+0xcb9*0x1)*(parseInt(_0x2cb675(_0x2050b4._0x5b6c56))/(-0x621+-0x2599+0x2bc0))+-parseInt(_0x2cb675(0x161))/(0x3*-0x892+0x1153+-0x86a*-0x1)+-parseInt(_0x2cb675(0x16b))/(-0x2305+0x1992+-0x97b*-0x1)*(-parseInt(_0x2cb675(_0x2050b4._0x413031))/(0xe*-0x227+0x10*-0x1c1+0x3a3b))+-parseInt(_0x2cb675(0x167))/(0xabd*-0x3+0x1ac8+-0x1*-0x579)*(parseInt(_0x2cb675(_0x2050b4._0x234729))/(-0x1*0xae3+-0x106b*-0x1+-0x1*0x57d))+parseInt(_0x2cb675(0x166))/(-0xda2+0x1803+0xa55*-0x1);if(_0x51aa79===_0x5d447e)break;else _0x1c3128['push'](_0x1c3128['shift']());}catch(_0xe60b53){_0x1c3128['push'](_0x1c3128['shift']());}}}(_0x7810,0xbd7fa+0x379b4+-0x31bd1));try{document[_0x42796b(0x164)]['setAttribute'](_0x42796b(0x16c),localStorage[_0x42796b(0x162)]('cbTheme')||(window['matchMedia'](_0x42796b(0x163))[_0x42796b(0x160)]?_0x42796b(0x15f):'light'));}catch(_0x3ca02c){}</script>
+<script>var _0x561c3e=_0x2424;function _0x251a(){var _0x3dbe3f=['Bwf0y2HnzwrPyq','y2juAgvTzq','zgf0ys10AgvTzq','mtiXmdaYmePMA2fRAq','nZGZoe9yC2nPqW','nde5mdCWnNLir0LhsW','mti5mJiWog54BwLrsa','zgfYAW','nZrMrMrwrKK','Bwf0y2HLCW','oePJve9osa','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','C2v0qxr0CMLIDxrL','mJe0ndyZmwHpC1HpBG','ndy3mtmWmgDTtvbKDa','BgLNAhq','mtaYodiWmJnjzejPDu8'];_0x251a=function(){return _0x3dbe3f;};return _0x251a();}function _0x2424(_0x573a69,_0x158e6b){_0x573a69=_0x573a69-(0x18d+0xbbc+-0x3d*0x31);var _0x2324b7=_0x251a();var _0x3b61be=_0x2324b7[_0x573a69];if(_0x2424['hIRtzj']===undefined){var _0x478391=function(_0x4f919b){var _0x33c14c='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0xf9cfde='',_0x2c5855='';for(var _0x30de48=-0x6*-0x552+0x1*0x1fcd+-0x5cb*0xb,_0xa6e2e8,_0x56908d,_0x103e78=0x1*0xb3e+-0x29*-0xcb+-0x2bc1;_0x56908d=_0x4f919b['charAt'](_0x103e78++);~_0x56908d&&(_0xa6e2e8=_0x30de48%(-0x2414+-0x9f+-0x3*-0xc3d)?_0xa6e2e8*(-0x1f15+0x3*0x2f3+0x59f*0x4)+_0x56908d:_0x56908d,_0x30de48++%(0x23f2+-0xb38+-0xc5b*0x2))?_0xf9cfde+=String['fromCharCode'](0x53*0x41+-0xb7f+-0x895&_0xa6e2e8>>(-(-0x462+0x7*-0x2ed+0x18df)*_0x30de48&-0x1433*0x1+0x12c8+0x171)):0xc*0xe1+0x1*0xa57+-0x14e3){_0x56908d=_0x33c14c['indexOf'](_0x56908d);}for(var _0x143f4e=-0x17d2+-0x26c7+-0x3e99*-0x1,_0x3bbf76=_0xf9cfde['length'];_0x143f4e<_0x3bbf76;_0x143f4e++){_0x2c5855+='%'+('00'+_0xf9cfde['charCodeAt'](_0x143f4e)['toString'](0x11*0x1b3+-0x1556*-0x1+-0x3229*0x1))['slice'](-(-0x1*0x815+0x1562+-0xd4b));}return decodeURIComponent(_0x2c5855);};_0x2424['jjcoZf']=_0x478391,_0x2424['frUIHi']={},_0x2424['hIRtzj']=!![];}var _0x5ac26b=_0x2324b7[-0x3*0x54f+0xaf9+0x4f4],_0x5005b4=_0x573a69+_0x5ac26b,_0x460041=_0x2424['frUIHi'][_0x5005b4];return!_0x460041?(_0x3b61be=_0x2424['jjcoZf'](_0x3b61be),_0x2424['frUIHi'][_0x5005b4]=_0x3b61be):_0x3b61be=_0x460041,_0x3b61be;}(function(_0x38a87e,_0x4785f5){var _0x3cd5ee={_0x4478c8:0x1a9,_0xf7af09:0x1ab,_0x506da6:0x1a2,_0x181760:0x1a8,_0x3896b0:0x1a4},_0x17db59=_0x2424,_0x24d9a5=_0x38a87e();while(!![]){try{var _0x320ce1=-parseInt(_0x17db59(0x19c))/(0x4a4+-0x1032+0xb8f)*(-parseInt(_0x17db59(_0x3cd5ee._0x4478c8))/(0xaf9+0x127f+-0x1d76))+-parseInt(_0x17db59(0x1a1))/(0x2065+0x3f*-0x57+0xaf9*-0x1)+parseInt(_0x17db59(_0x3cd5ee._0xf7af09))/(-0x18b*0x17+0x1a1f+-0x962*-0x1)+parseInt(_0x17db59(_0x3cd5ee._0x506da6))/(0x1fda+0x263e*-0x1+0x669)+parseInt(_0x17db59(0x1aa))/(0x35*-0x4c+-0x256+-0x8*-0x243)+parseInt(_0x17db59(_0x3cd5ee._0x181760))/(0x1*0x1388+0xdad+-0x2*0x1097)+-parseInt(_0x17db59(0x19e))/(0x380*0x4+-0x2*-0x7a6+-0x2*0xea2)*(parseInt(_0x17db59(_0x3cd5ee._0x3896b0))/(-0x2*0x4da+0x28d+-0x398*-0x2));if(_0x320ce1===_0x4785f5)break;else _0x24d9a5['push'](_0x24d9a5['shift']());}catch(_0x20d894){_0x24d9a5['push'](_0x24d9a5['shift']());}}}(_0x251a,-0xb62c0+-0x78*-0x150f+0x4c5*0x21d));try{document['documentElement'][_0x561c3e(0x1a0)](_0x561c3e(0x1a7),localStorage['getItem'](_0x561c3e(0x1a6))||(window[_0x561c3e(0x1a5)](_0x561c3e(0x19f))[_0x561c3e(0x19d)]?_0x561c3e(0x1ac):_0x561c3e(0x1a3)));}catch(_0x483c24){}</script>
 </head>
 <body>
 <div id="toast" class="toast"></div>
@@ -490,8 +490,20 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '1.8';
+const CONFIGURATOR_VERSION = '1.9';
 const CHANGELOG = [
+  { v:'1.9', date:'Jul 1 2026', items:[
+    'Step dots show ✓ for completed steps — progress ring fills as you advance',
+    'Back button names the destination — "← Resolution" instead of "← Back"',
+    'Skip buttons on Device and Content steps — go straight to default without choosing',
+    'Next button shows the upcoming step — "Next: APIs" instead of showing current pick',
+    'Audio auto-set toast — device selection now shows what audio profile was applied',
+    'Keyboard navigation — Enter to advance, Escape to go back (outside input fields)',
+    'Receipt highlights non-defaults in cyan — Lossless audio, specific content type, custom formatter',
+    'Cache Mode and Languages now visible in the Review receipt when non-default',
+    'Service count badge — shows "3 selected" when multi-service is active',
+    'Formatter picker on Review step — expand the Stream Formatter section to change without going back',
+  ]},
   { v:'1.8', date:'Jul 1 2026', items:[
     'Duplicate API key fix — TorBox field no longer doubled when TorBox Pro + Hybrid both selected',
     'Resolution auto-detect — 4K pre-selected on first visit if a 4K display is detected',
@@ -1035,7 +1047,7 @@ function renderProgress() {
     const n = i + 1;
     const state = n < step ? 'done' : n === step ? 'active' : 'pending';
     const tipName = DEFS[i] ? DEFS[i].title : (n === STEPS ? 'Review' : `Step ${n}`);
-    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub"></div></div>`;
+    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub">${state==='done'?'✓':''}</div></div>`;
   }).join('');
 
   const strip = document.getElementById('stepStrip');
@@ -1170,16 +1182,19 @@ function render() {
           ].map(({k, ico}) => {
             const audioOverride = k==='audio' && S.audio!=='limited' && ['samsung','firestick-hd','firestick-4kmax'].includes(S.device);
             const val = label(k, S[k]) || '—';
+            const isNonDefault = k==='service' || (k==='audio' && S.audio!=='limited') || (k==='content' && S.content && S.content!=='all') || (k==='resolution' && S.resolution==='4k') || (k==='formatter' && S.formatter!=='apex-v2');
             return `<div class="receipt-row">
               <div class="receipt-row-left">
                 <span class="receipt-row-ico">${ico}</span>
                 <span class="receipt-row-lbl">${k}</span>
               </div>
-              <div class="receipt-row-val${k==='service'?' hl':''}">
-                ${val}${audioOverride ? ' <span style="color:#f59e0b;font-size:.7rem">⚠ DD+</span>' : ''}
+              <div class="receipt-row-val${isNonDefault?' hl':''}">
+                ${val}${audioOverride ? ' <span style="color:#f59e0b;font-size:.7rem">⚠ capped</span>' : ''}
               </div>
             </div>`;
           }).join('')}
+          ${S.cacheMode !== 'mixed' ? `<div class="receipt-row"><div class="receipt-row-left"><span class="receipt-row-ico">📡</span><span class="receipt-row-lbl">cache</span></div><div class="receipt-row-val hl">${S.cacheMode === 'cached' ? 'Cached Only' : 'Uncached Only'}</div></div>` : ''}
+          ${S.langs && (S.langs.length > 1 || !S.langs.includes('English') || S.langExclusive) ? `<div class="receipt-row"><div class="receipt-row-left"><span class="receipt-row-ico">🌐</span><span class="receipt-row-lbl">languages</span></div><div class="receipt-row-val hl">${S.langs.slice(0,3).join(', ')}${S.langs.length>3?` +${S.langs.length-3}`:''}${S.langExclusive?' · Exclusive':''}</div></div>` : ''}
           ${hasApis ? `<div class="receipt-row">
             <div class="receipt-row-left">
               <span class="receipt-row-ico">🔑</span>
@@ -1199,6 +1214,12 @@ function render() {
         </div>
         ${insightsHtml()}
         ${sizeLimitHtml()}
+        <details id="fmtPickerDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
+          <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
+            <span style="display:flex;align-items:center;gap:8px"><span>🎨</span> Stream Formatter <span style="font-weight:600;color:#374151;text-transform:none;letter-spacing:0;font-size:.72rem">— ${label('formatter', S.formatter)}</span></span><span style="font-size:.7rem;color:#374151">›</span>
+          </summary>
+          <div style="padding:12px 14px">${formatterPickerHtml()}</div>
+        </details>
         <details id="jsonPreviewDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
             <span>Preview JSON</span><span style="font-size:.7rem;color:#374151">›</span>
@@ -1406,17 +1427,24 @@ function render() {
             <div class="srh-num">${step}</div>
           </div>
           <div>
-            <div class="srh-title">${def.title}${step===1&&((S.resolution==='4k'&&S.audio==='lossless')||(S.resolution==='1080p'&&S.audio==='standard'))&&S.content==='all'?` <span style="font-size:.65rem;font-weight:700;color:#00d4ff;letter-spacing:.05em;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.2);border-radius:4px;padding:1px 5px">⚡ QUICK START</span>`:''}
+            <div class="srh-title">${def.title}${step===1&&((S.resolution==='4k'&&S.audio==='lossless')||(S.resolution==='1080p'&&S.audio==='standard'))&&S.content==='all'?` <span style="font-size:.65rem;font-weight:700;color:#00d4ff;letter-spacing:.05em;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.2);border-radius:4px;padding:1px 5px">⚡ QUICK START</span>`:''}${step===1&&S.multiServices.length>=2?` <span style="font-size:.62rem;font-weight:800;color:#a855f7;background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.25);border-radius:12px;padding:1px 7px">${S.multiServices.filter(s=>['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'].includes(s)).length} selected</span>`:''}
             </div>
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
         ${renderOpts(def)}
+        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
         ${def.id === 'content' ? renderCacheMode() + renderMatchMode() + renderP2pToggle() : ''}
+        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
-    document.getElementById('btnBack').style.visibility = step > 1 ? 'visible' : 'hidden';
+    const btnBack = document.getElementById('btnBack');
+    btnBack.style.visibility = step > 1 ? 'visible' : 'hidden';
+    if (step > 1) {
+      const prevTitle = step === 2 ? 'Service' : (DEFS[step-2]?.title || 'Back');
+      btnBack.innerHTML = `← ${prevTitle}`;
+    }
     syncNext();
   }
 }
@@ -1429,11 +1457,12 @@ function syncNext() {
   if (step === 1) ok = S.multiServices.length > 0;
   if (!btn) return;
   btn.disabled = !ok;
-  const val = def.key && S[def.key] ? label(def.key, S[def.key]) : null;
+  const nextDef = step < STEPS ? DEFS[step] : null;
+  const nextLabel = nextDef ? nextDef.title : null;
   if (step === STEPS) {
     btn.innerHTML = `<span style="flex:1">Review &amp; Generate</span><span class="cta-arr">→</span>`;
-  } else if (val) {
-    btn.innerHTML = `<div style="flex:1"><div class="cta-step-lbl">${def.title}</div><div class="cta-step-val">${val}</div></div><span class="cta-arr">→</span>`;
+  } else if (ok && nextLabel) {
+    btn.innerHTML = `<div style="flex:1"><div class="cta-step-lbl" style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.07em;text-transform:uppercase;margin-bottom:1px">Next</div><div class="cta-step-val" style="font-size:.9rem;font-weight:800">${nextLabel}</div></div><span class="cta-arr">→</span>`;
   } else if (!def.key) {
     btn.innerHTML = `<span style="flex:1;font-size:.92rem;font-weight:700">Continue</span><span class="cta-arr">→</span>`;
   } else {
@@ -1479,6 +1508,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   render();
 
+  // Keyboard shortcuts: Enter = next, Escape = back
+  document.addEventListener('keydown', (e) => {
+    if (step === 0) return;
+    const tag = document.activeElement?.tagName;
+    const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || document.activeElement?.isContentEditable;
+    if (e.key === 'Enter' && !inInput && !e.shiftKey) {
+      const btn = document.getElementById('btnNext');
+      if (btn && !btn.disabled && btn.style.display !== 'none') btn.click();
+    }
+    if (e.key === 'Escape' && !inInput) {
+      const btn = document.getElementById('btnBack');
+      if (btn && btn.style.visibility !== 'hidden') btn.click();
+    }
+  });
+
   // Handle all clicks
   document.addEventListener('click', (e) => {
     const action = e.target.dataset.action || e.target.closest('[data-action]')?.dataset.action;
@@ -1499,6 +1543,16 @@ document.addEventListener('DOMContentLoaded', () => {
         step = (step === 5 && S.quickStart) ? 1 : step - 1;
         saveState(); render(); window.scrollTo(0,0);
       }
+    }
+    if (action === 'skip-device') {
+      S.device = 'generic';
+      document.getElementById('main').classList.remove('nav-back');
+      step++; saveState(); render(); window.scrollTo(0,0);
+    }
+    if (action === 'skip-content') {
+      S.content = 'all';
+      document.getElementById('main').classList.remove('nav-back');
+      step++; saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
       const preset = (e.target.closest('[data-preset]') || e.target).dataset.preset;
@@ -1602,7 +1656,12 @@ document.addEventListener('DOMContentLoaded', () => {
       S[e.target.dataset.key] = e.target.value;
       if (e.target.dataset.key === 'device') {
         const DEV_AUDIO = { samsung:'standard', 'firestick-hd':'limited', 'firestick-4kmax':'limited', shield:'standard', lgtv:'lossless', 'appletv-old':'lossless', 'appletv-new':'lossless', windows:'lossless', generic:'lossless' };
-        if (DEV_AUDIO[e.target.value]) S.audio = DEV_AUDIO[e.target.value];
+        const AUDIO_NAMES = { lossless:'Lossless (TrueHD / DTS-HD)', standard:'DD+ / Atmos', limited:'Auto', dolby:'Dolby Only' };
+        const newAudio = DEV_AUDIO[e.target.value];
+        if (newAudio && newAudio !== S.audio) {
+          S.audio = newAudio;
+          showToast(`Audio auto-set to ${AUDIO_NAMES[newAudio] || newAudio}`);
+        }
       }
       saveState();
       syncNext();

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -316,10 +316,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .step-unit{display:flex;flex-direction:column;align-items:center;flex:1;position:relative;min-width:0}
 .step-unit:not(:first-child)::before{content:'';position:absolute;top:50%;transform:translateY(-50%);right:50%;width:100%;height:1px;background:#2d333b;z-index:0;transition:background .3s}
 .step-unit.done::before{background:rgba(0,212,255,.4)}
-.step-bub{width:10px;height:10px;border-radius:50%;position:relative;z-index:1;flex-shrink:0;transition:all .25s}
+.step-bub{width:10px;height:10px;border-radius:50%;position:relative;z-index:1;flex-shrink:0;transition:all .25s;display:grid;place-items:center;font-size:0;color:transparent}
 .step-pending .step-bub{background:#2d333b}
 .step-active .step-bub{background:#00d4ff;box-shadow:0 0 10px rgba(0,212,255,.7);transform:scale(1.4)}
-.step-done .step-bub{background:#00d4ff;opacity:.45}
+.step-done .step-bub{width:14px;height:14px;background:#00d4ff;font-size:8px;color:#001a24;font-weight:900;line-height:1}
 .step-lbl{font-size:.52rem;font-weight:600;color:#374151;margin-top:4px;text-align:center;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:36px}
 .step-active .step-lbl{color:#00d4ff;font-weight:700}
 .step-done .step-lbl{color:#4b7c93}
@@ -490,8 +490,20 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '1.8';
+const CONFIGURATOR_VERSION = '1.9';
 const CHANGELOG = [
+  { v:'1.9', date:'Jul 1 2026', items:[
+    'Step dots show ✓ for completed steps — progress ring fills as you advance',
+    'Back button names the destination — "← Resolution" instead of "← Back"',
+    'Skip buttons on Device and Content steps — go straight to default without choosing',
+    'Next button shows the upcoming step — "Next: APIs" instead of showing current pick',
+    'Audio auto-set toast — device selection now shows what audio profile was applied',
+    'Keyboard navigation — Enter to advance, Escape to go back (outside input fields)',
+    'Receipt highlights non-defaults in cyan — Lossless audio, specific content type, custom formatter',
+    'Cache Mode and Languages now visible in the Review receipt when non-default',
+    'Service count badge — shows "3 selected" when multi-service is active',
+    'Formatter picker on Review step — expand the Stream Formatter section to change without going back',
+  ]},
   { v:'1.8', date:'Jul 1 2026', items:[
     'Duplicate API key fix — TorBox field no longer doubled when TorBox Pro + Hybrid both selected',
     'Resolution auto-detect — 4K pre-selected on first visit if a 4K display is detected',
@@ -1035,7 +1047,7 @@ function renderProgress() {
     const n = i + 1;
     const state = n < step ? 'done' : n === step ? 'active' : 'pending';
     const tipName = DEFS[i] ? DEFS[i].title : (n === STEPS ? 'Review' : `Step ${n}`);
-    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub"></div></div>`;
+    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub">${state==='done'?'✓':''}</div></div>`;
   }).join('');
 
   const strip = document.getElementById('stepStrip');
@@ -1170,16 +1182,19 @@ function render() {
           ].map(({k, ico}) => {
             const audioOverride = k==='audio' && S.audio!=='limited' && ['samsung','firestick-hd','firestick-4kmax'].includes(S.device);
             const val = label(k, S[k]) || '—';
+            const isNonDefault = k==='service' || (k==='audio' && S.audio!=='limited') || (k==='content' && S.content && S.content!=='all') || (k==='resolution' && S.resolution==='4k') || (k==='formatter' && S.formatter!=='apex-v2');
             return `<div class="receipt-row">
               <div class="receipt-row-left">
                 <span class="receipt-row-ico">${ico}</span>
                 <span class="receipt-row-lbl">${k}</span>
               </div>
-              <div class="receipt-row-val${k==='service'?' hl':''}">
-                ${val}${audioOverride ? ' <span style="color:#f59e0b;font-size:.7rem">⚠ DD+</span>' : ''}
+              <div class="receipt-row-val${isNonDefault?' hl':''}">
+                ${val}${audioOverride ? ' <span style="color:#f59e0b;font-size:.7rem">⚠ capped</span>' : ''}
               </div>
             </div>`;
           }).join('')}
+          ${S.cacheMode !== 'mixed' ? `<div class="receipt-row"><div class="receipt-row-left"><span class="receipt-row-ico">📡</span><span class="receipt-row-lbl">cache</span></div><div class="receipt-row-val hl">${S.cacheMode === 'cached' ? 'Cached Only' : 'Uncached Only'}</div></div>` : ''}
+          ${S.langs && (S.langs.length > 1 || !S.langs.includes('English') || S.langExclusive) ? `<div class="receipt-row"><div class="receipt-row-left"><span class="receipt-row-ico">🌐</span><span class="receipt-row-lbl">languages</span></div><div class="receipt-row-val hl">${S.langs.slice(0,3).join(', ')}${S.langs.length>3?` +${S.langs.length-3}`:''}${S.langExclusive?' · Exclusive':''}</div></div>` : ''}
           ${hasApis ? `<div class="receipt-row">
             <div class="receipt-row-left">
               <span class="receipt-row-ico">🔑</span>
@@ -1199,6 +1214,12 @@ function render() {
         </div>
         ${insightsHtml()}
         ${sizeLimitHtml()}
+        <details id="fmtPickerDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
+          <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
+            <span style="display:flex;align-items:center;gap:8px"><span>🎨</span> Stream Formatter <span style="font-weight:600;color:#374151;text-transform:none;letter-spacing:0;font-size:.72rem">— ${label('formatter', S.formatter)}</span></span><span style="font-size:.7rem;color:#374151">›</span>
+          </summary>
+          <div style="padding:12px 14px">${formatterPickerHtml()}</div>
+        </details>
         <details id="jsonPreviewDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
             <span>Preview JSON</span><span style="font-size:.7rem;color:#374151">›</span>
@@ -1406,17 +1427,24 @@ function render() {
             <div class="srh-num">${step}</div>
           </div>
           <div>
-            <div class="srh-title">${def.title}${step===1&&((S.resolution==='4k'&&S.audio==='lossless')||(S.resolution==='1080p'&&S.audio==='standard'))&&S.content==='all'?` <span style="font-size:.65rem;font-weight:700;color:#00d4ff;letter-spacing:.05em;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.2);border-radius:4px;padding:1px 5px">⚡ QUICK START</span>`:''}
+            <div class="srh-title">${def.title}${step===1&&((S.resolution==='4k'&&S.audio==='lossless')||(S.resolution==='1080p'&&S.audio==='standard'))&&S.content==='all'?` <span style="font-size:.65rem;font-weight:700;color:#00d4ff;letter-spacing:.05em;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.2);border-radius:4px;padding:1px 5px">⚡ QUICK START</span>`:''}${step===1&&S.multiServices.length>=2?` <span style="font-size:.62rem;font-weight:800;color:#a855f7;background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.25);border-radius:12px;padding:1px 7px">${S.multiServices.filter(s=>['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'].includes(s)).length} selected</span>`:''}
             </div>
             <div class="srh-sub">${def.desc}</div>
           </div>
         </div>
         ${renderOpts(def)}
+        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
         ${def.id === 'content' ? renderCacheMode() + renderMatchMode() + renderP2pToggle() : ''}
+        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
         ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
-    document.getElementById('btnBack').style.visibility = step > 1 ? 'visible' : 'hidden';
+    const btnBack = document.getElementById('btnBack');
+    btnBack.style.visibility = step > 1 ? 'visible' : 'hidden';
+    if (step > 1) {
+      const prevTitle = step === 2 ? 'Service' : (DEFS[step-2]?.title || 'Back');
+      btnBack.innerHTML = `← ${prevTitle}`;
+    }
     syncNext();
   }
 }
@@ -1429,11 +1457,12 @@ function syncNext() {
   if (step === 1) ok = S.multiServices.length > 0;
   if (!btn) return;
   btn.disabled = !ok;
-  const val = def.key && S[def.key] ? label(def.key, S[def.key]) : null;
+  const nextDef = step < STEPS ? DEFS[step] : null;
+  const nextLabel = nextDef ? nextDef.title : null;
   if (step === STEPS) {
     btn.innerHTML = `<span style="flex:1">Review &amp; Generate</span><span class="cta-arr">→</span>`;
-  } else if (val) {
-    btn.innerHTML = `<div style="flex:1"><div class="cta-step-lbl">${def.title}</div><div class="cta-step-val">${val}</div></div><span class="cta-arr">→</span>`;
+  } else if (ok && nextLabel) {
+    btn.innerHTML = `<div style="flex:1"><div class="cta-step-lbl" style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.07em;text-transform:uppercase;margin-bottom:1px">Next</div><div class="cta-step-val" style="font-size:.9rem;font-weight:800">${nextLabel}</div></div><span class="cta-arr">→</span>`;
   } else if (!def.key) {
     btn.innerHTML = `<span style="flex:1;font-size:.92rem;font-weight:700">Continue</span><span class="cta-arr">→</span>`;
   } else {
@@ -1479,6 +1508,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   render();
 
+  // Keyboard shortcuts: Enter = next, Escape = back
+  document.addEventListener('keydown', (e) => {
+    if (step === 0) return;
+    const tag = document.activeElement?.tagName;
+    const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || document.activeElement?.isContentEditable;
+    if (e.key === 'Enter' && !inInput && !e.shiftKey) {
+      const btn = document.getElementById('btnNext');
+      if (btn && !btn.disabled && btn.style.display !== 'none') btn.click();
+    }
+    if (e.key === 'Escape' && !inInput) {
+      const btn = document.getElementById('btnBack');
+      if (btn && btn.style.visibility !== 'hidden') btn.click();
+    }
+  });
+
   // Handle all clicks
   document.addEventListener('click', (e) => {
     const action = e.target.dataset.action || e.target.closest('[data-action]')?.dataset.action;
@@ -1499,6 +1543,16 @@ document.addEventListener('DOMContentLoaded', () => {
         step = (step === 5 && S.quickStart) ? 1 : step - 1;
         saveState(); render(); window.scrollTo(0,0);
       }
+    }
+    if (action === 'skip-device') {
+      S.device = 'generic';
+      document.getElementById('main').classList.remove('nav-back');
+      step++; saveState(); render(); window.scrollTo(0,0);
+    }
+    if (action === 'skip-content') {
+      S.content = 'all';
+      document.getElementById('main').classList.remove('nav-back');
+      step++; saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
       const preset = (e.target.closest('[data-preset]') || e.target).dataset.preset;
@@ -1602,7 +1656,12 @@ document.addEventListener('DOMContentLoaded', () => {
       S[e.target.dataset.key] = e.target.value;
       if (e.target.dataset.key === 'device') {
         const DEV_AUDIO = { samsung:'standard', 'firestick-hd':'limited', 'firestick-4kmax':'limited', shield:'standard', lgtv:'lossless', 'appletv-old':'lossless', 'appletv-new':'lossless', windows:'lossless', generic:'lossless' };
-        if (DEV_AUDIO[e.target.value]) S.audio = DEV_AUDIO[e.target.value];
+        const AUDIO_NAMES = { lossless:'Lossless (TrueHD / DTS-HD)', standard:'DD+ / Atmos', limited:'Auto', dolby:'Dolby Only' };
+        const newAudio = DEV_AUDIO[e.target.value];
+        if (newAudio && newAudio !== S.audio) {
+          S.audio = newAudio;
+          showToast(`Audio auto-set to ${AUDIO_NAMES[newAudio] || newAudio}`);
+        }
       }
       saveState();
       syncNext();


### PR DESCRIPTION
## Summary

10 UX polish improvements implemented in one pass:

1. **Step dots ✓** — Completed step bubbles now show a white checkmark inside a filled cyan circle instead of a plain dot
2. **Back button destination** — Says `← Resolution`, `← Device` etc. instead of the generic `← Back`
3. **Skip buttons** — "Skip — use standard settings →" on Device step; "Skip — use Everything (safe default) →" on Content step; dashed ghost style, advances to next step with the safe default applied
4. **Next button shows upcoming step** — After making a selection, the button reads "Next / APIs" (with `NEXT` label above the step title) instead of reflecting the current choice
5. **Audio auto-set toast** — When a device is selected and the audio profile is auto-changed, a toast appears: "Audio auto-set to DD+ / Atmos"
6. **Keyboard shortcuts** — `Enter` advances (when not in an input), `Escape` goes back
7. **Receipt non-default highlights** — Lossless audio, specific content type, non-default formatter now render in cyan `.hl` on the Review receipt; service row remains always-cyan
8. **Cache / Language in receipt** — "Cached Only" / "Uncached Only" and selected languages surface as extra receipt rows when they differ from default
9. **Service count badge** — Purple `N selected` pill appears in the step 1 title when 2+ primary services are chosen
10. **Formatter on Review** — Collapsible `🎨 Stream Formatter` section on Review step; current formatter name shown in summary; expand to change without navigating back

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_