### PR TITLE
fix(docs+github): restore intro logo, rebrand all banners + GitHub to cyan

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,4 +49,4 @@ Small fixes (typos, broken links, outdated info) can be submitted as a PR direct
 
 ## ❓ Questions
 
-Not a bug or contribution — just a question? Open a [Discussion](https://github.com/Branding-Brevity/Core-Builds-By-Brevity/discussions) rather than an issue.
+Not a bug or contribution — just a question? Open a [Discussion](https://github.com/brevityA/Core-Builds/discussions) rather than an issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 General Questions & Help
-    url: https://github.com/Branding-Brevity/Core-Builds-By-Brevity/discussions
+    url: https://github.com/brevityA/Core-Builds/discussions
     about: Not a bug? Ask in Discussions instead.
   - name: 📖 Documentation
-    url: https://github.com/brevityA/Core-Builds/blob/main/Guides/README.md
+    url: https://core-builds.mintlify.app
     about: Check the full guide before opening an issue.

--- a/Assets/community_banner.svg
+++ b/Assets/community_banner.svg
@@ -1,56 +1,51 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" width="1200" height="280">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#080f0b"/>
-      <stop offset="50%" stop-color="#0d1710"/>
-      <stop offset="100%" stop-color="#080f0b"/>
+      <stop offset="0%" stop-color="#080b0f"/>
+      <stop offset="50%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#080b0f"/>
     </linearGradient>
     <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#3fb950" stop-opacity="0"/>
-      <stop offset="30%" stop-color="#3fb950" stop-opacity="0.8"/>
-      <stop offset="70%" stop-color="#3fb950" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#3fb950" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
     </linearGradient>
   </defs>
 
   <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
-  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#3fb950" stroke-width="1" stroke-opacity="0.15"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#00d4ff" stroke-width="1" stroke-opacity="0.15"/>
 
   <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
 
-  <!-- Main title -->
   <text x="600" y="105"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="72" font-weight="800" letter-spacing="-1"
     fill="#ffffff" text-anchor="middle">COMMUNITY BUILDS</text>
 
-  <!-- By line -->
   <text x="600" y="148"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="400" letter-spacing="12"
-    fill="#3fb950" text-anchor="middle" opacity="0.9">BY BREVITY</text>
+    fill="#00d4ff" text-anchor="middle" opacity="0.9">BY BREVITY</text>
 
-  <rect x="400" y="158" width="400" height="2" rx="1" fill="#3fb950" opacity="0.4"/>
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#00d4ff" opacity="0.4"/>
 
-  <!-- Subtitle -->
   <text x="600" y="208"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="300" letter-spacing="4"
-    fill="#7ee89a" text-anchor="middle" opacity="0.7">FORMATTERS  ·  TEMPLATES  ·  CONTRIBUTIONS</text>
+    fill="#7eeeff" text-anchor="middle" opacity="0.7">FORMATTERS  ·  TEMPLATES  ·  CONTRIBUTIONS</text>
 
-  <!-- Tag line -->
   <text x="600" y="244"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="14" font-weight="300" letter-spacing="3"
     fill="#888fa0" text-anchor="middle" opacity="0.6">OPEN TO ALL AIOSTREAMS USERS</text>
 
-  <!-- Corner decorations -->
-  <rect x="40" y="20" width="30" height="4" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="40" y="20" width="4" height="30" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="40" y="256" width="30" height="4" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="40" y="230" width="4" height="30" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#3fb950" opacity="0.4"/>
-  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#3fb950" opacity="0.4"/>
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
 </svg>

--- a/Assets/formatters_banner.svg
+++ b/Assets/formatters_banner.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" width="1200" height="280">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f0a06"/>
-      <stop offset="50%" stop-color="#140e08"/>
-      <stop offset="100%" stop-color="#0f0a06"/>
+      <stop offset="0%" stop-color="#080b0f"/>
+      <stop offset="50%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#080b0f"/>
     </linearGradient>
     <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f0883e" stop-opacity="0"/>
-      <stop offset="30%" stop-color="#f0883e" stop-opacity="0.8"/>
-      <stop offset="70%" stop-color="#f0883e" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#f0883e" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
     </linearGradient>
   </defs>
 
   <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
-  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#f0883e" stroke-width="1" stroke-opacity="0.15"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#00d4ff" stroke-width="1" stroke-opacity="0.15"/>
 
   <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
 
@@ -26,26 +26,26 @@
   <text x="600" y="148"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="400" letter-spacing="12"
-    fill="#f0883e" text-anchor="middle" opacity="0.9">BY BREVITY</text>
+    fill="#00d4ff" text-anchor="middle" opacity="0.9">BY BREVITY</text>
 
-  <rect x="400" y="158" width="400" height="2" rx="1" fill="#f0883e" opacity="0.4"/>
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#00d4ff" opacity="0.4"/>
 
   <text x="600" y="208"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="300" letter-spacing="4"
-    fill="#ffc09e" text-anchor="middle" opacity="0.7">STREAM DISPLAY LAYOUTS FOR AIOSTREAMS</text>
+    fill="#7eeeff" text-anchor="middle" opacity="0.7">STREAM DISPLAY LAYOUTS FOR AIOSTREAMS</text>
 
   <text x="600" y="244"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="14" font-weight="300" letter-spacing="3"
     fill="#888fa0" text-anchor="middle" opacity="0.6">14 FORMATTERS  ·  TAMTARO COMPATIBLE  ·  COMMUNITY INCLUDED</text>
 
-  <rect x="40" y="20" width="30" height="4" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="40" y="20" width="4" height="30" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="40" y="256" width="30" height="4" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="40" y="230" width="4" height="30" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#f0883e" opacity="0.4"/>
-  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#f0883e" opacity="0.4"/>
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
 </svg>

--- a/Assets/master_guide_banner.svg
+++ b/Assets/master_guide_banner.svg
@@ -6,15 +6,15 @@
       <stop offset="100%" stop-color="#080b0f"/>
     </linearGradient>
     <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#58a6ff" stop-opacity="0"/>
-      <stop offset="30%" stop-color="#58a6ff" stop-opacity="0.8"/>
-      <stop offset="70%" stop-color="#58a6ff" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#58a6ff" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
     </linearGradient>
   </defs>
 
   <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
-  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#58a6ff" stroke-width="1" stroke-opacity="0.15"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#00d4ff" stroke-width="1" stroke-opacity="0.15"/>
 
   <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
 
@@ -26,26 +26,26 @@
   <text x="600" y="148"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="400" letter-spacing="12"
-    fill="#58a6ff" text-anchor="middle" opacity="0.9">BY BREVITY</text>
+    fill="#00d4ff" text-anchor="middle" opacity="0.9">BY BREVITY</text>
 
-  <rect x="400" y="158" width="400" height="2" rx="1" fill="#58a6ff" opacity="0.4"/>
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#00d4ff" opacity="0.4"/>
 
   <text x="600" y="208"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="300" letter-spacing="4"
-    fill="#a5c8ff" text-anchor="middle" opacity="0.7">SET UP  ·  CUSTOMISE  ·  MAINTAIN YOUR BUILD</text>
+    fill="#7eeeff" text-anchor="middle" opacity="0.7">SET UP  ·  CUSTOMISE  ·  MAINTAIN YOUR BUILD</text>
 
   <text x="600" y="244"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="14" font-weight="300" letter-spacing="3"
     fill="#888fa0" text-anchor="middle" opacity="0.6">COMPLETE REFERENCE FOR CORE BUILDS</text>
 
-  <rect x="40" y="20" width="30" height="4" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="40" y="20" width="4" height="30" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="40" y="256" width="30" height="4" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="40" y="230" width="4" height="30" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#58a6ff" opacity="0.4"/>
-  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#58a6ff" opacity="0.4"/>
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
 </svg>

--- a/Assets/templates_banner.svg
+++ b/Assets/templates_banner.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" width="1200" height="280">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a080f"/>
+      <stop offset="0%" stop-color="#080b0f"/>
       <stop offset="50%" stop-color="#0d1117"/>
-      <stop offset="100%" stop-color="#0a080f"/>
+      <stop offset="100%" stop-color="#080b0f"/>
     </linearGradient>
     <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#a371f7" stop-opacity="0"/>
-      <stop offset="30%" stop-color="#a371f7" stop-opacity="0.8"/>
-      <stop offset="70%" stop-color="#a371f7" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#a371f7" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#00d4ff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
     </linearGradient>
   </defs>
 
   <rect width="1200" height="280" fill="url(#bg)" rx="12"/>
-  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#a371f7" stroke-width="1" stroke-opacity="0.15"/>
+  <rect x="1" y="1" width="1198" height="278" rx="11" fill="none" stroke="#00d4ff" stroke-width="1" stroke-opacity="0.15"/>
 
   <rect x="40" y="139" width="1120" height="1" fill="url(#line)" opacity="0.3"/>
 
@@ -26,26 +26,26 @@
   <text x="600" y="148"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="400" letter-spacing="12"
-    fill="#a371f7" text-anchor="middle" opacity="0.9">BY BREVITY</text>
+    fill="#00d4ff" text-anchor="middle" opacity="0.9">BY BREVITY</text>
 
-  <rect x="400" y="158" width="400" height="2" rx="1" fill="#a371f7" opacity="0.4"/>
+  <rect x="400" y="158" width="400" height="2" rx="1" fill="#00d4ff" opacity="0.4"/>
 
   <text x="600" y="208"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="18" font-weight="300" letter-spacing="4"
-    fill="#c8a9fa" text-anchor="middle" opacity="0.7">TORBOX  ·  ALLDEBRID  ·  EASYNEWS</text>
+    fill="#7eeeff" text-anchor="middle" opacity="0.7">TORBOX  ·  ALLDEBRID  ·  EASYNEWS</text>
 
   <text x="600" y="244"
     font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
     font-size="14" font-weight="300" letter-spacing="3"
     fill="#888fa0" text-anchor="middle" opacity="0.6">CORE BUILDS TEMPLATE LIBRARY</text>
 
-  <rect x="40" y="20" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="40" y="20" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="40" y="256" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="40" y="230" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#a371f7" opacity="0.4"/>
-  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#a371f7" opacity="0.4"/>
+  <rect x="40" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="20" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="20" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="40" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1130" y="256" width="30" height="4" rx="2" fill="#00d4ff" opacity="0.4"/>
+  <rect x="1156" y="230" width="4" height="30" rx="2" fill="#00d4ff" opacity="0.4"/>
 </svg>

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@
 
 <p align="center">
   <a href="https://github.com/brevityA/Core-Builds/discussions">
-    <img src="https://img.shields.io/badge/DISCUSSIONS-Community-7c3aed?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1f27" alt="Discussions"/>
+    <img src="https://img.shields.io/badge/DISCUSSIONS-Community-00d4ff?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1f27" alt="Discussions"/>
   </a>
   <a href="https://www.reddit.com/r/CoreBuilds/">
     <img src="https://img.shields.io/badge/REDDIT-r%2FCoreBuilds-FF4500?style=for-the-badge&logo=reddit&logoColor=white&labelColor=1a1f27" alt="Reddit"/>
   </a>
-  <a href="https://github.com/brevityA/Core-Builds/blob/main/ROADMAP.md">
-    <img src="https://img.shields.io/badge/ROADMAP-What's_Next-0ea5e9?style=for-the-badge&logo=github&logoColor=white&labelColor=1a1f27" alt="Roadmap"/>
+  <a href="https://core-builds.mintlify.app/roadmap">
+    <img src="https://img.shields.io/badge/ROADMAP-What's_Next-00d4ff?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Roadmap"/>
   </a>
   <a href="https://core-builds.mintlify.app">
-    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-3B82F6?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
+    <img src="https://img.shields.io/badge/DOCS-core--builds.mintlify.app-00d4ff?style=for-the-badge&logo=gitbook&logoColor=white&labelColor=1a1f27" alt="Documentation"/>
   </a>
 </p>
 
@@ -248,15 +248,19 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 ---
 
-## 📖 Wiki
+## 📖 Documentation
+
+Full docs at **[core-builds.mintlify.app](https://core-builds.mintlify.app)**
 
 | Guide | Link |
 |---|---|
-| Import a template | [Wiki → Importing a Template](https://github.com/brevityA/Core-Builds/wiki/Importing-a-Template) |
-| Formatters | [Wiki → Formatters](https://github.com/brevityA/Core-Builds/wiki/Formatters) |
-| Filtering | [Wiki → Expression Rules](https://github.com/brevityA/Core-Builds/blob/main/Guides/EXPRESSION_RULES.md) |
-| Device profiles | [Wiki → Device Profiles](https://github.com/brevityA/Core-Builds/wiki/Device-Profiles) |
-| Troubleshooting | [Wiki → Troubleshooting and FAQ](https://github.com/brevityA/Core-Builds/wiki/Troubleshooting-and-FAQ) |
+| Quick Start | [Docs → Quick Start](https://core-builds.mintlify.app/quick-start) |
+| Import a template | [Docs → Importing a Template](https://core-builds.mintlify.app/importing) |
+| Which template? | [Docs → Which Template?](https://core-builds.mintlify.app/which-template) |
+| Formatters | [Docs → Formatters](https://core-builds.mintlify.app/formatters) |
+| Device profiles | [Docs → Device Profiles](https://core-builds.mintlify.app/device-profiles) |
+| Troubleshooting | [Docs → Troubleshooting](https://core-builds.mintlify.app/troubleshooting) |
+| FAQ | [Docs → FAQ](https://core-builds.mintlify.app/faq) |
 
 ---
 
@@ -282,7 +286,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 ## 📜 Version
 
-Current: **`v2.8.3`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
+Current: **`v3.0.2`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
 
 ---
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -28,28 +28,16 @@ mode: "wide"
         <stop offset="50%" stopColor="#c060c0"/>
         <stop offset="100%" stopColor="#ff4b2b"/>
       </linearGradient>
-      <radialGradient id="dsrmask" cx="50%" cy="50%" r="50%">
-        <stop offset="20%" stopColor="white" stopOpacity="1"/>
-        <stop offset="70%" stopColor="white" stopOpacity="0.6"/>
-        <stop offset="100%" stopColor="white" stopOpacity="0"/>
-      </radialGradient>
-      <mask id="dsm"><rect width="512" height="512" fill="url(#dsrmask)"/></mask>
-      <filter id="dsf1"><feGaussianBlur stdDeviation="32"/></filter>
-      <filter id="dsf2"><feGaussianBlur stdDeviation="16" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
-      <filter id="dsf3"><feGaussianBlur stdDeviation="60"/></filter>
-      <filter id="dsf4"><feGaussianBlur stdDeviation="6" result="b"/><feComposite in="SourceGraphic" in2="b" operator="over"/></filter>
     </defs>
-    <g mask="url(#dsm)">
-      <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.14" filter="url(#dsf3)"/>
-      <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.22" filter="url(#dsf3)"/>
-      <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="52" strokeLinejoin="round" opacity="0.18" filter="url(#dsf1)"/>
-      <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="18" strokeLinejoin="round" opacity="0.28" filter="url(#dsf4)"/>
-      <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#dsg1)" strokeWidth="14" strokeLinejoin="round" opacity="0.82"/>
-      <polygon className="cb-diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#dsg2)" opacity="0.3" filter="url(#dsf2)"/>
-      <polygon className="cb-diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#dsg2)" opacity="0.85"/>
-      <circle className="cb-core-ring"   cx="256" cy="256" r="90" stroke="url(#dsg2)"/>
-      <circle className="cb-core-ring cb-core-ring-2" cx="256" cy="256" r="90" stroke="url(#dsg2)"/>
-    </g>
+    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.10"/>
+    <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.18"/>
+    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="28" strokeLinejoin="round" opacity="0.14"/>
+    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="18" strokeLinejoin="round" opacity="0.22"/>
+    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="url(#dsg1)" strokeWidth="14" strokeLinejoin="round" opacity="0.82"/>
+    <polygon className="cb-diamond-glow" points="256,166 346,256 256,346 166,256" fill="url(#dsg2)" opacity="0.3"/>
+    <polygon className="cb-diamond-core" points="256,166 346,256 256,346 166,256" fill="url(#dsg2)" opacity="0.85"/>
+    <circle className="cb-core-ring" cx="256" cy="256" r="90" stroke="url(#dsg2)"/>
+    <circle className="cb-core-ring cb-core-ring-2" cx="256" cy="256" r="90" stroke="url(#dsg2)"/>
   </svg>
 
   <div style={{ display: 'inline-block', background: 'rgba(0,212,255,0.1)', border: '1px solid rgba(0,212,255,0.35)', color: '#00d4ff', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>


### PR DESCRIPTION
## Summary

Full cyan rebrand across docs banners, the intro page logo, and GitHub-facing files.

---

### Docs: intro page logo restored

- Removed `<mask>` element from the animated SVG — Mintlify sanitizes mask elements, making everything inside `<g mask="url(#dsm)">` invisible on the live site. Removed the mask wrapper and simplified the glow layers. The hex / diamond / ring animation now renders correctly.

### Docs: all page banners → cyan

All four section banners rebranded from their individual accent colors to `#00d4ff`:

| Banner | Was | Now |
|---|---|---|
| `Assets/templates_banner.svg` | `#a371f7` purple | `#00d4ff` cyan |
| `Assets/master_guide_banner.svg` | `#58a6ff` blue | `#00d4ff` cyan |
| `Assets/formatters_banner.svg` | `#f0883e` orange | `#00d4ff` cyan |
| `Assets/community_banner.svg` | `#3fb950` green | `#00d4ff` cyan |

### GitHub: README badges + stale link fixes

- DISCUSSIONS, ROADMAP, DOCS badges recolored from purple/blue → `#00d4ff`
- Version footer corrected: `v2.8.3` → `v3.0.2`
- Wiki section replaced with Documentation section → mintlify links (Quick Start, Importing, Which Template, Formatters, Device Profiles, Troubleshooting, FAQ)
- ROADMAP badge href updated → mintlify `/roadmap`
- `.github/ISSUE_TEMPLATE/config.yml`: Documentation link → mintlify; Discussions link → current brevityA repo (was old Branding-Brevity URL)
- `.github/CONTRIBUTING.md`: Discussions link → current brevityA repo