### PR TITLE
feat(configurator): review step polish + API credential UX

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -527,7 +527,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
 </style>
-<script>function _0x14dd(_0x4bc69a,_0x59880c){_0x4bc69a=_0x4bc69a-(-0x18c8+0x1bfc+-0x1*0x1b3);var _0x58d2f6=_0x8470();var _0x1f8e26=_0x58d2f6[_0x4bc69a];if(_0x14dd['xurEOh']===undefined){var _0x52bbf4=function(_0x5d7b63){var _0x50c723='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x5512ce='',_0x5d4e25='';for(var _0x4e61ac=0x207e+0x15fe*-0x1+0x380*-0x3,_0x2183f6,_0x518f6f,_0x256ba0=0x29*-0x3a+-0x1813+0x3*0xb1f;_0x518f6f=_0x5d7b63['charAt'](_0x256ba0++);~_0x518f6f&&(_0x2183f6=_0x4e61ac%(-0x1b79+0x1fea+0xb*-0x67)?_0x2183f6*(-0x171+0xa5e+-0x8ad*0x1)+_0x518f6f:_0x518f6f,_0x4e61ac++%(-0xfb*0x16+0x49*0x31+0x79d))?_0x5512ce+=String['fromCharCode'](-0xb*0x35d+-0x23d6+0x49d4&_0x2183f6>>(-(0xdc0+0xb62+-0x2*0xc90)*_0x4e61ac&0x25a1+-0x1cb*0xd+-0xe4c)):-0x1059*0x1+-0x1c5f+-0x6c*-0x6a){_0x518f6f=_0x50c723['indexOf'](_0x518f6f);}for(var _0x4b0266=0xf*-0xcb+0xc0c+-0x27*0x1,_0x474d9b=_0x5512ce['length'];_0x4b0266<_0x474d9b;_0x4b0266++){_0x5d4e25+='%'+('00'+_0x5512ce['charCodeAt'](_0x4b0266)['toString'](0x359*-0x8+-0xc71+0x2749))['slice'](-(-0x1cb4+0x1*-0x201b+0x1*0x3cd1));}return decodeURIComponent(_0x5d4e25);};_0x14dd['zMUcDo']=_0x52bbf4,_0x14dd['asWwAq']={},_0x14dd['xurEOh']=!![];}var _0x2b1eed=_0x58d2f6[0x11b5+-0x256b*-0x1+-0x3720*0x1],_0xf48497=_0x4bc69a+_0x2b1eed,_0x58c1d1=_0x14dd['asWwAq'][_0xf48497];return!_0x58c1d1?(_0x1f8e26=_0x14dd['zMUcDo'](_0x1f8e26),_0x14dd['asWwAq'][_0xf48497]=_0x1f8e26):_0x1f8e26=_0x58c1d1,_0x1f8e26;}var _0x1ff456=_0x14dd;(function(_0x1270df,_0x71d252){var _0x21398b={_0x12f7b9:0x193,_0x1a91aa:0x188,_0x2d520a:0x190,_0x4d719c:0x182,_0x3eaa69:0x18c,_0x1a6510:0x18f,_0x195ae5:0x181},_0x3590ab=_0x14dd,_0x3beb18=_0x1270df();while(!![]){try{var _0x202315=parseInt(_0x3590ab(_0x21398b._0x12f7b9))/(0x1cb7+0x3be*-0x1+0x31f*-0x8)*(parseInt(_0x3590ab(_0x21398b._0x1a91aa))/(0x2560+0x1926+-0x3e84))+-parseInt(_0x3590ab(0x18e))/(-0x17e*-0xf+-0x27*-0x7f+0x18*-0x1bd)+-parseInt(_0x3590ab(0x18d))/(-0x262a+-0x2c9+0x28f7*0x1)*(parseInt(_0x3590ab(0x187))/(-0x34b*0x2+0x2708+-0x206d))+parseInt(_0x3590ab(_0x21398b._0x2d520a))/(-0xc5e*0x2+0x61*-0x31+0x2b53)+parseInt(_0x3590ab(_0x21398b._0x4d719c))/(-0x5ad+0xda5+-0x7f1)*(parseInt(_0x3590ab(_0x21398b._0x3eaa69))/(0x1d*0x13b+0x1*-0xbc3+-0x17e4))+-parseInt(_0x3590ab(_0x21398b._0x1a6510))/(-0x7*0x1a1+-0x1bc9+0xd13*0x3)+-parseInt(_0x3590ab(_0x21398b._0x195ae5))/(0x879+-0x370*0x8+-0x1311*-0x1)*(parseInt(_0x3590ab(0x192))/(0x1*0x45a+0x1d78+-0x21c7));if(_0x202315===_0x71d252)break;else _0x3beb18['push'](_0x3beb18['shift']());}catch(_0x32aadf){_0x3beb18['push'](_0x3beb18['shift']());}}}(_0x8470,-0x10eda9+-0x14f3*-0xd3+0x10aff*0x8));try{document['documentElement'][_0x1ff456(0x191)](_0x1ff456(0x189),localStorage[_0x1ff456(0x186)](_0x1ff456(0x184))||(window[_0x1ff456(0x183)](_0x1ff456(0x18b))[_0x1ff456(0x185)]?'dark':_0x1ff456(0x18a)));}catch(_0x5d2856){}function _0x8470(){var _0x573206=['zgf0ys10AgvTzq','BgLNAhq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mte2mJrPCLjoyNu','mJe1nZKYDMjAEvPR','odeXnZy0wNrID0Pi','odm2odqZngDLzKrnqG','ntuWntm4ne5HDK1TCW','C2v0qxr0CMLIDxrL','mtfsyvbxv3i','mNbdz2XkrW','mZCXmZbhtfL1wgm','mJuXm0Ldshfjyq','Bwf0y2HnzwrPyq','y2juAgvTzq','Bwf0y2HLCW','z2v0sxrLBq','nJvVr2DZCgG','mtaZnti0ngTyuwzIyW'];_0x8470=function(){return _0x573206;};return _0x8470();}</script>
+<script>var _0x34a8b5=_0x346f;(function(_0x2fe1e2,_0x5b535b){var _0x343cd5={_0x413ffe:0xb0,_0x388513:0xbe,_0x5b2de2:0xb4,_0x544232:0xbd},_0x50fea0=_0x346f,_0x26273c=_0x2fe1e2();while(!![]){try{var _0x5a5918=parseInt(_0x50fea0(_0x343cd5._0x413ffe))/(0x6cb+-0x15f6+0x1*0xf2c)+parseInt(_0x50fea0(0xb2))/(0x10cc+-0x1df1+0xd27)+-parseInt(_0x50fea0(_0x343cd5._0x388513))/(-0xbc0+0x28d*-0x6+0x1b11*0x1)*(parseInt(_0x50fea0(0xba))/(-0x5d3+-0x1bb8+0x218f))+parseInt(_0x50fea0(0xb6))/(-0x5b*-0x2b+0x67*0x22+-0x1cf2)*(-parseInt(_0x50fea0(0xb3))/(-0x301+0x129c*-0x2+0x283f))+-parseInt(_0x50fea0(0xbb))/(-0x8*0x143+0x3a9*-0x1+0xa8*0x15)+parseInt(_0x50fea0(_0x343cd5._0x5b2de2))/(0x206e+0x5d6+-0x263c)*(parseInt(_0x50fea0(0xb8))/(0x133+0x5*0x6de+-0x2380))+parseInt(_0x50fea0(_0x343cd5._0x544232))/(0x5be+0x21d*0xd+-0xb0f*0x3);if(_0x5a5918===_0x5b535b)break;else _0x26273c['push'](_0x26273c['shift']());}catch(_0x5ea5bb){_0x26273c['push'](_0x26273c['shift']());}}}(_0x53d0,0x13292c+-0xd5737+0x51e7f));function _0x346f(_0x264669,_0x2e7e80){_0x264669=_0x264669-(-0x1d3b*-0x1+0x415*-0x5+0x823*-0x1);var _0x2158bd=_0x53d0();var _0x1d02a7=_0x2158bd[_0x264669];if(_0x346f['WvAcRR']===undefined){var _0x10ff5b=function(_0x5de790){var _0x289462='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0xddb0dd='',_0x1ec804='';for(var _0x276156=0x2184+0x1b46*0x1+-0x2*0x1e65,_0x2720c1,_0x4257a1,_0x406315=-0x2*0xe6f+-0x425+-0x2103*-0x1;_0x4257a1=_0x5de790['charAt'](_0x406315++);~_0x4257a1&&(_0x2720c1=_0x276156%(0x505+0x47a*0x5+-0x1b63)?_0x2720c1*(0x1*-0xbc9+-0x18a6+0x24af*0x1)+_0x4257a1:_0x4257a1,_0x276156++%(-0x1e68*0x1+-0x10ee+-0x17ad*-0x2))?_0xddb0dd+=String['fromCharCode'](0x2b*-0xc2+0x5c3+0x3*0x946&_0x2720c1>>(-(-0x3f6*-0x1+0x5*0xc4+-0x7c8)*_0x276156&0x612+0xebb*0x1+0x14c7*-0x1)):0x2e*-0x65+0x7*-0x56e+-0xc*-0x4ae){_0x4257a1=_0x289462['indexOf'](_0x4257a1);}for(var _0x44e84f=-0xb69+0x17b2+0x275*-0x5,_0x14cda6=_0xddb0dd['length'];_0x44e84f<_0x14cda6;_0x44e84f++){_0x1ec804+='%'+('00'+_0xddb0dd['charCodeAt'](_0x44e84f)['toString'](0x135f+0x23c8+-0x3717))['slice'](-(0xd6c*-0x1+-0x1abf*-0x1+-0x1e7*0x7));}return decodeURIComponent(_0x1ec804);};_0x346f['UcDvnC']=_0x10ff5b,_0x346f['dvQoJj']={},_0x346f['WvAcRR']=!![];}var _0x3219b1=_0x2158bd[0x1*-0x16ba+-0x8cc*0x3+0x311e],_0x4ce671=_0x264669+_0x3219b1,_0x5f3848=_0x346f['dvQoJj'][_0x4ce671];return!_0x5f3848?(_0x1d02a7=_0x346f['UcDvnC'](_0x1d02a7),_0x346f['dvQoJj'][_0x4ce671]=_0x1d02a7):_0x1d02a7=_0x5f3848,_0x1d02a7;}try{document[_0x34a8b5(0xb9)][_0x34a8b5(0xb5)]('data-theme',localStorage[_0x34a8b5(0xaf)]('cbTheme')||(window['matchMedia'](_0x34a8b5(0xb1))[_0x34a8b5(0xbc)]?_0x34a8b5(0xb7):_0x34a8b5(0xbf)));}catch(_0x14f174){}function _0x53d0(){var _0x46d81a=['nJG2otG0vwzVtwfL','mJu1mhvjwuLzBG','mJaXotm2ChnqzxDw','C2v0qxr0CMLIDxrL','mti0nJvHvKvQruO','zgfYAW','mJi1vu1yAgTU','zg9JDw1LBNrfBgvTzw50','ngjrsKndrW','mta2ndqYn2fltuXhqG','Bwf0y2HLCW','mta4odi1mhjsu1Djzq','odm2nZmWs2nLrePh','BgLNAhq','z2v0sxrLBq','mteYnda0nxnQv0DMuW','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP'];_0x53d0=function(){return _0x46d81a;};return _0x53d0();}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -1519,9 +1519,12 @@ function render() {
           </details>
         </div>
         <div style="margin-top:20px;padding-top:16px;border-top:1px solid rgba(255,255,255,.06);text-align:center">
-          <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:11px">More from Core Builds</div>
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:11px">
+            <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase">More from Core Builds</div>
+            <button data-action="start-setup" style="font-size:.65rem;font-weight:700;color:#4b5563;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
+          </div>
           <div style="display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 16px">
-            <a href="https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox" target="_blank" rel="noopener" class="community-link">
+            <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
               Browse Templates
             </a>
@@ -1537,7 +1540,9 @@ function render() {
         </div>
       </div>`;
     nav.style.display = 'flex';
-    document.getElementById('btnBack').style.visibility = 'visible';
+    const _rb = document.getElementById('btnBack');
+    _rb.style.visibility = 'visible';
+    _rb.innerHTML = '← Edit Config';
     document.getElementById('btnNext').style.display = 'none';
     if (pasteMode) {
       pasteMode = false;
@@ -1612,8 +1617,15 @@ function render() {
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
             <a href="${inp.url}" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="text" placeholder="${inp.placeholder}"
-            value="${S.creds[inp.id] || ''}" maxlength="120">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
+              value="${S.creds[inp.id] || ''}" maxlength="120" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="cred_${inp.id}" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1623,16 +1635,30 @@ function render() {
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="text" placeholder="eyJhbGciOiJSUzI1NiJ9…"
-            value="${S.tmdbToken}" maxlength="400">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="password" placeholder="eyJhbGciOiJSUzI1NiJ9…"
+              value="${S.tmdbToken}" maxlength="400" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="tmdbIn" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="text" placeholder="abc123def456…"
-            value="${S.tmdbApiKey}" maxlength="60">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="password" placeholder="abc123def456…"
+              value="${S.tmdbApiKey}" maxlength="60" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="tmdbKeyIn" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>
       </div>`;
     nav.style.display = 'flex';
@@ -1832,6 +1858,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'create-import') createImportUrl();
     if (action === 'gen-pwd') genPwd();
     if (action === 'toggle-pwd') togglePwd();
+    if (action === 'toggle-cred-vis') {
+      const inp = document.getElementById(e.target.closest('[data-target]').dataset.target);
+      if (inp) inp.type = inp.type === 'password' ? 'text' : 'password';
+    }
     if (action === 'install-stremio') openInAIOStreams();
     if (action === 'copy-manifest') {
       const url = e.target.dataset.url || e.target.closest('[data-url]')?.dataset.url;
@@ -2351,6 +2381,13 @@ function generate() {
   const json = JSON.stringify(build(), null, 2), blob = new Blob([json], {type:'application/json'}), url = URL.createObjectURL(blob), a = document.createElement('a');
   a.href = url; a.download = (S.name.trim()||defaultName()).toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') + '.json';
   document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(() => URL.revokeObjectURL(url), 100);
+  const dlBtn = document.querySelector('.btn-dl');
+  if (dlBtn) {
+    const orig = dlBtn.innerHTML;
+    dlBtn.innerHTML = '✓ Downloaded!';
+    dlBtn.style.background = 'linear-gradient(135deg,#065f46,#059669)';
+    setTimeout(() => { dlBtn.innerHTML = orig; dlBtn.style.background = ''; }, 2200);
+  }
 }
 
 function showManifestModal(manifestUrl, password, hostLabel) {
@@ -2422,7 +2459,7 @@ function showManifestModal(manifestUrl, password, hostLabel) {
         </div>
       </details>
       <div style="margin-top:12px;padding-top:12px;border-top:1px solid rgba(255,255,255,.05);display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 14px">
-        <a href="https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox" target="_blank" rel="noopener" class="community-link">Browse Templates →</a>
+        <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">Browse Templates →</a>
         <a href="https://www.reddit.com/r/CoreBuilds/" target="_blank" rel="noopener" class="community-link">Reddit</a>
         <a href="https://github.com/brevityA/Core-Builds" target="_blank" rel="noopener" class="community-link">GitHub</a>
       </div>
@@ -2566,11 +2603,18 @@ function showApiReminder(onContinue) {
             <span class="rem-field-name">${inp.label}</span>
             <a href="${inp.url}" target="_blank" class="rem-field-link">Get key →</a>
           </div>
-          <input class="rem-input" id="rem_${inp.id}" data-service="${inp.id}" data-action="update-cred"
-            type="${inp.id === 'easynewsPass' ? 'password' : 'text'}"
-            placeholder="${inp.placeholder}"
-            value="${S.creds[inp.id] || ''}" maxlength="120"
-            oninput="S.creds[this.dataset.service]=this.value;saveState()">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="rem-input" id="rem_${inp.id}" data-service="${inp.id}" data-action="update-cred"
+              type="password"
+              placeholder="${inp.placeholder}"
+              value="${S.creds[inp.id] || ''}" maxlength="120" style="padding-right:40px"
+              oninput="S.creds[this.dataset.service]=this.value;saveState()">
+            <button type="button" data-action="toggle-cred-vis" data-target="rem_${inp.id}" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>`).join('')}
       </div>
       <div class="rem-actions">
@@ -2711,7 +2755,28 @@ async function createImportUrl() {
 
   if (url) {
     navigator.clipboard.writeText(url).catch(()=>{});
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div></div>`;
+
+    // Build credential reminder block — keys were stripped from import URL
+    const credInputs = getDebridInputs().filter(i => S.creds[i.id] && S.creds[i.id].trim());
+    let credBlock = '';
+    if (credInputs.length) {
+      const rows = credInputs.map(inp => {
+        const val = (S.creds[inp.id] || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+        const preview = val.length > 32 ? val.slice(0, 14) + '…' + val.slice(-8) : val;
+        return `<div style="display:flex;align-items:center;gap:6px;margin-top:5px">
+          <span style="font-size:.68rem;color:#6b7280;flex-shrink:0;min-width:76px">${inp.label}</span>
+          <div style="flex:1;font-family:monospace;font-size:.63rem;color:#9ca3af;background:rgba(0,0,0,.25);border-radius:4px;padding:3px 7px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${val}">${preview}</div>
+          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.63rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
+        </div>`;
+      }).join('');
+      credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
+        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">CREDENTIALS TO ENTER IN AIOSTREAMS AFTER IMPORT</div>
+        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Enter these in AIOStreams → Services once your template has loaded.</div>
+        ${rows}
+      </div>`;
+    }
+
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">Your browser's security blocked the cross-origin request. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -1519,9 +1519,12 @@ function render() {
           </details>
         </div>
         <div style="margin-top:20px;padding-top:16px;border-top:1px solid rgba(255,255,255,.06);text-align:center">
-          <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:11px">More from Core Builds</div>
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:11px">
+            <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase">More from Core Builds</div>
+            <button data-action="start-setup" style="font-size:.65rem;font-weight:700;color:#4b5563;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
+          </div>
           <div style="display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 16px">
-            <a href="https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox" target="_blank" rel="noopener" class="community-link">
+            <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
               Browse Templates
             </a>
@@ -1537,7 +1540,9 @@ function render() {
         </div>
       </div>`;
     nav.style.display = 'flex';
-    document.getElementById('btnBack').style.visibility = 'visible';
+    const _rb = document.getElementById('btnBack');
+    _rb.style.visibility = 'visible';
+    _rb.innerHTML = '← Edit Config';
     document.getElementById('btnNext').style.display = 'none';
     if (pasteMode) {
       pasteMode = false;
@@ -1612,8 +1617,15 @@ function render() {
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
             <a href="${inp.url}" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="text" placeholder="${inp.placeholder}"
-            value="${S.creds[inp.id] || ''}" maxlength="120">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
+              value="${S.creds[inp.id] || ''}" maxlength="120" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="cred_${inp.id}" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1623,16 +1635,30 @@ function render() {
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="text" placeholder="eyJhbGciOiJSUzI1NiJ9…"
-            value="${S.tmdbToken}" maxlength="400">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="password" placeholder="eyJhbGciOiJSUzI1NiJ9…"
+              value="${S.tmdbToken}" maxlength="400" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="tmdbIn" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
-          <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="text" placeholder="abc123def456…"
-            value="${S.tmdbApiKey}" maxlength="60">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="password" placeholder="abc123def456…"
+              value="${S.tmdbApiKey}" maxlength="60" style="padding-right:38px">
+            <button type="button" data-action="toggle-cred-vis" data-target="tmdbKeyIn" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;font-size:.72rem;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>
       </div>`;
     nav.style.display = 'flex';
@@ -1832,6 +1858,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'create-import') createImportUrl();
     if (action === 'gen-pwd') genPwd();
     if (action === 'toggle-pwd') togglePwd();
+    if (action === 'toggle-cred-vis') {
+      const inp = document.getElementById(e.target.closest('[data-target]').dataset.target);
+      if (inp) inp.type = inp.type === 'password' ? 'text' : 'password';
+    }
     if (action === 'install-stremio') openInAIOStreams();
     if (action === 'copy-manifest') {
       const url = e.target.dataset.url || e.target.closest('[data-url]')?.dataset.url;
@@ -2351,6 +2381,13 @@ function generate() {
   const json = JSON.stringify(build(), null, 2), blob = new Blob([json], {type:'application/json'}), url = URL.createObjectURL(blob), a = document.createElement('a');
   a.href = url; a.download = (S.name.trim()||defaultName()).toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') + '.json';
   document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(() => URL.revokeObjectURL(url), 100);
+  const dlBtn = document.querySelector('.btn-dl');
+  if (dlBtn) {
+    const orig = dlBtn.innerHTML;
+    dlBtn.innerHTML = '✓ Downloaded!';
+    dlBtn.style.background = 'linear-gradient(135deg,#065f46,#059669)';
+    setTimeout(() => { dlBtn.innerHTML = orig; dlBtn.style.background = ''; }, 2200);
+  }
 }
 
 function showManifestModal(manifestUrl, password, hostLabel) {
@@ -2422,7 +2459,7 @@ function showManifestModal(manifestUrl, password, hostLabel) {
         </div>
       </details>
       <div style="margin-top:12px;padding-top:12px;border-top:1px solid rgba(255,255,255,.05);display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 14px">
-        <a href="https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox" target="_blank" rel="noopener" class="community-link">Browse Templates →</a>
+        <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">Browse Templates →</a>
         <a href="https://www.reddit.com/r/CoreBuilds/" target="_blank" rel="noopener" class="community-link">Reddit</a>
         <a href="https://github.com/brevityA/Core-Builds" target="_blank" rel="noopener" class="community-link">GitHub</a>
       </div>
@@ -2566,11 +2603,18 @@ function showApiReminder(onContinue) {
             <span class="rem-field-name">${inp.label}</span>
             <a href="${inp.url}" target="_blank" class="rem-field-link">Get key →</a>
           </div>
-          <input class="rem-input" id="rem_${inp.id}" data-service="${inp.id}" data-action="update-cred"
-            type="${inp.id === 'easynewsPass' ? 'password' : 'text'}"
-            placeholder="${inp.placeholder}"
-            value="${S.creds[inp.id] || ''}" maxlength="120"
-            oninput="S.creds[this.dataset.service]=this.value;saveState()">
+          <div style="position:relative;display:flex;align-items:center">
+            <input class="rem-input" id="rem_${inp.id}" data-service="${inp.id}" data-action="update-cred"
+              type="password"
+              placeholder="${inp.placeholder}"
+              value="${S.creds[inp.id] || ''}" maxlength="120" style="padding-right:40px"
+              oninput="S.creds[this.dataset.service]=this.value;saveState()">
+            <button type="button" data-action="toggle-cred-vis" data-target="rem_${inp.id}" title="Show / hide"
+              style="position:absolute;right:10px;background:none;border:none;cursor:pointer;color:#4b5563;padding:0;line-height:1;transition:color .15s"
+              onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+          </div>
         </div>`).join('')}
       </div>
       <div class="rem-actions">
@@ -2711,7 +2755,28 @@ async function createImportUrl() {
 
   if (url) {
     navigator.clipboard.writeText(url).catch(()=>{});
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div></div>`;
+
+    // Build credential reminder block — keys were stripped from import URL
+    const credInputs = getDebridInputs().filter(i => S.creds[i.id] && S.creds[i.id].trim());
+    let credBlock = '';
+    if (credInputs.length) {
+      const rows = credInputs.map(inp => {
+        const val = (S.creds[inp.id] || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+        const preview = val.length > 32 ? val.slice(0, 14) + '…' + val.slice(-8) : val;
+        return `<div style="display:flex;align-items:center;gap:6px;margin-top:5px">
+          <span style="font-size:.68rem;color:#6b7280;flex-shrink:0;min-width:76px">${inp.label}</span>
+          <div style="flex:1;font-family:monospace;font-size:.63rem;color:#9ca3af;background:rgba(0,0,0,.25);border-radius:4px;padding:3px 7px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${val}">${preview}</div>
+          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.63rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
+        </div>`;
+      }).join('');
+      credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
+        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">CREDENTIALS TO ENTER IN AIOSTREAMS AFTER IMPORT</div>
+        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Enter these in AIOStreams → Services once your template has loaded.</div>
+        ${rows}
+      </div>`;
+    }
+
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">Your browser's security blocked the cross-origin request. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;


### PR DESCRIPTION
## Summary

Two focused areas: review step structural fixes, and better credential handling across the API entry step and import flow.

---

### Review step fixes

| # | What changed |
|---|---|
| Back button label | Now reads **← Edit Config** instead of the static "← Back" fallback |
| Download feedback | "⬇ Generate & Download" flashes **✓ Downloaded!** for 2.2s after saving the file |
| Browse Templates links | Review footer + manifest modal footer both updated from old GitHub tree URL → mintlify `/template-directory` |
| Start Over | Quiet **Start Over** link added to the "More from Core Builds" row — resets wizard to step 1 |

---

### API credential UX

**Step 5 fields + reminder modal** — all API key and TMDB token inputs now default to `type="password"` (keys hidden). An eye-icon toggle button sits inside each field to reveal/re-hide. Applies to:
- TorBox / AllDebrid / RealDebrid / EasyNews / TMDB Token / TMDB Key in step 5
- Same fields in the full-screen API reminder modal
- New `toggle-cred-vis` action handler wired into the delegated click listener

**Import URL credential reminder** — when "Create Import URL" succeeds and the user has debrid keys set, a warning block appears below the instance chips showing each key (truncated) with a **Copy** button. Users can paste these into AIOStreams → Services after the template loads, without having to navigate back to find them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_