### PR TITLE
fix(docs): standalone animated SVG for intro logo

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -17,17 +17,7 @@ mode: "wide"
 
 <div style={{ maxWidth: '680px', margin: '0 auto', padding: '16px 24px 0', textAlign: 'center' }}>
 
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="200" height="200" style={{ display:'block', margin:'0 auto 24px', overflow:'visible' }} aria-label="Core Builds logo">
-    <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.08"/>
-    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="30" strokeLinejoin="round" opacity="0.12"/>
-    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="16" strokeLinejoin="round" opacity="0.2"/>
-    <polygon className="cb-hex-breath" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" strokeWidth="13" strokeLinejoin="round" opacity="0.9"/>
-    <polygon points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.2"/>
-    <polygon className="cb-diamond-glow" points="256,166 346,256 256,346 166,256" fill="#a855f7" opacity="0.38"/>
-    <polygon className="cb-diamond-core" points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.88"/>
-    <circle className="cb-core-ring" cx="256" cy="256" r="90" stroke="#a855f7"/>
-    <circle className="cb-core-ring cb-core-ring-2" cx="256" cy="256" r="90" stroke="#ff4b2b"/>
-  </svg>
+  <img src="/logo/intro_logo.svg" width="200" height="200" style={{ display: 'block', margin: '0 auto 24px' }} alt="Core Builds logo" />
 
   <div style={{ display: 'inline-block', background: 'rgba(0,212,255,0.1)', border: '1px solid rgba(0,212,255,0.35)', color: '#00d4ff', padding: '4px 14px', borderRadius: '999px', fontSize: '13px', fontWeight: '500', marginBottom: '20px', letterSpacing: '0.01em' }}>
     AIOStreams Templates

--- a/docs/logo/intro_logo.svg
+++ b/docs/logo/intro_logo.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <style>
+    @keyframes hexBreath { 0%,100%{ opacity:.55 } 50%{ opacity:.95 } }
+    @keyframes corePulse { 0%,100%{ transform:scale(1); opacity:.88 } 50%{ transform:scale(1.07); opacity:1 } }
+    @keyframes coreGlow  { 0%,100%{ transform:scale(1); opacity:.32 } 50%{ transform:scale(1.26); opacity:.82 } }
+    @keyframes ringOut   { 0%{ transform:scale(.5); opacity:.72 } 100%{ transform:scale(2.1); opacity:0 } }
+    @media (prefers-reduced-motion: reduce) {
+      .hex, .core, .glow, .ring { animation: none }
+    }
+    .hex  { animation: hexBreath 2.6s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+    .core { animation: corePulse 2.6s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+    .glow { animation: coreGlow  2.6s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+    .ring { animation: ringOut   2.6s ease-out   infinite; transform-box: fill-box; transform-origin: center; fill: none; stroke-width: 5; }
+    .ring2 { animation-delay: 1.3s; }
+  </style>
+
+  <!-- hex background fill -->
+  <polygon points="256,41 442,149 442,363 256,471 70,363 70,149" fill="#00e5ff" opacity="0.07"/>
+
+  <!-- hex glow layers -->
+  <polygon class="hex" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="32" stroke-linejoin="round" opacity="0.11"/>
+  <polygon class="hex" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="16" stroke-linejoin="round" opacity="0.20"/>
+
+  <!-- hex outline -->
+  <polygon class="hex" points="256,41 442,149 442,363 256,471 70,363 70,149" fill="none" stroke="#00e5ff" stroke-width="13" stroke-linejoin="round" opacity="0.92"/>
+
+  <!-- diamond glow -->
+  <polygon class="glow" points="256,166 346,256 256,346 166,256" fill="#a855f7" opacity="0.40"/>
+
+  <!-- diamond core -->
+  <polygon class="core" points="256,166 346,256 256,346 166,256" fill="#c060c0" opacity="0.90"/>
+
+  <!-- rings -->
+  <circle class="ring"       cx="256" cy="256" r="90" stroke="#a855f7"/>
+  <circle class="ring ring2" cx="256" cy="256" r="90" stroke="#ff4b2b"/>
+</svg>


### PR DESCRIPTION
## Summary

Inline `<svg>` in Mintlify MDX is not reliable — gradients, masks, and CSS class animations are all stripped at render time, leaving the logo invisible. This switches to the approach that works: a standalone SVG file referenced via `<img>`.

## Changes

- **New file `docs/logo/intro_logo.svg`** — the animated hex + diamond + ring logo with all animation CSS embedded inside a `<style>` tag within the SVG itself. This completely bypasses Mintlify's MDX sanitizer.
- **`docs/introduction.mdx`** — 11-line inline `<svg>` block replaced with a single ``'&lt;img src="/logo/intro_logo.svg" width="200" height="200" /&gt;'``.

## Why this works

External SVG files loaded via `<img>` are served as static assets — Mintlify never touches their content. CSS `@keyframes` and class animations embedded inside the SVG `<style>` tag run in the browser directly. The `cb-*` CSS classes in `custom.css` are not needed since the animations are self-contained.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_