### PR TITLE
feat: parentConfig support + Core Builds Base TorBox template

### DIFF
--- a/Templates/Base/core-nexus-base-torbox.json
+++ b/Templates/Base/core-nexus-base-torbox.json
@@ -1,0 +1,1355 @@
+{
+  "metadata": {
+    "id": "core-nexus-base-torbox",
+    "name": "Core Builds Base \u2014 TorBox",
+    "version": "1.0.0",
+    "description": "Shared base configuration for all Core Builds TorBox templates. Import this first, then use its UUID in the configurator to generate slimmed child templates.",
+    "author": "Branding-Brevity",
+    "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Base/core-nexus-base-torbox.json",
+    "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
+    "category": "Base",
+    "tags": [
+      "torbox",
+      "base",
+      "core-builds"
+    ],
+    "setToSaveInstallMenu": true
+  },
+  "config": {
+    "trusted": false,
+    "showChanges": true,
+    "addonLogo": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg",
+    "includedResolutions": [],
+    "excludedQualities": [],
+    "includedQualities": [],
+    "requiredQualities": [],
+    "preferredQualities": [
+      "BluRay REMUX",
+      "BluRay",
+      "WEB-DL",
+      "WEBRip",
+      "HDRip",
+      "HC HD-Rip",
+      "DVDRip",
+      "HDTV",
+      "SCR",
+      "TC",
+      "TS",
+      "CAM",
+      "Unknown"
+    ],
+    "excludedLanguages": [],
+    "includedLanguages": [
+      "English",
+      "Original",
+      "Dual Audio",
+      "Multi",
+      "Dubbed",
+      "Unknown"
+    ],
+    "requiredLanguages": [],
+    "preferredLanguages": [
+      "English",
+      "Original",
+      "Dual Audio",
+      "Multi",
+      "Dubbed"
+    ],
+    "excludedSubtitles": [],
+    "includedSubtitles": [],
+    "requiredSubtitles": [],
+    "preferredSubtitles": [
+      "English"
+    ],
+    "excludedVisualTags": [
+      "3D",
+      "H-OU",
+      "H-SBS"
+    ],
+    "includedVisualTags": [],
+    "requiredVisualTags": [],
+    "includedAudioTags": [],
+    "requiredAudioTags": [],
+    "preferredAudioTags": [
+      "Atmos",
+      "DTS:X",
+      "TrueHD",
+      "DTS-HD MA",
+      "FLAC",
+      "DTS-HD",
+      "DTS-ES",
+      "DD+",
+      "DTS",
+      "DD",
+      "OPUS",
+      "AAC"
+    ],
+    "includedAudioChannels": [],
+    "requiredAudioChannels": [],
+    "excludedStreamTypes": [
+      "youtube"
+    ],
+    "includedStreamTypes": [],
+    "requiredStreamTypes": [],
+    "includedEncodes": [],
+    "requiredEncodes": [],
+    "excludedRegexPatterns": [
+      "/(\\bAI[ ._-]?(Upscaled?|Enhanced|Remaster(ed)?)?\\b)|(\\b(AIUS|RW|GuyZo|BR-GuyZo)\\b)|(\\b((Upscale)?Re-?graded?)\\b)|(\\b(The[ ._-]?Upscaler)\\b)|(\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b)/i",
+      "/(?<=\\b[12]\\d{3}\\b).*\\b(Extras|Bonus|Extended[ ._-]Clip)\\b/i",
+      "/(?<=\\bS\\d+\\b).*\\b(Extras|Bonus|Extended[ ._-]Clip)\\b/i",
+      "/\\b(beAst|COLLECTiVE|EPiC|iVy|KiNGDOM|LUCY|Scene|SUNSCREEN)\\b/",
+      "/(?<=\\b[12]\\d{3}\\b).*\\b(Sing[-_. ]Along)\\b/i",
+      "/^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*$/i",
+      "/[.]heb\\b|\\[eztvx?[ ._-]?(io|re|to)?\\]|\\[(rarbg|rartv|TGx)\\]|[.]VAV\\b|\\b(ORARBG)\\b/i",
+      "/[.]heb\\b|\\[eztvx?[ ._-]?(io|re|to)?\\]|\\[(rarbg|rartv|TGx)\\]/i"
+    ],
+    "syncedExcludedStreamExpressionUrls": [],
+    "requiredReleaseGroups": [],
+    "includeSeederRange": [
+      0,
+      1000
+    ],
+    "seederRangeTypes": [],
+    "ageRangeTypes": [],
+    "digitalReleaseFilter": {
+      "enabled": false,
+      "tolerance": 14,
+      "requestTypes": [
+        "movie",
+        "series",
+        "anime"
+      ],
+      "addons": []
+    },
+    "excludeCached": false,
+    "excludeCachedFromAddons": [],
+    "excludeCachedFromServices": [],
+    "excludeCachedFromStreamTypes": [],
+    "excludeUncached": false,
+    "excludeUncachedFromAddons": [],
+    "excludeUncachedFromServices": [],
+    "excludeUncachedFromStreamTypes": [],
+    "rankedStreamExpressions": [],
+    "rankedRegexPatterns": [],
+    "selOverrides": [],
+    "sortCriteria": {
+      "global": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "movies": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "series": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "anime": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "cached": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "uncached": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "cachedMovies": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "uncachedMovies": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "cachedSeries": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "uncachedSeries": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "cachedAnime": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ],
+      "uncachedAnime": [
+        {
+          "key": "cached",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionMatched",
+          "direction": "desc"
+        },
+        {
+          "key": "streamExpressionScore",
+          "direction": "desc"
+        },
+        {
+          "key": "library",
+          "direction": "desc"
+        },
+        {
+          "key": "resolution",
+          "direction": "desc"
+        },
+        {
+          "key": "quality",
+          "direction": "desc"
+        },
+        {
+          "key": "regexScore",
+          "direction": "desc"
+        },
+        {
+          "key": "visualTag",
+          "direction": "desc"
+        },
+        {
+          "key": "encode",
+          "direction": "desc"
+        },
+        {
+          "key": "audioTag",
+          "direction": "desc"
+        },
+        {
+          "key": "audioChannel",
+          "direction": "desc"
+        },
+        {
+          "key": "language",
+          "direction": "desc"
+        },
+        {
+          "key": "seeders",
+          "direction": "desc"
+        },
+        {
+          "key": "size",
+          "direction": "desc"
+        }
+      ]
+    },
+    "formatter": {
+      "id": "tamtaro",
+      "definitions": {
+        "overrides": {
+          "tamtaro": {
+            "name": "{stream.resolution::exists[\"{stream.resolution::replace('2160p','\ud83d\udfe3 4K')::replace('1440p','\ud83d\udfe1 2K')::replace('1080p','\ud83d\udd35 1080P')::replace('720p','\ud83d\udfe2 720P')::replace('480p','\u26ab 480P')::replace('360p','\u26ab 360P')}  \"||\"\ud83d\udcfa HD  \"]}{service.shortName::exists[\"\u26a1 {service.shortName::upper}  \"||\"\ud83d\udce1 P2P  \"]}{stream.library::istrue[\"\ud83d\uddc4\ufe0f  \"||\"\"]}{stream.proxied::istrue[\"\ud83d\udd75\ufe0f  \"||\"\"]}{stream.visualTags::~(?i)(DV|HDR|HLG)[\"{stream.visualTags::join(' ')::replace('DV','\ud83d\udc41\ufe0f DV')::replace('HDR10+','\u2728 HDR\u00b9\u2070\u207a')::replace('HDR10','\ud83c\udf1f HDR\u00b9\u2070')::replace('HLG','\ud83c\udf24\ufe0f HLG')::replace('HDR','\ud83c\udf1f HDR')::replace('SDR','')::replace('10BIT','')::replace('10bit','')::replace('STANDARD','')}  \"||\"\"]}{stream.title::exists[\"{stream.title::upper}\"||\"\"]}{stream.formattedSeasons::exists[\" {stream.formattedSeasons::upper}\"||\"\"]}{stream.formattedEpisodes::exists[\" {stream.formattedEpisodes::upper}\"||\"\"]}",
+            "description": " {service.cached::istrue[\"\ud83d\ude80 INSTANT  \"||\"\"]}{service.cached::isfalse[\"\u26a0\ufe0f UNCACHED  \"||\"\"]}{stream.nSeScore::>=75[\"\ud83d\udc8e {stream.nSeScore}  \"||\"\"]}{stream.seadexBest::istrue[\"\u2b50 BEST  \"||\"\"]}{stream.seadex::istrue[\"\u2705 SEADEX  \"||\"\"]}{stream.regexMatched::exists[\"\ud83c\udfaf {stream.regexMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.seMatched::exists[\"\ud83e\uddf2 {stream.seMatched::truncate(12)::smallcaps}  \"||\"\"]}{stream.releaseGroup::exists[\"\ud83c\udff7\ufe0f {stream.releaseGroup::smallcaps}  \"||\"\"]}{stream.releaseGroup::~(?i)(epsilon|framestor|qxr|tigole|ntb|flux|d-z0n3|playbd|hifi|don|huno|bmf)[\"\ud83d\udc51 PREMIER  \"||\"\"]}{stream.filename::~(?i)IMAX[\"\ud83c\udf9e\ufe0f IMAX  \"||\"\"]}{tools.newLine} \ud83c\udfac {stream.quality::exists[\"{stream.quality::upper::replace('BLURAY REMUX','\ud83d\udc8e REMUX')::replace('BLURAY','\ud83d\udcbf BLURAY')::replace('BLU-RAY REMUX','\ud83d\udc8e REMUX')::replace('BLU-RAY','\ud83d\udcbf BLURAY')::replace('WEB-DL','\ud83c\udf7f WEB-DL')::replace('WEBRIP','\ud83d\udcfc WEBRIP')::replace('HDTV','\ud83c\udf9e\ufe0f HDTV')::replace('HDRIP','\ud83c\udf9e\ufe0f HDRIP')}  \"||\"\"]}{stream.encode::exists[\"{stream.encode::smallcaps}  \"||\"\"]}{stream.container::exists[\"{stream.container::smallcaps}  \"||\"\"]}{stream.hasChapters::istrue[\"\ud83d\udcd6  \"||\"\"]}{stream.visualTags::exists[\"{stream.visualTags::join(' ')::replace('DV','\ud83d\udc41\ufe0f DV')::replace('HDR10+','\u2728 HDR\u00b9\u2070\u207a')::replace('HDR10','\ud83c\udf1f HDR\u00b9\u2070')::replace('HLG','\ud83c\udf24\ufe0f HLG')::replace('HDR','\ud83c\udf1f HDR')::replace('SDR','\u2600\ufe0f SDR')::replace('10BIT','\ud83c\udfa8 10\u0299\u026a\u1d1b')::replace('10bit','\ud83c\udfa8 10\u0299\u026a\u1d1b')::replace('STANDARD','\u2600\ufe0f SDR')}  \"||\"\u2600\ufe0f SDR  \"]}{stream.bitrate::exists[\"{stream.bitrate::sbitrate::smallcaps}  \"||\"\"]}{stream.network::exists[\"\ud83c\udf7f {stream.network::upper}  \"||\"\"]}{stream.upscaled::istrue[\"\ud83d\udd2c UPSCALED  \"||\"\"]}{stream.unrated::istrue[\"\ud83d\udeab UNRATED  \"||\"\"]}{stream.uncensored::istrue[\"\ud83d\udd1e  \"||\"\"]}{stream.editions::exists[\"\u2702\ufe0f {stream.editions::join(' ')::upper}  \"||\"\"]}{tools.newLine} \ud83c\udf9b\ufe0f {stream.audioTags::exists[\"{stream.audioTags::join(' ')::upper::replace('ATMOS','\ud83d\udd2e ATMOS')::replace('TRUEHD','\ud83d\udc8e TRUEHD')::replace('DTS-HD MA','\ud83d\udd37 DTS-HD MA')::replace('DTS-X','\ud83c\udfb5 DTS-X')::replace('EAC3','\ud83c\udfb6 EAC3')::replace('DDP','\ud83c\udfb6 DD+')::replace('DD+','\ud83c\udfb6 DD+')::replace('AAC','\ud83c\udfa7 AAC')::replace('FLAC','\ud83d\udcbf FLAC')::replace('AC3','\ud83c\udfb5 AC3')}  \"||\"\u1d00\u1d1c\u1d05\u026a\u1d0f  \"]}{stream.audioChannels::first::=2.0[\"\ud83d\udd08 \"||\"\"]}{stream.audioChannels::first::=5.1[\"\ud83d\udd09 \"||\"\"]}{stream.audioChannels::first::=7.1[\"\ud83d\udd0a \"||\"\"]}{stream.audioChannels::exists[\"{stream.audioChannels::first}  \"||\"\"]}\ud83c\udf0d {stream.uLanguageEmojis::exists[\"{stream.uLanguageEmojis::join(' ')}\"||\"MULTI\"]}{stream.dubbed::istrue[\"  \ud83c\udf99\ufe0f DUB\"||\"\"]}{stream.uSubtitleEmojis::exists[\"  \ud83d\udcdd {stream.uSubtitleEmojis::slice(0,3)::join(' ')}\"||\"\"]}{tools.newLine} \ud83d\udcbe {stream.size::exists[\"{stream.size::sbytes}  \"||\"\"]}{stream.folderSize::exists[\"\ud83d\udce6 {stream.folderSize::sbytes}  \"||\"\"]}{stream.seasonPack::istrue[\"\ud83d\uddc2\ufe0f PACK  \"||\"\"]}{stream.repack::istrue[\"\ud83d\udee0\ufe0f REPACK  \"||\"\"]}{stream.seeders::exists[\"\ud83c\udf31 {stream.seeders}  \"||\"\"]}{stream.freeleech::istrue[\"\ud83c\udd93 FREE  \"||\"\"]}{stream.age::exists[\"\u23f1\ufe0f {stream.age::smallcaps}  \"||\"\"]}{stream.indexer::exists[\"\ud83d\udd0d {stream.indexer::truncate(12)::smallcaps}  \"||\"\"]}\ud83d\udd0c {stream.type::exists[\"{stream.type::smallcaps}\"||\"\"]}"
+          }
+        }
+      }
+    },
+    "proxy": {
+      "id": "mediaflow",
+      "proxiedAddons": [],
+      "proxiedServices": []
+    },
+    "hideErrors": true,
+    "hideErrorsForResources": [
+      "addon_catalog",
+      "catalog",
+      "subtitles"
+    ],
+    "statistics": {
+      "enabled": false,
+      "position": "bottom",
+      "statsToShow": [
+        "addon",
+        "filter",
+        "timing"
+      ],
+      "showFilterStatsOnNoStreams": true
+    },
+    "yearMatching": {
+      "enabled": true,
+      "strict": false,
+      "useInitialAirDate": true,
+      "tolerance": 2,
+      "requestTypes": [],
+      "addons": []
+    },
+    "titleMatching": {
+      "enabled": true,
+      "mode": "contains",
+      "similarityThreshold": 0.75,
+      "requestTypes": [],
+      "addons": []
+    },
+    "seasonEpisodeMatching": {
+      "enabled": true,
+      "strict": false,
+      "requestTypes": [],
+      "addons": []
+    },
+    "deduplicator": {
+      "enabled": true,
+      "excludeAddons": [],
+      "multiGroupBehaviour": "aggressive",
+      "keys": [
+        "filename",
+        "infoHash",
+        "smartDetect"
+      ],
+      "cached": "single_result",
+      "uncached": "per_service",
+      "p2p": "per_addon",
+      "smartDetectAttributes": [
+        "size",
+        "resolution",
+        "quality",
+        "visualTags",
+        "audioTags",
+        "audioChannels",
+        "languages",
+        "encode",
+        "edition",
+        "network",
+        "remastered",
+        "bitrate",
+        "releaseGroup"
+      ],
+      "smartDetectRounding": 10,
+      "libraryBehaviour": "prefer",
+      "tiebreakers": [
+        {
+          "type": "torrent_seeders",
+          "position": "before_addon"
+        },
+        {
+          "type": "usenet_age",
+          "position": "before_addon"
+        }
+      ]
+    },
+    "autoPlay": {
+      "enabled": true,
+      "method": "matchingFile",
+      "attributes": [
+        "resolution",
+        "quality",
+        "audioTags"
+      ]
+    },
+    "areYouStillThere": {
+      "enabled": false
+    },
+    "precacheNextEpisode": true,
+    "precacheSingleStream": true,
+    "checkOwned": false,
+    "externalDownloads": false,
+    "autoRemoveDownloads": false,
+    "excludedStreamSources": [
+      "YouTube",
+      "AI Enhanced"
+    ],
+    "addonCategoryColors": {
+      "Mix": "indigo",
+      "Debrid": "emerald",
+      "Usenet": "lime",
+      "HTTP": "cyan",
+      "P2P": "orange",
+      "Subs": "purple"
+    },
+    "mergedCatalogs": [],
+    "rpdbApiKey": "t0-free-rpdb",
+    "posterService": "rpdb",
+    "enhanceResults": true,
+    "tmdbAccessToken": "<template_placeholder>",
+    "tmdbApiKey": "<template_placeholder>",
+    "usePosterRedirectApi": true,
+    "usePosterServiceForMeta": true,
+    "syncedRankedRegexUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json"
+    ],
+    "syncedRankedStreamExpressionUrls": [
+      "https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json"
+    ],
+    "resultLimits": {
+      "global": 20,
+      "resolution": 8,
+      "mode": "conjunctive"
+    },
+    "cacheAndPlay": {
+      "enabled": true,
+      "streamTypes": [
+        "usenet",
+        "torrent"
+      ]
+    },
+    "nzbFailover": {
+      "enabled": true,
+      "position": "last"
+    },
+    "serviceWrap": {
+      "enabled": false,
+      "services": [
+        "torbox"
+      ],
+      "reconfigureService": false
+    },
+    "preloadStreams": {
+      "enabled": true,
+      "selector": "queryType == 'movie' ? slice(perGroup(cached(streams), 'quality', 2), 0, 4) : slice(perGroup(cached(streams), 'resolution', 2), 0, 4)",
+      "singleStream": true
+    },
+    "precacheSelector": "count(cached(streams)) == 0 ? slice(uncached(type(streams, 'debrid', 'usenet')), 0, 1) : []",
+    "presets": [
+      {
+        "type": "library",
+        "instanceId": "lib-1",
+        "enabled": true,
+        "options": {
+          "name": "Library",
+          "timeout": 3000,
+          "resources": [
+            "stream",
+            "catalog",
+            "meta"
+          ],
+          "mediaTypes": [],
+          "showRefreshActions": [
+            "catalog"
+          ],
+          "skipProcessing": false,
+          "hideStreams": false,
+          "useMultipleInstances": false
+        }
+      },
+      {
+        "type": "zilean",
+        "instanceId": "nx-fix-04",
+        "enabled": true,
+        "options": {
+          "name": "Zilean",
+          "timeout": 4000,
+          "resources": [
+            "stream"
+          ]
+        },
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "seadex",
+        "instanceId": "tam-seadex",
+        "enabled": false,
+        "options": {
+          "name": "SeaDex",
+          "timeout": 4000,
+          "mediaTypes": [
+            "anime"
+          ]
+        },
+        "category": "Debrid",
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "stremthruTorz",
+        "instanceId": "67c",
+        "enabled": true,
+        "options": {
+          "name": "StremThru Torz",
+          "timeout": 5000,
+          "includeP2P": false,
+          "useMultipleInstances": false
+        },
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "meteor",
+        "instanceId": "nx-fix-02",
+        "enabled": true,
+        "options": {
+          "name": "Meteor",
+          "timeout": 6000,
+          "yourMedia": {
+            "sources": [
+              "torrent",
+              "webdl",
+              "usenet"
+            ],
+            "showStreams": true,
+            "enabled": true
+          },
+          "usenet": {
+            "enabled": true,
+            "customSearchEngines": true
+          },
+          "url": "https://meteorfortheweebs.midnightignite.me",
+          "resources": [
+            "stream"
+          ]
+        },
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "comet",
+        "instanceId": "nx-fix-01",
+        "enabled": true,
+        "options": {
+          "name": "Comet RD",
+          "timeout": 7000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "scrapeDebridAccountTorrents": true
+        },
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "mediafusion",
+        "enabled": true,
+        "instanceId": "d5f1ff1d-b8f5-4ade-a922-357a0c02e8b4",
+        "options": {
+          "timeout": 7000,
+          "name": "MediaFusion",
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ]
+        },
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "hdhub",
+        "enabled": true,
+        "instanceId": "hdhub-1",
+        "options": {
+          "name": "HdHub",
+          "timeout": 5000,
+          "resources": [
+            "stream"
+          ],
+          "mediaTypes": [
+            "movie",
+            "series",
+            "anime"
+          ],
+          "tb_only": true
+        }
+      },
+      {
+        "type": "eztv",
+        "enabled": true,
+        "options": {
+          "timeout": 5000,
+          "name": "EZTV"
+        },
+        "instanceId": "3cb9b60c-eee4-4622-a992-62dd746bab58",
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "torrent-galaxy",
+        "enabled": true,
+        "options": {
+          "timeout": 5000,
+          "name": "Torrent Galaxy"
+        },
+        "instanceId": "8b334f9b-e5c2-4061-bc3d-305d1d0c422f",
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "knaben",
+        "instanceId": "tam-knaben",
+        "enabled": true,
+        "options": {
+          "name": "Knaben",
+          "timeout": 6000,
+          "mediaTypes": [],
+          "useMultipleInstances": false
+        },
+        "category": "Debrid",
+        "resources": [
+          "stream"
+        ]
+      },
+      {
+        "type": "aiosubtitle",
+        "instanceId": "aio-sub-1",
+        "enabled": true,
+        "options": {
+          "timeout": 4000,
+          "name": "AIOSubtitle",
+          "languages": [
+            "en"
+          ]
+        }
+      },
+      {
+        "type": "torbox-search",
+        "instanceId": "5f6",
+        "enabled": false,
+        "options": {
+          "name": "TorBox Search",
+          "timeout": 4000,
+          "sources": [
+            "torrent",
+            "usenet"
+          ],
+          "mediaTypes": [],
+          "userSearchEngines": false,
+          "onlyShowUserSearchResults": false,
+          "useMultipleInstances": false
+        }
+      }
+    ],
+    "services": [
+      {
+        "id": "realdebrid",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "alldebrid",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "premiumize",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "debridlink",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "torbox",
+        "enabled": true,
+        "credentials": {}
+      },
+      {
+        "id": "offcloud",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "putio",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "easynews",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "easydebrid",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "pikpak",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "seedr",
+        "enabled": false,
+        "credentials": {}
+      },
+      {
+        "id": "debrider",
+        "enabled": false,
+        "credentials": {}
+      }
+    ],
+    "addonName": "Core Builds Base \u2014 TorBox",
+    "addonDescription": "Shared base configuration for Core Builds TorBox templates. Import this first, then reference its UUID when generating child templates via the configurator.",
+    "excludedResolutions": [
+      "144p",
+      "240p",
+      "360p"
+    ],
+    "requiredResolutions": [],
+    "preferredResolutions": [
+      "2160p",
+      "1080p",
+      "720p",
+      "480p",
+      "Unknown"
+    ],
+    "preferredVisualTags": [
+      "HDR+DV",
+      "DV",
+      "HDR10+",
+      "HDR10",
+      "HDR",
+      "HLG",
+      "10bit",
+      "SDR",
+      "IMAX"
+    ],
+    "excludedAudioTags": [],
+    "excludedAudioChannels": [],
+    "preferredAudioChannels": [
+      "7.1",
+      "5.1",
+      "2.0"
+    ],
+    "excludedEncodes": [],
+    "preferredEncodes": [
+      "AV1",
+      "H.265",
+      "H.264",
+      "MPEG-2",
+      "MPEG-4",
+      "VC-1",
+      "VP9",
+      "Unknown"
+    ],
+    "preferredStreamTypes": [
+      "usenet",
+      "debrid"
+    ],
+    "preferredRegexPatterns": [],
+    "regexOverrides": [],
+    "excludedStreamExpressions": [],
+    "preferredStreamExpressions": [],
+    "includedStreamExpressions": [],
+    "size": {
+      "min": "1 B",
+      "max": "150 GB"
+    },
+    "bitrate": {
+      "min": 0,
+      "max": 150
+    },
+    "maxResults": 20,
+    "maxResultsPerResolution": 8,
+    "dynamicAddonFetching": {
+      "enabled": false,
+      "condition": ""
+    },
+    "groups": {},
+    "catalogModifications": [],
+    "appliedTemplates": []
+  }
+}

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -497,7 +497,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
 </style>
