### PR TITLE
fix(configurator): radial-mask blend on loader + splash logos

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -488,7 +488,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .host-cfg-link:hover{color:#0c4a6e;text-shadow:none}
 #cb-loader{position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;background:#0d1117;animation:cbLoad 3s cubic-bezier(.4,0,.2,1) forwards;pointer-events:none}
 [data-theme="light"] #cb-loader{background:#e8eef4}
-#cb-loader-icon{width:112px;height:112px;animation:cbIconPop .7s cubic-bezier(.34,1.56,.64,1) .15s both}
+#cb-loader-icon{width:150px;height:150px;animation:cbIconPop .7s cubic-bezier(.34,1.56,.64,1) .15s both}
 #cb-loader-title{font-family:system-ui,-apple-system,sans-serif;font-size:1.55rem;font-weight:900;letter-spacing:-.03em;color:#e6edf3;line-height:1}
 [data-theme="light"] #cb-loader-title{color:#1c2128}
 #cb-loader-title span{color:#00b8cc}
@@ -497,7 +497,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
 </style>
-<script>var _0x1866c5=_0x31e2;function _0x31e2(_0x5e61c8,_0x2a21c5){_0x5e61c8=_0x5e61c8-(-0x359+0x228e*-0x1+0x253*0x11);var _0x2b5b00=_0x5345();var _0x5dbc12=_0x2b5b00[_0x5e61c8];if(_0x31e2['dYOkEi']===undefined){var _0x1a87ad=function(_0x3b911c){var _0x51f52e='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x34cfe8='',_0x1ee14c='';for(var _0x44373f=0x256f+-0x50+-0x2db*0xd,_0xbb7a6d,_0x4cfcaf,_0x22b6c0=0x26*-0xc6+0x1*-0x827+-0x258b*-0x1;_0x4cfcaf=_0x3b911c['charAt'](_0x22b6c0++);~_0x4cfcaf&&(_0xbb7a6d=_0x44373f%(0x4*0x823+-0xe3+-0x1fa5)?_0xbb7a6d*(0x1*-0xb5c+-0x962+0x14fe)+_0x4cfcaf:_0x4cfcaf,_0x44373f++%(-0x19d2+-0x1989*-0x1+0x7*0xb))?_0x34cfe8+=String['fromCharCode'](-0x677*-0x1+-0x2011+0x1a99&_0xbb7a6d>>(-(0xc*-0x2f+0x1ba0+-0x196a)*_0x44373f&0x1981+-0x17+-0x1964)):-0xbcd+0x5*0x38a+-0x5e5){_0x4cfcaf=_0x51f52e['indexOf'](_0x4cfcaf);}for(var _0x20307d=0x21ce*0x1+-0xfc3+0x1*-0x120b,_0x4681c8=_0x34cfe8['length'];_0x20307d<_0x4681c8;_0x20307d++){_0x1ee14c+='%'+('00'+_0x34cfe8['charCodeAt'](_0x20307d)['toString'](-0x4a*-0x4b+0x1c5b+-0x31f9))['slice'](-(-0x11*0xa1+-0x16*-0x9e+0x1*-0x2e1));}return decodeURIComponent(_0x1ee14c);};_0x31e2['vbuXpV']=_0x1a87ad,_0x31e2['DlbuVv']={},_0x31e2['dYOkEi']=!![];}var _0x5df1de=_0x2b5b00[-0x5f7*-0x5+0x4c3+0x26*-0xe9],_0x1b86bc=_0x5e61c8+_0x5df1de,_0x2573c1=_0x31e2['DlbuVv'][_0x1b86bc];return!_0x2573c1?(_0x5dbc12=_0x31e2['vbuXpV'](_0x5dbc12),_0x31e2['DlbuVv'][_0x1b86bc]=_0x5dbc12):_0x5dbc12=_0x2573c1,_0x5dbc12;}function _0x5345(){var _0x3a00e0=['Bwf0y2HLCW','z2v0sxrLBq','zg9JDw1LBNrfBgvTzw50','mJy3mty5CeXxAKXc','mJC2nZG1mJbcqLrewgG','zgfYAW','mtbrCKXLrKG','mJa3nZyWnvf6z2LZCW','y2juAgvTzq','ndq5ndqYnKvLrwzPza','nJa3mZC5mK9tww5QDW','odrmBK1fAvC','nta1mti1mhnks3jmCq','zgf0ys10AgvTzq','nhLtwKXOyG','BgLNAhq','mZqYnJC0DerdDwfP'];_0x5345=function(){return _0x3a00e0;};return _0x5345();}(function(_0x31ede2,_0x212f56){var _0x360548={_0x19f609:0x1ab,_0x1a88eb:0x1a1,_0x887dd4:0x19f},_0x5ccdf8=_0x31e2,_0x57143c=_0x31ede2();while(!![]){try{var _0x33bb10=parseInt(_0x5ccdf8(_0x360548._0x19f609))/(0x25ca*-0x1+0xc8a+0x1941)*(-parseInt(_0x5ccdf8(_0x360548._0x1a88eb))/(-0x16*-0x1b7+-0x1156+0xa31*-0x2))+-parseInt(_0x5ccdf8(0x1a4))/(-0xd7*-0x5+-0xdc6+0x996)+-parseInt(_0x5ccdf8(0x1a9))/(-0xcb3+-0x1*-0x12b2+0x5fb*-0x1)*(parseInt(_0x5ccdf8(0x1a2))/(-0x1c31+0x1a*-0x4+0x1c9e))+parseInt(_0x5ccdf8(0x1a6))/(-0x1207*-0x1+0xf81+-0x2182)*(parseInt(_0x5ccdf8(0x19e))/(-0x1655*0x1+-0xe7f+-0x24db*-0x1))+parseInt(_0x5ccdf8(0x1a5))/(0x1452+0x1d30+-0x317a)+parseInt(_0x5ccdf8(0x1a7))/(-0x12c*-0x4+-0xa*-0x22e+0x3*-0x8d1)+parseInt(_0x5ccdf8(_0x360548._0x887dd4))/(-0x26cd+0x5*-0x1a5+-0x3*-0xfb0);if(_0x33bb10===_0x212f56)break;else _0x57143c['push'](_0x57143c['shift']());}catch(_0x219aa0){_0x57143c['push'](_0x57143c['shift']());}}}(_0x5345,-0x6*0x4cab+0x28805+-0x2503*-0x64));try{document[_0x1866c5(0x19d)]['setAttribute'](_0x1866c5(0x1a8),localStorage[_0x1866c5(0x19c)](_0x1866c5(0x1a3))||(window['matchMedia']('(prefers-color-scheme:dark)')[_0x1866c5(0x1ac)]?_0x1866c5(0x1a0):_0x1866c5(0x1aa)));}catch(_0xf80f89){}</script>
+<script>var _0x358af2=_0x22fa;function _0x53c9(){var _0x185c4b=['C2v0qxr0CMLIDxrL','Bwf0y2HnzwrPyq','zg9JDw1LBNrfBgvTzw50','BgLNAhq','zgf0ys10AgvTzq','nZK0ndi3mhfhv2TUEa','mtqWndC5nuHJwhHhBa','mtaWnZi3mdzMsMf5t04','zgfYAW','mZa5mJeZoeDmweLjvW','mtq4suTisLbm','mtq3mtjOzfrbweG','mtC5mtCXnJHYBfngBhu','Bwf0y2HLCW','odiWotu3mMzZrKPUqW','y2juAgvTzq','z2v0sxrLBq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP'];_0x53c9=function(){return _0x185c4b;};return _0x53c9();}function _0x22fa(_0x25a149,_0x2738bc){_0x25a149=_0x25a149-(-0x1*-0x5e7+-0x11f0+-0x62*-0x21);var _0x3ab052=_0x53c9();var _0x2a7f0c=_0x3ab052[_0x25a149];if(_0x22fa['rnMayQ']===undefined){var _0x43fafd=function(_0x21c384){var _0xc54713='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x3b0e33='',_0x5373eb='';for(var _0x1fc60e=0x5c*0x20+-0x69b*0x1+0x1*-0x4e5,_0x41be26,_0x34a19d,_0x255acc=-0x2260+0x1d9a+0x4c6;_0x34a19d=_0x21c384['charAt'](_0x255acc++);~_0x34a19d&&(_0x41be26=_0x1fc60e%(0xb0e+0x1cc4+-0x27ce)?_0x41be26*(-0xfa9+-0x1*-0xac5+-0x2f*-0x1c)+_0x34a19d:_0x34a19d,_0x1fc60e++%(0x12*0x93+0x11af*0x1+-0x1c01))?_0x3b0e33+=String['fromCharCode'](0x2253*-0x1+0x2*0xec2+0x2*0x2e7&_0x41be26>>(-(-0x4*-0x3ad+0x7f1*0x3+-0x2685)*_0x1fc60e&-0x133d+-0x451+0x6*0x3ee)):-0x1215+-0x41c*-0x1+0xdf9){_0x34a19d=_0xc54713['indexOf'](_0x34a19d);}for(var _0x2911d8=0x1539+0x1406+0x1*-0x293f,_0x360add=_0x3b0e33['length'];_0x2911d8<_0x360add;_0x2911d8++){_0x5373eb+='%'+('00'+_0x3b0e33['charCodeAt'](_0x2911d8)['toString'](-0x2*0xaa9+0x1*-0x82a+0x1d8c))['slice'](-(0x9*0x2f5+-0x1139*-0x1+-0x2bd4));}return decodeURIComponent(_0x5373eb);};_0x22fa['FQynYb']=_0x43fafd,_0x22fa['LLbXXA']={},_0x22fa['rnMayQ']=!![];}var _0x386e8d=_0x3ab052[-0x110+-0x1*-0xefd+-0xded],_0x30febb=_0x25a149+_0x386e8d,_0x2af9f3=_0x22fa['LLbXXA'][_0x30febb];return!_0x2af9f3?(_0x2a7f0c=_0x22fa['FQynYb'](_0x2a7f0c),_0x22fa['LLbXXA'][_0x30febb]=_0x2a7f0c):_0x2a7f0c=_0x2af9f3,_0x2a7f0c;}(function(_0x3d5ae5,_0x243351){var _0x4bbcaf={_0x2925ac:0x9e,_0x3fddbb:0xa0,_0x54e1af:0x9f,_0x366fcb:0xa3,_0x216c27:0x9c,_0x41e497:0xa1},_0xee63b9=_0x22fa,_0x10c766=_0x3d5ae5();while(!![]){try{var _0x1c3d85=-parseInt(_0xee63b9(0x9b))/(0x1*0x261c+-0xb24+0x3b*-0x75)+parseInt(_0xee63b9(_0x4bbcaf._0x2925ac))/(-0x6e2*-0x3+0x105f+-0x2503)+parseInt(_0xee63b9(_0x4bbcaf._0x3fddbb))/(-0x1*-0xefd+-0x9de+-0x51c)*(parseInt(_0xee63b9(_0x4bbcaf._0x54e1af))/(-0x6f0+0x1*0x903+-0x1*0x20f))+-parseInt(_0xee63b9(0x9a))/(0xb69*-0x1+-0x1cf8+0x1*0x2866)+parseInt(_0xee63b9(_0x4bbcaf._0x366fcb))/(0x877*-0x1+-0x56c+0xde9)+-parseInt(_0xee63b9(_0x4bbcaf._0x216c27))/(0x655*0x5+0xf4f+-0xc5*0x3d)+parseInt(_0xee63b9(_0x4bbcaf._0x41e497))/(-0x1*-0x1f75+-0x2064+0xf7*0x1);if(_0x1c3d85===_0x243351)break;else _0x10c766['push'](_0x10c766['shift']());}catch(_0x4dd3a6){_0x10c766['push'](_0x10c766['shift']());}}}(_0x53c9,0x107*-0xbfa+0x5*-0x5524d+-0x24a6f*-0x17));try{document[_0x358af2(0xa9)][_0x358af2(0xa7)](_0x358af2(0x99),localStorage[_0x358af2(0xa5)](_0x358af2(0xa4))||(window[_0x358af2(0xa8)](_0x358af2(0xa6))[_0x358af2(0xa2)]?_0x358af2(0x9d):_0x358af2(0xaa)));}catch(_0x4b3ed3){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -505,18 +505,21 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
     <defs>
       <linearGradient id="lg1" x1="50%" y1="0%" x2="50%" y2="100%"><stop offset="0%" stop-color="#00c4d9"/><stop offset="100%" stop-color="#4090d4"/></linearGradient>
       <linearGradient id="lg2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4090d4"/><stop offset="50%" stop-color="#8a4890"/><stop offset="100%" stop-color="#c03a20"/></linearGradient>
-      <filter id="lf1"><feGaussianBlur stdDeviation="10" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-      <filter id="lf2"><feGaussianBlur stdDeviation="14" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-      <filter id="lf3"><feGaussianBlur stdDeviation="24"/></filter>
+      <radialGradient id="lrmask" cx="50%" cy="50%" r="50%"><stop offset="20%" stop-color="white" stop-opacity="1"/><stop offset="70%" stop-color="white" stop-opacity="0.6"/><stop offset="100%" stop-color="white" stop-opacity="0"/></radialGradient>
+      <mask id="lm"><rect width="512" height="512" fill="url(#lrmask)"/></mask>
+      <filter id="lf1"><feGaussianBlur stdDeviation="32"/></filter>
+      <filter id="lf2"><feGaussianBlur stdDeviation="16" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+      <filter id="lf3"><feGaussianBlur stdDeviation="60"/></filter>
     </defs>
-    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00c4d9" opacity="0.04" filter="url(#lf3)"/>
-    <polygon points="256,166 346,256 256,346 166,256" fill="#8a4890" opacity="0.07" filter="url(#lf3)"/>
-    <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00c4d9" stroke-width="28" stroke-linejoin="round" opacity="0.25" filter="url(#lf1)"/>
-    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#lg1)" stroke-width="16" stroke-linejoin="round" opacity=".75"/>
-    <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.35" filter="url(#lf2)"/>
-    <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.85"/>
-    <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#lg2)"/>
-    <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#lg2)"/>
+    <g mask="url(#lm)">
+      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00c4d9" opacity="0.18" filter="url(#lf3)"/>
+      <polygon points="256,166 346,256 256,346 166,256" fill="#8a4890" opacity="0.22" filter="url(#lf3)"/>
+      <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00c4d9" stroke-width="48" stroke-linejoin="round" opacity="0.22" filter="url(#lf1)"/>
+      <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.3" filter="url(#lf2)"/>
+      <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.7"/>
+      <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#lg2)" opacity=".42"/>
+      <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#lg2)" opacity=".42"/>
+    </g>
   </svg>
   <div id="cb-loader-title">CORE <span>BUILDS</span></div>
   <div id="cb-loader-sub">by Brevity</div>
@@ -1171,19 +1174,21 @@ function splashHtml() {
       <defs>
         <linearGradient id="sg1" x1="50%" y1="0%" x2="50%" y2="100%"><stop offset="0%" stop-color="#00e5ff"/><stop offset="100%" stop-color="#4facfe"/></linearGradient>
         <linearGradient id="sg2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4facfe"/><stop offset="50%" stop-color="#c060c0"/><stop offset="100%" stop-color="#ff4b2b"/></linearGradient>
-        <filter id="sf1"><feGaussianBlur stdDeviation="10" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-        <filter id="sf2"><feGaussianBlur stdDeviation="14" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-        <filter id="sf3"><feGaussianBlur stdDeviation="24"/></filter>
+        <radialGradient id="srmask" cx="50%" cy="50%" r="50%"><stop offset="20%" stop-color="white" stop-opacity="1"/><stop offset="70%" stop-color="white" stop-opacity="0.6"/><stop offset="100%" stop-color="white" stop-opacity="0"/></radialGradient>
+        <mask id="sm"><rect width="512" height="512" fill="url(#srmask)"/></mask>
+        <filter id="sf1"><feGaussianBlur stdDeviation="32"/></filter>
+        <filter id="sf2"><feGaussianBlur stdDeviation="16" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+        <filter id="sf3"><feGaussianBlur stdDeviation="60"/></filter>
       </defs>
-      <circle cx="256" cy="256" r="248" fill="#080c10"/>
-      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.05" filter="url(#sf3)"/>
-      <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.09" filter="url(#sf3)"/>
-      <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round" opacity="0.3" filter="url(#sf1)"/>
-      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#sg1)" stroke-width="22" stroke-linejoin="round"/>
-      <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.4" filter="url(#sf2)"/>
-      <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.95"/>
-      <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
-      <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+      <g mask="url(#sm)">
+        <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.18" filter="url(#sf3)"/>
+        <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.22" filter="url(#sf3)"/>
+        <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="48" stroke-linejoin="round" opacity="0.22" filter="url(#sf1)"/>
+        <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.3" filter="url(#sf2)"/>
+        <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.85"/>
+        <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+        <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+      </g>
     </svg>
     <div class="splash-title"><span class="hdr-core">CORE</span><span class="hdr-builds"> BUILDS</span></div>
     <div class="splash-by">By Brevity</div>

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -488,7 +488,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .host-cfg-link:hover{color:#0c4a6e;text-shadow:none}
 #cb-loader{position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;background:#0d1117;animation:cbLoad 3s cubic-bezier(.4,0,.2,1) forwards;pointer-events:none}
 [data-theme="light"] #cb-loader{background:#e8eef4}
-#cb-loader-icon{width:112px;height:112px;animation:cbIconPop .7s cubic-bezier(.34,1.56,.64,1) .15s both}
+#cb-loader-icon{width:150px;height:150px;animation:cbIconPop .7s cubic-bezier(.34,1.56,.64,1) .15s both}
 #cb-loader-title{font-family:system-ui,-apple-system,sans-serif;font-size:1.55rem;font-weight:900;letter-spacing:-.03em;color:#e6edf3;line-height:1}
 [data-theme="light"] #cb-loader-title{color:#1c2128}
 #cb-loader-title span{color:#00b8cc}
@@ -505,18 +505,21 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
     <defs>
       <linearGradient id="lg1" x1="50%" y1="0%" x2="50%" y2="100%"><stop offset="0%" stop-color="#00c4d9"/><stop offset="100%" stop-color="#4090d4"/></linearGradient>
       <linearGradient id="lg2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4090d4"/><stop offset="50%" stop-color="#8a4890"/><stop offset="100%" stop-color="#c03a20"/></linearGradient>
-      <filter id="lf1"><feGaussianBlur stdDeviation="10" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-      <filter id="lf2"><feGaussianBlur stdDeviation="14" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-      <filter id="lf3"><feGaussianBlur stdDeviation="24"/></filter>
+      <radialGradient id="lrmask" cx="50%" cy="50%" r="50%"><stop offset="20%" stop-color="white" stop-opacity="1"/><stop offset="70%" stop-color="white" stop-opacity="0.6"/><stop offset="100%" stop-color="white" stop-opacity="0"/></radialGradient>
+      <mask id="lm"><rect width="512" height="512" fill="url(#lrmask)"/></mask>
+      <filter id="lf1"><feGaussianBlur stdDeviation="32"/></filter>
+      <filter id="lf2"><feGaussianBlur stdDeviation="16" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+      <filter id="lf3"><feGaussianBlur stdDeviation="60"/></filter>
     </defs>
-    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00c4d9" opacity="0.04" filter="url(#lf3)"/>
-    <polygon points="256,166 346,256 256,346 166,256" fill="#8a4890" opacity="0.07" filter="url(#lf3)"/>
-    <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00c4d9" stroke-width="28" stroke-linejoin="round" opacity="0.25" filter="url(#lf1)"/>
-    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#lg1)" stroke-width="16" stroke-linejoin="round" opacity=".75"/>
-    <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.35" filter="url(#lf2)"/>
-    <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.85"/>
-    <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#lg2)"/>
-    <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#lg2)"/>
+    <g mask="url(#lm)">
+      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00c4d9" opacity="0.18" filter="url(#lf3)"/>
+      <polygon points="256,166 346,256 256,346 166,256" fill="#8a4890" opacity="0.22" filter="url(#lf3)"/>
+      <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00c4d9" stroke-width="48" stroke-linejoin="round" opacity="0.22" filter="url(#lf1)"/>
+      <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.3" filter="url(#lf2)"/>
+      <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#lg2)" opacity="0.7"/>
+      <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#lg2)" opacity=".42"/>
+      <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#lg2)" opacity=".42"/>
+    </g>
   </svg>
   <div id="cb-loader-title">CORE <span>BUILDS</span></div>
   <div id="cb-loader-sub">by Brevity</div>
@@ -1171,19 +1174,21 @@ function splashHtml() {
       <defs>
         <linearGradient id="sg1" x1="50%" y1="0%" x2="50%" y2="100%"><stop offset="0%" stop-color="#00e5ff"/><stop offset="100%" stop-color="#4facfe"/></linearGradient>
         <linearGradient id="sg2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4facfe"/><stop offset="50%" stop-color="#c060c0"/><stop offset="100%" stop-color="#ff4b2b"/></linearGradient>
-        <filter id="sf1"><feGaussianBlur stdDeviation="10" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-        <filter id="sf2"><feGaussianBlur stdDeviation="14" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-        <filter id="sf3"><feGaussianBlur stdDeviation="24"/></filter>
+        <radialGradient id="srmask" cx="50%" cy="50%" r="50%"><stop offset="20%" stop-color="white" stop-opacity="1"/><stop offset="70%" stop-color="white" stop-opacity="0.6"/><stop offset="100%" stop-color="white" stop-opacity="0"/></radialGradient>
+        <mask id="sm"><rect width="512" height="512" fill="url(#srmask)"/></mask>
+        <filter id="sf1"><feGaussianBlur stdDeviation="32"/></filter>
+        <filter id="sf2"><feGaussianBlur stdDeviation="16" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
+        <filter id="sf3"><feGaussianBlur stdDeviation="60"/></filter>
       </defs>
-      <circle cx="256" cy="256" r="248" fill="#080c10"/>
-      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.05" filter="url(#sf3)"/>
-      <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.09" filter="url(#sf3)"/>
-      <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="30" stroke-linejoin="round" opacity="0.3" filter="url(#sf1)"/>
-      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#sg1)" stroke-width="22" stroke-linejoin="round"/>
-      <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.4" filter="url(#sf2)"/>
-      <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.95"/>
-      <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
-      <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+      <g mask="url(#sm)">
+        <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.18" filter="url(#sf3)"/>
+        <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.22" filter="url(#sf3)"/>
+        <polygon class="hex-glow-layer" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="48" stroke-linejoin="round" opacity="0.22" filter="url(#sf1)"/>
+        <polygon class="diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.3" filter="url(#sf2)"/>
+        <polygon class="diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#sg2)" opacity="0.85"/>
+        <circle class="core-ring" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+        <circle class="core-ring core-ring-2" cx="256" cy="256" r="90" stroke="url(#sg2)"/>
+      </g>
     </svg>
     <div class="splash-title"><span class="hdr-core">CORE</span><span class="hdr-builds"> BUILDS</span></div>
     <div class="splash-by">By Brevity</div>


### PR DESCRIPTION
## Summary

- **Loader logo** — replaces hard hex stroke with a radial gradient mask so the logo dissolves cleanly into the page background. No visible boundary — shape reads only through soft glow blooms and the animated diamond/rings. Icon size 112px → 150px.
- **Splash logo** — same radial-mask treatment. Removes the dark filled circle, identical mask gradient (opaque at 20%, fades to transparent at edges). Full-saturation colours retained.
- Both logos now blend cleanly into their backgrounds in dark and light mode with no visible SVG boundary.

## Test plan

- [ ] Loading screen: logo dissolves into dark (`#0d1117`) and light (`#e8eef4`) backgrounds with no hard edge
- [ ] Splash screen: logo blends into card background in both themes
- [ ] Animations still work: hex breath, diamond pulse, dual ripple rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_