-<script>var _0x358af2=_0x22fa;function _0x53c9(){var _0x185c4b=['C2v0qxr0CMLIDxrL','Bwf0y2HnzwrPyq','zg9JDw1LBNrfBgvTzw50','BgLNAhq','zgf0ys10AgvTzq','nZK0ndi3mhfhv2TUEa','mtqWndC5nuHJwhHhBa','mtaWnZi3mdzMsMf5t04','zgfYAW','mZa5mJeZoeDmweLjvW','mtq4suTisLbm','mtq3mtjOzfrbweG','mtC5mtCXnJHYBfngBhu','Bwf0y2HLCW','odiWotu3mMzZrKPUqW','y2juAgvTzq','z2v0sxrLBq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP'];_0x53c9=function(){return _0x185c4b;};return _0x53c9();}function _0x22fa(_0x25a149,_0x2738bc){_0x25a149=_0x25a149-(-0x1*-0x5e7+-0x11f0+-0x62*-0x21);var _0x3ab052=_0x53c9();var _0x2a7f0c=_0x3ab052[_0x25a149];if(_0x22fa['rnMayQ']===undefined){var _0x43fafd=function(_0x21c384){var _0xc54713='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x3b0e33='',_0x5373eb='';for(var _0x1fc60e=0x5c*0x20+-0x69b*0x1+0x1*-0x4e5,_0x41be26,_0x34a19d,_0x255acc=-0x2260+0x1d9a+0x4c6;_0x34a19d=_0x21c384['charAt'](_0x255acc++);~_0x34a19d&&(_0x41be26=_0x1fc60e%(0xb0e+0x1cc4+-0x27ce)?_0x41be26*(-0xfa9+-0x1*-0xac5+-0x2f*-0x1c)+_0x34a19d:_0x34a19d,_0x1fc60e++%(0x12*0x93+0x11af*0x1+-0x1c01))?_0x3b0e33+=String['fromCharCode'](0x2253*-0x1+0x2*0xec2+0x2*0x2e7&_0x41be26>>(-(-0x4*-0x3ad+0x7f1*0x3+-0x2685)*_0x1fc60e&-0x133d+-0x451+0x6*0x3ee)):-0x1215+-0x41c*-0x1+0xdf9){_0x34a19d=_0xc54713['indexOf'](_0x34a19d);}for(var _0x2911d8=0x1539+0x1406+0x1*-0x293f,_0x360add=_0x3b0e33['length'];_0x2911d8<_0x360add;_0x2911d8++){_0x5373eb+='%'+('00'+_0x3b0e33['charCodeAt'](_0x2911d8)['toString'](-0x2*0xaa9+0x1*-0x82a+0x1d8c))['slice'](-(0x9*0x2f5+-0x1139*-0x1+-0x2bd4));}return decodeURIComponent(_0x5373eb);};_0x22fa['FQynYb']=_0x43fafd,_0x22fa['LLbXXA']={},_0x22fa['rnMayQ']=!![];}var _0x386e8d=_0x3ab052[-0x110+-0x1*-0xefd+-0xded],_0x30febb=_0x25a149+_0x386e8d,_0x2af9f3=_0x22fa['LLbXXA'][_0x30febb];return!_0x2af9f3?(_0x2a7f0c=_0x22fa['FQynYb'](_0x2a7f0c),_0x22fa['LLbXXA'][_0x30febb]=_0x2a7f0c):_0x2a7f0c=_0x2af9f3,_0x2a7f0c;}(function(_0x3d5ae5,_0x243351){var _0x4bbcaf={_0x2925ac:0x9e,_0x3fddbb:0xa0,_0x54e1af:0x9f,_0x366fcb:0xa3,_0x216c27:0x9c,_0x41e497:0xa1},_0xee63b9=_0x22fa,_0x10c766=_0x3d5ae5();while(!![]){try{var _0x1c3d85=-parseInt(_0xee63b9(0x9b))/(0x1*0x261c+-0xb24+0x3b*-0x75)+parseInt(_0xee63b9(_0x4bbcaf._0x2925ac))/(-0x6e2*-0x3+0x105f+-0x2503)+parseInt(_0xee63b9(_0x4bbcaf._0x3fddbb))/(-0x1*-0xefd+-0x9de+-0x51c)*(parseInt(_0xee63b9(_0x4bbcaf._0x54e1af))/(-0x6f0+0x1*0x903+-0x1*0x20f))+-parseInt(_0xee63b9(0x9a))/(0xb69*-0x1+-0x1cf8+0x1*0x2866)+parseInt(_0xee63b9(_0x4bbcaf._0x366fcb))/(0x877*-0x1+-0x56c+0xde9)+-parseInt(_0xee63b9(_0x4bbcaf._0x216c27))/(0x655*0x5+0xf4f+-0xc5*0x3d)+parseInt(_0xee63b9(_0x4bbcaf._0x41e497))/(-0x1*-0x1f75+-0x2064+0xf7*0x1);if(_0x1c3d85===_0x243351)break;else _0x10c766['push'](_0x10c766['shift']());}catch(_0x4dd3a6){_0x10c766['push'](_0x10c766['shift']());}}}(_0x53c9,0x107*-0xbfa+0x5*-0x5524d+-0x24a6f*-0x17));try{document[_0x358af2(0xa9)][_0x358af2(0xa7)](_0x358af2(0x99),localStorage[_0x358af2(0xa5)](_0x358af2(0xa4))||(window[_0x358af2(0xa8)](_0x358af2(0xa6))[_0x358af2(0xa2)]?_0x358af2(0x9d):_0x358af2(0xaa)));}catch(_0x4b3ed3){}</script>
+<script>var _0x35caa9=_0x10de;function _0x10de(_0xbd1d66,_0x8f920d){_0xbd1d66=_0xbd1d66-(0x2497+0x1f2d+-0xf*0x46b);var _0x4d399f=_0x46ca();var _0x2a7a51=_0x4d399f[_0xbd1d66];if(_0x10de['cCwqqs']===undefined){var _0x48778a=function(_0x3e5653){var _0x1189d9='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x2b6330='',_0xaeb484='';for(var _0x224954=-0x16a1+0x225b+-0xbba,_0x85f55a,_0x1968cd,_0x57e9f2=0x1*0x9d3+-0x1*0xb5d+0x18a*0x1;_0x1968cd=_0x3e5653['charAt'](_0x57e9f2++);~_0x1968cd&&(_0x85f55a=_0x224954%(0x5*0xa9+0x504+-0x84d)?_0x85f55a*(0x1*0x3dd+-0x1ce1+-0x7*-0x39c)+_0x1968cd:_0x1968cd,_0x224954++%(-0x1*-0x26c7+-0x1580+-0x1143))?_0x2b6330+=String['fromCharCode'](0x2c*-0x1b+0x1c4d+0x3*-0x78e&_0x85f55a>>(-(-0xd83+-0x20f4+0x2e79)*_0x224954&0x667*-0x5+-0x7c+-0x681*-0x5)):-0x1a1*0x4+-0x4*-0x5a7+0x14*-0xce){_0x1968cd=_0x1189d9['indexOf'](_0x1968cd);}for(var _0x209ad4=0x23dc+-0x1ed2+-0x50a,_0x1d475f=_0x2b6330['length'];_0x209ad4<_0x1d475f;_0x209ad4++){_0xaeb484+='%'+('00'+_0x2b6330['charCodeAt'](_0x209ad4)['toString'](-0x20b2+0xa6*-0x11+-0xaf2*-0x4))['slice'](-(0x5*0x629+-0x3*0x641+0x9a*-0x14));}return decodeURIComponent(_0xaeb484);};_0x10de['SjbbAU']=_0x48778a,_0x10de['UEescT']={},_0x10de['cCwqqs']=!![];}var _0x26ca76=_0x4d399f[0x2f*0x7+0x1*0x1f46+-0x208f*0x1],_0x1f38c3=_0xbd1d66+_0x26ca76,_0x32d675=_0x10de['UEescT'][_0x1f38c3];return!_0x32d675?(_0x2a7a51=_0x10de['SjbbAU'](_0x2a7a51),_0x10de['UEescT'][_0x1f38c3]=_0x2a7a51):_0x2a7a51=_0x32d675,_0x2a7a51;}function _0x46ca(){var _0x1d599f=['mZm5ntaXoefsywDLuq','nJy4nZm4mgzRCNvLCW','mte3BKffqNbr','Bwf0y2HnzwrPyq','y2juAgvTzq','mtbtqvvdufm','mtaWnZm4odb4tNzYyKG','mZa0mZCXm3byr3jLCW','ngXSzxPfvW','mti4nJeYyMD3u1fp','mJC5nJqWyvrrt2zv','ntm2ndv0wgr2ufu','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mZzOrM9xs1G','zgf0ys10AgvTzq','nKj3wMXbEq','Bwf0y2HLCW','BgLNAhq','zg9JDw1LBNrfBgvTzw50','C2v0qxr0CMLIDxrL'];_0x46ca=function(){return _0x1d599f;};return _0x46ca();}(function(_0x13ffdd,_0x5444b8){var _0x43515a={_0x2d8067:0x191,_0x18cdbe:0x18b,_0x2b75d6:0x189,_0x30905a:0x18d,_0x56dcac:0x18f,_0x2dee8d:0x18c,_0x5ac7ee:0x184,_0x1cfdde:0x182},_0x2088c3=_0x10de,_0xaee5fc=_0x13ffdd();while(!![]){try{var _0x3f6e1a=parseInt(_0x2088c3(_0x43515a._0x2d8067))/(-0x262d+-0x386+0x29b4)*(-parseInt(_0x2088c3(_0x43515a._0x18cdbe))/(-0x1241+0x20f5+-0xeb2*0x1))+parseInt(_0x2088c3(_0x43515a._0x2b75d6))/(-0x94*-0xe+0x3*0xa4d+-0x26fc)*(parseInt(_0x2088c3(0x18a))/(0x586+0xc7d*0x1+0x11ff*-0x1))+-parseInt(_0x2088c3(_0x43515a._0x30905a))/(-0x1*-0x1a+-0x936+0x921)*(-parseInt(_0x2088c3(_0x43515a._0x56dcac))/(-0x8be+0x27a*0x3+0x72*0x3))+parseInt(_0x2088c3(0x183))/(0x6fc*-0x2+0xac4+-0x1*-0x33b)+-parseInt(_0x2088c3(_0x43515a._0x2dee8d))/(-0x19ab*0x1+-0x2c5*0x1+0x71e*0x4)*(parseInt(_0x2088c3(_0x43515a._0x5ac7ee))/(0x242a+-0x375+-0x20ac))+parseInt(_0x2088c3(0x187))/(0x24*0xc1+-0x6cd+-0x1*0x144d)*(parseInt(_0x2088c3(_0x43515a._0x1cfdde))/(0x2d*-0xa5+-0x12d9*0x1+-0xc9*-0x3d))+-parseInt(_0x2088c3(0x188))/(0x2*-0x137b+-0x800+0x1781*0x2);if(_0x3f6e1a===_0x5444b8)break;else _0xaee5fc['push'](_0xaee5fc['shift']());}catch(_0x5076fe){_0xaee5fc['push'](_0xaee5fc['shift']());}}}(_0x46ca,-0x13887a+0x1*-0x13f3cd+0x319ad5));try{document[_0x35caa9(0x180)][_0x35caa9(0x181)](_0x35caa9(0x190),localStorage['getItem'](_0x35caa9(0x186))||(window[_0x35caa9(0x185)](_0x35caa9(0x18e))[_0x35caa9(0x192)]?'dark':_0x35caa9(0x17f)));}catch(_0x292641){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -648,7 +648,7 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
 
 const FORMATTERS = [
   {
@@ -1429,6 +1429,35 @@ function render() {
               <div id="uuidStatus" style="font-size:.73rem;margin-top:4px;min-height:18px"></div>
             </div>
           </div>
+          <details id="baseConfigDetails" style="margin-top:12px;border:1px solid rgba(168,85,247,.18);border-radius:10px;padding:10px 13px;background:rgba(168,85,247,.04)">
+            <summary style="list-style:none;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;outline:none">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/></svg>
+              <span style="font-size:.74rem;font-weight:700;color:#a855f7;letter-spacing:.03em">Base Config</span>
+              <span style="font-size:.65rem;color:#6b7280;margin-left:2px">${S.baseUuid ? '· active' : '· optional'}</span>
+              <span style="margin-left:auto;font-size:.72rem;color:#6b7280">›</span>
+            </summary>
+            <div style="margin-top:10px">
+              <div style="font-size:.72rem;color:#6b7280;line-height:1.5;margin-bottom:10px">
+                If you've imported <strong style="color:#a855f7">Core Builds Base — TorBox</strong>, enter its UUID here.
+                Your generated template will inherit all shared config from the parent — smaller JSON, instant propagation of base updates.
+              </div>
+              <div class="name-row" style="margin-bottom:6px">
+                <label style="color:#a855f7">Base UUID</label>
+                <input class="name-input" id="baseUuidInput" type="text"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  value="${S.baseUuid}" data-action="update-base-uuid" maxlength="36"
+                  style="font-family:monospace;font-size:.85rem;border-color:${S.baseUuid ? 'rgba(168,85,247,.5)' : ''}">
+              </div>
+              <div class="name-row" style="margin-bottom:0">
+                <label style="color:#a855f7">Base Password</label>
+                <input class="name-input" id="basePwdInput" type="password"
+                  placeholder="leave blank if none"
+                  value="${S.basePassword}" data-action="update-base-pwd" maxlength="200"
+                  autocomplete="new-password">
+              </div>
+              ${S.baseUuid ? `<div style="font-size:.7rem;color:#a855f7;margin-top:8px;display:flex;align-items:center;gap:5px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>Generated template will use parentConfig — formatter, sort, presets inherited from base.</div>` : ''}
+            </div>
+          </details>
           <button class="btn-manifest" id="btnAio" data-action="install-stremio" style="margin-top:14px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
             Generate Manifest
@@ -1900,6 +1929,8 @@ document.addEventListener('DOMContentLoaded', () => {
     else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
     else if (a === 'update-pwd') S.instancePassword = e.target.value;
+    else if (a === 'update-base-uuid') { S.baseUuid = e.target.value.trim(); e.target.style.borderColor = S.baseUuid ? 'rgba(168,85,247,.5)' : ''; }
+    else if (a === 'update-base-pwd') S.basePassword = e.target.value;
     else if (a === 'update-uuid') {
       const raw = e.target.value.trim();
       const extracted = extractManifestParts(raw);
@@ -2174,37 +2205,80 @@ function pses() {
 
 function build() {
   const name = (S.name.trim() || defaultName()), rc = resolutionCfg(), ec = encodeCfg(), ac = audioCfg();
-  return {
-    metadata: { id: 'core-custom-' + sid(), name, description: `Custom template generated by Core Builds Configurator.`, source: 'external', version: '0.1.0', category: 'Debrid', serviceRequired: false, setToSaveInstallMenu: true, sourceUrl: 'https://github.com/brevityA/Core-Builds', changelogUrl: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md' },
-    config: {
-      trusted: false, showChanges: true, addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name, presets: presets(), services: services(),
-      excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
-      excludedQualities: [], includedQualities: [], requiredQualities: [], preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
-      excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
-      excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
-      enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
-      excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
-      checkOwned: false, externalDownloads: false, autoRemoveDownloads: false, excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
-      syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'], syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'], rankedRegexPatterns: [], preferredRegexPatterns: [], excludedRegexPatterns: [],
-      addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'}, mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,
-      ...(S.tmdbToken ? { tmdbAccessToken: S.tmdbToken } : {}),
-      ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
-      usePosterRedirectApi: true, usePosterServiceForMeta: true,
-      maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
-      excludedStreamExpressions: eses(), includedStreamExpressions: [
-        { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
-        ...(S.langExclusive && S.langs && S.langs.length ? [{
-          enabled: true,
-          expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
-        }] : [])
-      ], preferredStreamExpressions: pses(),
-      sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
-      deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
-      dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },
-      groups: { enabled: (S.service === 'torbox-pro' || S.service === 'hybrid' || (S.service === 'multi' && S.multiServices.includes('torbox-pro'))), groupings:[{ addons:['nx-fix-02','nx-fix-01'], condition:"count(cached(previousStreams))<3" }] },
-      formatter: (function(){ const _f = FORMATTERS.find(f => f.id === (S.formatter||'apex-v2')) || FORMATTERS[0]; return { id:'tamtaro', definitions:{ overrides:{ tamtaro:{ name: _f.name, description: _f.d } } } }; })()
-    }
+  const useBase = !!(S.baseUuid && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(S.baseUuid.trim()));
+
+  // Fields only included when NOT using a base config (inherited via misc/sorting/formatter/services)
+  const standaloneOnly = useBase ? {} : {
+    preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
+    excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
+    preferredAudioTags: ac.preferredAudioTags,
+    syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'],
+    syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'],
+    rankedRegexPatterns: [], excludedRegexPatterns: [],
+    addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'},
+    mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,
+    usePosterRedirectApi: true, usePosterServiceForMeta: true,
+    ...(S.tmdbToken ? { tmdbAccessToken: S.tmdbToken } : {}),
+    ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
+    sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
+    deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
+    formatter: (function(){ const _f = FORMATTERS.find(f => f.id === (S.formatter||'apex-v2')) || FORMATTERS[0]; return { id:'tamtaro', definitions:{ overrides:{ tamtaro:{ name: _f.name, description: _f.d } } } }; })(),
+    proxy: { id:'mediaflow', proxiedAddons:[], proxiedServices:[] },
+    checkOwned: false, externalDownloads: false, autoRemoveDownloads: false,
+    presets: presets(), services: services(),
   };
+
+  const cfg = {
+    trusted: false, showChanges: true,
+    addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name,
+    ...standaloneOnly,
+    excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
+    excludedQualities: [], includedQualities: [], requiredQualities: [],
+    excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes,
+    excludedAudioTags: ac.excludedAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
+    enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
+    excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [],
+    excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
+    excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
+    preferredRegexPatterns: [],
+    maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
+    excludedStreamExpressions: eses(),
+    includedStreamExpressions: [
+      { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
+      ...(S.langExclusive && S.langs && S.langs.length ? [{
+        enabled: true,
+        expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
+      }] : [])
+    ],
+    preferredStreamExpressions: pses(),
+    dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },
+    groups: { enabled: (S.service === 'torbox-pro' || S.service === 'hybrid' || (S.service === 'multi' && S.multiServices.includes('torbox-pro'))), groupings:[{ addons:['nx-fix-02','nx-fix-01'], condition:"count(cached(previousStreams))<3" }] },
+  };
+
+  const result = {
+    metadata: { id: 'core-custom-' + sid(), name, description: `Custom template generated by Core Builds Configurator.`, source: 'external', version: '0.1.0', category: 'Debrid', serviceRequired: false, setToSaveInstallMenu: true, sourceUrl: 'https://github.com/brevityA/Core-Builds', changelogUrl: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md' },
+    config: cfg
+  };
+
+  if (useBase) {
+    result.parentConfig = {
+      uuid: S.baseUuid.trim(),
+      password: S.basePassword || '',
+      mergeStrategies: {
+        presets: 'extend',
+        services: 'inherit',
+        filters: 'override',
+        sorting: 'inherit',
+        formatter: 'inherit',
+        branding: 'override',
+        proxy: 'inherit',
+        metadata: 'inherit',
+        misc: 'inherit'
+      }
+    };
+  }
+
+  return result;
 }
 
 function generate() {

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -648,7 +648,7 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
 
 const FORMATTERS = [
   {
@@ -1429,6 +1429,35 @@ function render() {
               <div id="uuidStatus" style="font-size:.73rem;margin-top:4px;min-height:18px"></div>
             </div>
           </div>
+          <details id="baseConfigDetails" style="margin-top:12px;border:1px solid rgba(168,85,247,.18);border-radius:10px;padding:10px 13px;background:rgba(168,85,247,.04)">
+            <summary style="list-style:none;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;outline:none">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/></svg>
+              <span style="font-size:.74rem;font-weight:700;color:#a855f7;letter-spacing:.03em">Base Config</span>
+              <span style="font-size:.65rem;color:#6b7280;margin-left:2px">${S.baseUuid ? '· active' : '· optional'}</span>
+              <span style="margin-left:auto;font-size:.72rem;color:#6b7280">›</span>
+            </summary>
+            <div style="margin-top:10px">
+              <div style="font-size:.72rem;color:#6b7280;line-height:1.5;margin-bottom:10px">
+                If you've imported <strong style="color:#a855f7">Core Builds Base — TorBox</strong>, enter its UUID here.
+                Your generated template will inherit all shared config from the parent — smaller JSON, instant propagation of base updates.
+              </div>
+              <div class="name-row" style="margin-bottom:6px">
+                <label style="color:#a855f7">Base UUID</label>
+                <input class="name-input" id="baseUuidInput" type="text"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  value="${S.baseUuid}" data-action="update-base-uuid" maxlength="36"
+                  style="font-family:monospace;font-size:.85rem;border-color:${S.baseUuid ? 'rgba(168,85,247,.5)' : ''}">
+              </div>
+              <div class="name-row" style="margin-bottom:0">
+                <label style="color:#a855f7">Base Password</label>
+                <input class="name-input" id="basePwdInput" type="password"
+                  placeholder="leave blank if none"
+                  value="${S.basePassword}" data-action="update-base-pwd" maxlength="200"
+                  autocomplete="new-password">
+              </div>
+              ${S.baseUuid ? `<div style="font-size:.7rem;color:#a855f7;margin-top:8px;display:flex;align-items:center;gap:5px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>Generated template will use parentConfig — formatter, sort, presets inherited from base.</div>` : ''}
+            </div>
+          </details>
           <button class="btn-manifest" id="btnAio" data-action="install-stremio" style="margin-top:14px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
             Generate Manifest
@@ -1900,6 +1929,8 @@ document.addEventListener('DOMContentLoaded', () => {
     else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
     else if (a === 'update-pwd') S.instancePassword = e.target.value;
+    else if (a === 'update-base-uuid') { S.baseUuid = e.target.value.trim(); e.target.style.borderColor = S.baseUuid ? 'rgba(168,85,247,.5)' : ''; }
+    else if (a === 'update-base-pwd') S.basePassword = e.target.value;
     else if (a === 'update-uuid') {
       const raw = e.target.value.trim();
       const extracted = extractManifestParts(raw);
@@ -2174,37 +2205,80 @@ function pses() {
 
 function build() {
   const name = (S.name.trim() || defaultName()), rc = resolutionCfg(), ec = encodeCfg(), ac = audioCfg();
-  return {
-    metadata: { id: 'core-custom-' + sid(), name, description: `Custom template generated by Core Builds Configurator.`, source: 'external', version: '0.1.0', category: 'Debrid', serviceRequired: false, setToSaveInstallMenu: true, sourceUrl: 'https://github.com/brevityA/Core-Builds', changelogUrl: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md' },
-    config: {
-      trusted: false, showChanges: true, addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name, presets: presets(), services: services(),
-      excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
-      excludedQualities: [], includedQualities: [], requiredQualities: [], preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
-      excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
-      excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes, excludedAudioTags: ac.excludedAudioTags, preferredAudioTags: ac.preferredAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
-      enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
-      excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [], excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
-      checkOwned: false, externalDownloads: false, autoRemoveDownloads: false, excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
-      syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'], syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'], rankedRegexPatterns: [], preferredRegexPatterns: [], excludedRegexPatterns: [],
-      addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'}, mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,
-      ...(S.tmdbToken ? { tmdbAccessToken: S.tmdbToken } : {}),
-      ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
-      usePosterRedirectApi: true, usePosterServiceForMeta: true,
-      maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
-      excludedStreamExpressions: eses(), includedStreamExpressions: [
-        { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
-        ...(S.langExclusive && S.langs && S.langs.length ? [{
-          enabled: true,
-          expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
-        }] : [])
-      ], preferredStreamExpressions: pses(),
-      sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
-      deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
-      dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },
-      groups: { enabled: (S.service === 'torbox-pro' || S.service === 'hybrid' || (S.service === 'multi' && S.multiServices.includes('torbox-pro'))), groupings:[{ addons:['nx-fix-02','nx-fix-01'], condition:"count(cached(previousStreams))<3" }] },
-      formatter: (function(){ const _f = FORMATTERS.find(f => f.id === (S.formatter||'apex-v2')) || FORMATTERS[0]; return { id:'tamtaro', definitions:{ overrides:{ tamtaro:{ name: _f.name, description: _f.d } } } }; })()
-    }
+  const useBase = !!(S.baseUuid && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(S.baseUuid.trim()));
+
+  // Fields only included when NOT using a base config (inherited via misc/sorting/formatter/services)
+  const standaloneOnly = useBase ? {} : {
+    preferredQualities: ['BluRay REMUX','BluRay','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','SCR','TC','TS','CAM','Unknown'],
+    excludedLanguages: [], includedLanguages: [...new Set([...(S.langs||['English']),'Original','Dual Audio','Multi','Dubbed','Unknown'])],
+    preferredAudioTags: ac.preferredAudioTags,
+    syncedExcludedRegexUrls: ['https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/refs/heads/main/AIOStreams-SyncedURLs/Tamtaro-synced-excluded-regex.json'],
+    syncedRankedRegexUrls: ['https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json'],
+    rankedRegexPatterns: [], excludedRegexPatterns: [],
+    addonCategoryColors: {Mix:'indigo',Debrid:'emerald',Usenet:'lime',HTTP:'cyan',P2P:'orange',Subs:'purple'},
+    mergedCatalogs: [], rpdbApiKey: 't0-free-rpdb', posterService: 'rpdb', enhanceResults: true,
+    usePosterRedirectApi: true, usePosterServiceForMeta: true,
+    ...(S.tmdbToken ? { tmdbAccessToken: S.tmdbToken } : {}),
+    ...(S.tmdbApiKey ? { tmdbApiKey: S.tmdbApiKey } : {}),
+    sortCriteria: { global:[{key:'cached',direction:'desc'},{key:'streamExpressionMatched',direction:'desc'},{key:'streamExpressionScore',direction:'desc'},{key:'library',direction:'desc'},...(S.qualityFirst?[{key:'quality',direction:'desc'},{key:'resolution',direction:'desc'}]:[{key:'resolution',direction:'desc'},{key:'quality',direction:'desc'}]),{key:'regexScore',direction:'desc'},{key:'visualTag',direction:'desc'},{key:'encode',direction:'desc'},{key:'audioTag',direction:'desc'},{key:'audioChannel',direction:'desc'},{key:'language',direction:'desc'},{key:'seeders',direction:'desc'},{key:'size',direction:'desc'}], movies:[], series:[], anime:[] },
+    deduplicator: { enabled:true, excludeAddons:[], multiGroupBehaviour: S.matchMode === 'relaxed' ? 'conservative' : 'aggressive', keys:['filename','infoHash','smartDetect'], cached: S.matchMode === 'relaxed' ? 'per_service' : 'single_result', uncached:'per_service', p2p:'per_addon', smartDetectAttributes:['size','resolution','quality','visualTags','audioTags','audioChannels','languages','encode','edition','network','remastered','bitrate','releaseGroup'], smartDetectRounding: S.matchMode === 'strict' ? 5 : 10, libraryBehaviour:'prefer', tiebreakers:[{type:'torrent_seeders',position:'before_addon'},{type:'usenet_age',position:'before_addon'}] },
+    formatter: (function(){ const _f = FORMATTERS.find(f => f.id === (S.formatter||'apex-v2')) || FORMATTERS[0]; return { id:'tamtaro', definitions:{ overrides:{ tamtaro:{ name: _f.name, description: _f.d } } } }; })(),
+    proxy: { id:'mediaflow', proxiedAddons:[], proxiedServices:[] },
+    checkOwned: false, externalDownloads: false, autoRemoveDownloads: false,
+    presets: presets(), services: services(),
   };
+
+  const cfg = {
+    trusted: false, showChanges: true,
+    addonName: name, addonLogo: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/core_icon.svg', addonDescription: name,
+    ...standaloneOnly,
+    excludedResolutions: rc.excludedResolutions, includedResolutions: rc.includedResolutions, requiredResolutions: rc.requiredResolutions, preferredResolutions: rc.preferredResolutions,
+    excludedQualities: [], includedQualities: [], requiredQualities: [],
+    excludedEncodes: ec.excludedEncodes, preferredEncodes: ec.preferredEncodes,
+    excludedAudioTags: ac.excludedAudioTags, preferredAudioChannels: ac.preferredAudioChannels, preferredVisualTags: visualTags(),
+    enableSeadex: S.content !== 'live', seadexBestOnly: S.content === 'anime',
+    excludeCached: S.cacheMode === 'uncached', excludeCachedFromAddons: [], excludeCachedFromServices: [], excludeCachedFromStreamTypes: [],
+    excludeUncached: S.cacheMode === 'cached', excludeUncachedFromAddons: [], excludeUncachedFromServices: [], excludeUncachedFromStreamTypes: [],
+    excludeUncachedMode: 'or', excludedStreamSources: ['YouTube','AI Enhanced'],
+    preferredRegexPatterns: [],
+    maxResults: rc.maxResults, maxResultsPerResolution: rc.maxResultsPerResolution,
+    excludedStreamExpressions: eses(),
+    includedStreamExpressions: [
+      { enabled:true, expression:"/* REPACK / PROPER */ keyword(streams,'filename','REPACK','PROPER','REPACK2','PROPER2')" },
+      ...(S.langExclusive && S.langs && S.langs.length ? [{
+        enabled: true,
+        expression: `/* Language Exclusive — only ${(S.langs||['English']).join('/')} */ language(streams,${[...new Set([...(S.langs||['English']),'Original','Multi','Dual Audio','Dubbed','Unknown'])].map(l=>`'${l}'`).join(',')})`
+      }] : [])
+    ],
+    preferredStreamExpressions: pses(),
+    dynamicAddonFetching: { enabled:true, condition: S.resolution==='4k' ? "count(cached(resolution(totalStreams,'2160p')))>=5 or totalTimeTaken>5000" : S.resolution==='ultrawide' ? "count(cached(resolution(totalStreams,'1080p')))>=10 or count(cached(resolution(totalStreams,'2160p')))>=3 or totalTimeTaken>5000" : "count(cached(resolution(totalStreams,'1080p')))>=15 or totalTimeTaken>5000" },
+    groups: { enabled: (S.service === 'torbox-pro' || S.service === 'hybrid' || (S.service === 'multi' && S.multiServices.includes('torbox-pro'))), groupings:[{ addons:['nx-fix-02','nx-fix-01'], condition:"count(cached(previousStreams))<3" }] },
+  };
+
+  const result = {
+    metadata: { id: 'core-custom-' + sid(), name, description: `Custom template generated by Core Builds Configurator.`, source: 'external', version: '0.1.0', category: 'Debrid', serviceRequired: false, setToSaveInstallMenu: true, sourceUrl: 'https://github.com/brevityA/Core-Builds', changelogUrl: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md' },
+    config: cfg
+  };
+
+  if (useBase) {
+    result.parentConfig = {
+      uuid: S.baseUuid.trim(),
+      password: S.basePassword || '',
+      mergeStrategies: {
+        presets: 'extend',
+        services: 'inherit',
+        filters: 'override',
+        sorting: 'inherit',
+        formatter: 'inherit',
+        branding: 'override',
+        proxy: 'inherit',
+        metadata: 'inherit',
+        misc: 'inherit'
+      }
+    };
+  }
+
+  return result;
 }
 
 function generate() {


### PR DESCRIPTION
## Summary

- **Configurator**: New purple "Base Config" collapsible panel on the Review step — accepts a Base UUID and optional Base Password. When a valid UUID is entered, `build()` strips inherited fields from the output and wraps it in a `parentConfig` block, reducing child template size ~33% (65 KB → 44 KB, 111 → 24 config keys).
- **`parentConfig` merge strategies**: `presets=extend`, `services/sorting/formatter/proxy/metadata/misc=inherit`, `filters/branding=override`.
- **`Templates/Base/core-nexus-base-torbox.json`** (v1.0.0, 23 KB): new shared base template holding all 84 common fields — 13 presets, full tamtaro formatter, sortCriteria (12 keys), deduplicator, autoPlay, proxy, regex URLs, addon category colors. Import once into AIOStreams, enter its UUID in the configurator, and all generated templates inherit it automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_