### PR TITLE
feat(templates): latestSeason guard on Kill Season Packs ESE (v3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.1.1 (2026-07-02)
+
+### Changed
+- **`latestSeason` guard on Kill Season Packs ESE** (all 44 active templates + shared `Filtering/core-builds-eses.json`) — the `Kill Season Packs When Episodes Exist` ESE previously fired whenever 3+ episode-level streams existed, regardless of how many seasons the show has. For a show in its first or second season, killing the season pack was often counterproductive — the pack *is* the full show and may be the best result. The guard `latestSeason >= 3` now allows season packs through for shows with ≤2 seasons, and keeps the episode-preference kill active only for long-running series (3+ seasons). Samsung and Apple TV templates, which use a `>= 10` episode threshold, received the same guard. Behaviour for movies is unchanged (season packs don't exist for movies so `seasonPack()` returns `[]` regardless).
+
+### Reference
+- **CLAUDE.md** — `floor`, `ceil`, `round`, `trunc` added to the confirmed available SEL Math functions list (from expr-eval).
+
+---
+
 ## 3.1.0 (2026-07-01)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ Points to Tamtaro's excluded regex file at `Tam-Taro/SEL-Filtering-and-Sorting` 
 
 **Array ops:** `count`, `negate`, `merge`, `slice`, `perGroup`, `pin`
 
-**Math:** `pow`, `sqrt`, `random` (from expr-eval)
+**Math:** `pow`, `sqrt`, `floor`, `ceil`, `round`, `trunc`, `random` (from expr-eval)
 
 ### Key function details
 

--- a/Filtering/core-builds-eses.json
+++ b/Filtering/core-builds-eses.json
@@ -12,7 +12,7 @@
     "enabled": true
   },
   {
-    "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+    "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
     "enabled": true
   },
   {

--- a/Templates/Core-Builds-Base-Config.json
+++ b/Templates/Core-Builds-Base-Config.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-builds-base",
     "name": "Core Builds Base Config",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Shared scraper + expression layer for all Core Builds templates. USAGE: (1) Import this file into AIOStreams to create the parent config and get its UUID. (2) In each child template, add: \"parentConfig\": {\"uuid\": \"PASTE_UUID_HERE\", \"password\": \"PASTE_PASSWORD_HERE\", \"mergeStrategies\": {\"presets\": \"extend\", \"services\": \"extend\", \"filters\": \"override\", \"sorting\": \"inherit\", \"formatter\": \"inherit\", \"branding\": \"override\", \"misc\": \"inherit\"}}. (3) Child template only needs: its service preset (stremthruTorz / stremthruStore), its PSEs, and its template-specific ESEs (Hard Resolution Kill, Score IQR Guard, DV-Only Kill, etc.). Scrapers, sort criteria, formatter, and universal ESEs all inherit from this parent. One update here propagates to all child templates instantly.",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Core-Builds-Base-Config.json",
     "changelog": []
@@ -385,7 +385,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json
@@ -5,7 +5,7 @@
     "description": "4K AllDebrid Lite. DV/HDR · TrueHD/Atmos · Relaxed filtering. No TorBox required. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -268,7 +268,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json
@@ -5,7 +5,7 @@
     "description": "Core Nexus 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD/Atmos · uncapped bitrate. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -320,7 +320,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json
@@ -5,7 +5,7 @@
     "description": "1080p AllDebrid Lite. DTS:X / TrueHD / HEVC · Relaxed filtering. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.17",
+    "version": "0.1.18",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -319,7 +319,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
+++ b/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json
@@ -5,7 +5,7 @@
     "description": "Core Nexus 1080p for AllDebrid. WEB-DL / Remux quality tiers · HDR preferred · TrueHD/Atmos. Requires AllDebrid account.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.18",
+    "version": "0.1.19",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -319,7 +319,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json
@@ -5,7 +5,7 @@
     "description": "Dedicated 4K anime template. SeaDex best releases · DV/HDR10+ priority · Dual audio · Nyaa-sourced · Sub + Dub aware. TorBox Essential. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.7",
+    "version": "2.8.8",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k-lite.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -453,7 +453,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime-4k.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-4k.json
@@ -5,7 +5,7 @@
     "description": "Dedicated 4K anime template. SeaDex best releases · DV/HDR10+ priority · Dual audio · Nyaa-sourced · Sub + Dub aware. TorBox Essential.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.9",
+    "version": "2.8.10",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-4k.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -533,7 +533,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json
@@ -5,7 +5,7 @@
     "description": "Dubbed-first anime build. Prioritises English dubs and Dual Audio over raw Japanese sub tracks. SeaDex best releases · Nyaa-sourced · FLAC/AAC · TorBox Essential. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.7",
+    "version": "2.8.8",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub-lite.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -454,7 +454,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime-dub.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-dub.json
@@ -5,7 +5,7 @@
     "description": "Dubbed-first anime build. Prioritises English dubs and Dual Audio over raw Japanese sub tracks. SeaDex best releases · Nyaa-sourced · FLAC/AAC · TorBox Essential. Ideal for users who prefer English voice acting or mixed households.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.9",
+    "version": "2.8.10",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-dub.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -534,7 +534,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime-lite.json
+++ b/Templates/Torbox/Anime/core-nexus-anime-lite.json
@@ -5,7 +5,7 @@
     "description": "Dedicated anime template. SeaDex best releases · Dual audio · Nyaa-sourced · Sub + Dub aware. TorBox Essential. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.7",
+    "version": "2.8.8",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime-lite.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -453,7 +453,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Anime/core-nexus-anime.json
+++ b/Templates/Torbox/Anime/core-nexus-anime.json
@@ -5,7 +5,7 @@
     "description": "Dedicated anime template. SeaDex best releases · Dual audio · Nyaa-sourced · Sub + Dub aware. TorBox Essential.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.8.9",
+    "version": "2.8.10",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Anime/core-nexus-anime.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md"
@@ -533,7 +533,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung RU7100 (UA65RU7100W) and compatible TVs. Native video containers: MKV, MP4, AVI, MOV, FLV, ASF, 3GP, VOB. Native audio: FLAC, AAC, MP3, M4A, WMA, WAV. No AV1 or Dolby Vision — DV streams excluded. HDR10+, HDR10, HLG priority. HEVC/AVC encodes only. Audio prioritises FLAC and AAC for native playback; Atmos/TrueHD/DTS ranked lower (passthrough/transcode). Full Core Builds expression layer: IQR Apex PSEs · REPACK/PROPER Passthrough · Per-Addon Flood Guard · Usenet Propagation Guard · AI Upscale Exclusion · Codec Efficiency Booster · Audio Pinnacle (native-first) · HDR Priority (no DV) · Ranked regex pool · Full CB ESE stack.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.21",
+    "version": "0.2.22",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -325,7 +325,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 10 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 10) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Samsung smart TVs without native Dolby Vision support — including RU7100, RU8000, NU8000, Q60, and similar 2018–2022 models. DV-only streams are excluded (DV-Only Kill ESE); only HDR10+, HDR10, HLG, and SDR content appears. AV1 and VC-1 excluded (not supported on older Samsung hardware). Lossless audio (TrueHD, DTS-HD MA, DTS:X, FLAC) excluded — Samsung passes these through only via HDMI ARC/eARC to compatible receivers, which most users don't have. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox · Library, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.19",
+    "version": "0.2.20",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -315,7 +315,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 10 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 10) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
+++ b/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json
@@ -5,7 +5,7 @@
     "description": "Stream template tuned for Samsung smart TVs and other devices without Dolby Vision support. DV-only streams are excluded — only HDR10, HDR10+, HLG, and SDR content appears. Based on Core Nexus Stream (1080p · TorBox Essential · Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.19",
+    "version": "0.2.20",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -309,7 +309,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 10 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 10) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Device/Windows/core-nexus-ultrawide.json
+++ b/Templates/Torbox/Device/Windows/core-nexus-ultrawide.json
@@ -5,7 +5,7 @@
     "description": "Windows PC / Ultra-Wide. 1080p primary · 1440p when available · 4K fallback. Full audio (Atmos, TrueHD, DTS-HD MA, DTS:X) · all encodes including AV1 · HDR-first visual priority. No codec restrictions.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -308,7 +308,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential-lite.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 4K build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -272,7 +272,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Essential/core-nexus-4k-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-4k-essential.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 4K build for TorBox Essential users. No Usenet access required -- runs entirely on TorBox's torrent cache.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.11.1",
+    "version": "2.11.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -324,7 +324,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Essential/core-nexus-essential-lite.json
+++ b/Templates/Torbox/Essential/core-nexus-essential-lite.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required — runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB–25 GB. Full addon stack: Comet, Meteor, Zilean, Knaben. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -275,7 +275,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Essential/core-nexus-essential.json
+++ b/Templates/Torbox/Essential/core-nexus-essential.json
@@ -5,7 +5,7 @@
     "description": "A full-featured 1080p SDR build for TorBox Essential users. No Usenet access required — runs entirely on TorBox's torrent cache. Targets WEB-DL and WEBRip sources, blocks BluRay, Remux, 4K, and HDR for reliable playback on budget hardware. File range 1 GB–25 GB. Full addon stack: Comet, Meteor, Zilean, Knaben. A single TorBox Essential subscription is all that is required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.9",
+    "version": "2.9.10",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -323,7 +323,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Flash/core-nexus-flash-4k.json
+++ b/Templates/Torbox/Flash/core-nexus-flash-4k.json
@@ -5,7 +5,7 @@
     "description": "Single-click instant play — 4K. Only cached streams appear — zero uncached results. Derived from Speed 4K but with excludeUncached:true, a 2-stream dynamic stop condition, and pre-resolved top stream. Resolution order: 2160p → 1080p fallback. DV → HDR10+ → HDR priority. If content has no cached streams, the 0Cached ISE shows a title passthrough rather than a blank screen. 4K · TorBox Essential · Library, TorBox Search, Comet, Zilean.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.6",
+    "version": "2.9.7",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1625,7 +1625,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Flash/core-nexus-flash.json
+++ b/Templates/Torbox/Flash/core-nexus-flash.json
@@ -5,7 +5,7 @@
     "description": "Single-click instant play. Only cached streams appear — zero uncached results. Derived from Speed but with excludeUncached:true, a 2-stream dynamic stop condition, and pre-resolved top stream. If content has no cached streams, the 0Cached ISE shows a title passthrough rather than a blank screen. 1080p · TorBox Essential · Library, TorBox Search, Comet, Zilean.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1606,7 +1606,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json
@@ -5,7 +5,7 @@
     "description": "4K flagship for TorBox users who also run a Usenet indexer. Pairs TorBox debrid with NZBGeek for maximum source diversity across debrid, torrent, and Usenet streams. Prioritises 2160p with 1080p fallback. Full HDR and lossless audio. Adaptive IQR bitrate PSEs — Tukey fence (≥4 ranked) with min/max and new-release median cluster fallbacks. NZBGeek API key required — enter your key in the Usenet preset before saving.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.11.1",
+    "version": "2.11.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -324,7 +324,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid-lite.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.11",
+    "version": "2.9.12",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -279,7 +279,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Hybrid/core-nexus-hybrid.json
+++ b/Templates/Torbox/Hybrid/core-nexus-hybrid.json
@@ -5,7 +5,7 @@
     "description": "A 1080p SDR hybrid build for TorBox users who also run a Usenet indexer. Combines TorBox's Usenet and torrent cache with NZBGeek for maximum source diversity. Unlike other builds, shows both cached and uncached streams — uncached streams are downloaded by TorBox before playback begins. Targets 1080p and 720p only — 4K and HDR are excluded. Blocks BluRay and Remux for low-end hardware compatibility. File range 1 GB–60 GB, 1080p capped at 25 GB. NZBGeek API key required — enter your key in the NZBGeek preset before saving. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.11",
+    "version": "2.9.12",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -327,7 +327,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
+++ b/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
@@ -5,7 +5,7 @@
     "description": "Nightly Labs build of Anime 4K. Tests SeaDex-aware conditional PSEs, perGroup() dedup, Score IQR Guard, Indexer Diversity, and anime elite group pins. Not a daily driver — report regressions before these features graduate to stable.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
@@ -538,7 +538,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
+++ b/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json
@@ -5,7 +5,7 @@
     "description": "4K template tuned for Apple TV 4K (3rd gen) and Infuse. Dolby Vision Profile 5/8 is natively supported — DV streams are prioritised. HDR10+ (3rd gen exclusive), HDR10, HLG, and SDR are also shown. AV1 hard-excluded (no hardware decoder on the A15 chip — severe performance hit). DD+ Atmos is the native top audio format. 2160p primary with 1080p fallback. Based on Core Nexus 4K Pro (TorBox · Library, TorBox Search, Comet, Zilean).",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -300,7 +300,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 10 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 10) ? seasonPack(streams) : []",
         "enabled": true
       }
     ],

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 4K build. Template directives: TorBox Search and exit thresholds configurable at import. Based on 4K Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -352,7 +352,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 1080p build. Template directives: TorBox Search and exit thresholds configurable at import.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -339,7 +339,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-4k-apex-labs",
     "name": "Core Nexus 4K Apex Labs",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "Nightly Labs v0.9.0 — all LABS features enabled: Score IQR Guard (replaces fixed -50 gate), perGroup() Extra Cached/Uncached ESEs, Bad Dual Audio Groups, Indexer Diversity, elite group pins (4K Remux / 1080p Remux / LQ bottom). Based on 4K Apex v0.4.16.",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json",
     "source": "external",
@@ -324,7 +324,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
@@ -5,7 +5,7 @@
     "description": "Nightly Labs build — single template for live-action TV, movies, and anime. Uses isAnime + hasSeaDex conditional PSEs to switch between anime and live-action quality tiers dynamically. Includes SeaDex, AnimeTosho, NekoBT, Meteor, Comet, MediaFusion, and all LABS features. Not a daily driver.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -376,7 +376,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, SeaDex) toggled at import; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on Stream.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -386,7 +386,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex-torbox.json
@@ -5,7 +5,7 @@
     "description": "TorBox-native build of Core Nexus 4K Apex. Uses only TorBox's own search and Usenet — no third-party indexers. Identical adaptive ranked-pool bitrate PSEs and full ESE stack. Simpler, faster to load, fewer moving parts.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.11.1",
+    "version": "2.11.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -324,7 +324,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -5,7 +5,7 @@
     "description": "Adaptive flagship build. Ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: ≥4 ranked streams → Q1−1.5×IQR to Q3+1.5×IQR window; 1–3 ranked → 80%–120% of min/max; 0 ranked → pow(0.95, daysSinceRelease) decay median cluster. HDR and SDR evaluated separately in the WEB-DL tier. Full ESE stack: REPACK passthrough, per-addon flood guard, Usenet propagation guard, codec efficiency booster, DV-Only Kill, audio pinnacle, and more.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -321,7 +321,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick-lite.json
@@ -5,7 +5,7 @@
     "description": "Firestick and budget Android TV optimised build. Hard SDR-only enforcement — excludes Dolby Vision, HDR10+, HDR10, HLG, and 10-bit content. AV1 excluded. TrueHD/Atmos/lossless audio excluded. 1080p + 720p · WEB-DL/WEBRip · TorBox Essential. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -286,7 +286,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-stream-firestick.json
+++ b/Templates/Torbox/Single/core-nexus-stream-firestick.json
@@ -5,7 +5,7 @@
     "description": "Firestick and budget Android TV optimised build. Hard SDR-only enforcement — excludes Dolby Vision, HDR10+, HDR10, HLG, and 10-bit content that causes playback failures or tone-mapping artifacts on Fire TV hardware. AV1 excluded. TrueHD/Atmos/lossless audio excluded. 1080p + 720p · WEB-DL/WEBRip · TorBox Essential. Single TorBox subscription required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.9",
+    "version": "2.9.10",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -334,7 +334,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-stream-lite.json
+++ b/Templates/Torbox/Single/core-nexus-stream-lite.json
@@ -5,7 +5,7 @@
     "description": "A frictionless 1080p SDR build running exclusively on TorBox, with RPDB poster database integration for enhanced metadata visuals in Stremio. Targets 1080p and 720p WEB-DL and WEBRip sources. Blocks BluRay, Remux, 4K, and HDR content for reliable playback on any hardware. File range 1 GB–60 GB, 1080p capped at 25 GB. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. No secondary debrid service required — a single TorBox subscription is sufficient. Designed for phones, tablets, budget Android TV boxes, and Fire TV Sticks. Relaxed filtering — quality gates removed, more results shown.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -276,7 +276,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Single/core-nexus-stream.json
+++ b/Templates/Torbox/Single/core-nexus-stream.json
@@ -5,7 +5,7 @@
     "description": "A frictionless 1080p SDR build running exclusively on TorBox, with RPDB poster database integration for enhanced metadata visuals in Stremio. Targets 1080p WEB-DL and WEBRip sources, with 720p fallback for titles where 1080p is unavailable. Blocks BluRay, Remux, 4K, and HDR content for reliable playback on any hardware. File range 1 GB–60 GB, 1080p capped at 25 GB. Tamtaro SEL stack with live-synced ESEs, PSEs, and regex. No secondary debrid service required — a single TorBox subscription is sufficient. Designed for phones, tablets, budget Android TV boxes, and Fire TV Sticks.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.10",
+    "version": "2.9.11",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -324,7 +324,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-4k-plus.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K build for TorBox Essential and EasyNews subscribers. Lean sources: Library, TorBox Search, Comet, and Zilean — the four fastest, delivering cached results in 2–3 seconds. 2160p priority · DV and HDR10+ · TrueHD/Atmos · files up to 150 GB. SeaDex best-release enforced for anime. Requires active TorBox Essential and EasyNews subscriptions.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.8",
+    "version": "2.9.9",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1657,7 +1657,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
+++ b/Templates/Torbox/Speed/EasyNews/core-nexus-speed-easynews.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for EasyNews subscribers — no TorBox required. Streams exclusively from EasyNews Usenet cache for near-instant playback. Three fast scrapers: Library, Zilean, Meteor with Usenet enabled. SDR only, WEB-DL preferred, BluRay and Remux blocked. Timeouts at 3500ms, 10 results max. Requires an active EasyNews subscription.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.9",
+    "version": "2.9.10",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -1639,7 +1639,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -280,7 +280,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-4k.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 4K build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 4K streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -328,7 +328,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed-lite.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Lite: hard kills only, quality gates removed. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -275,7 +275,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
+++ b/Templates/Torbox/Speed/TorBox/core-nexus-speed.json
@@ -5,7 +5,7 @@
     "description": "Speed-optimised 1080p build for TorBox Essential — no EasyNews required. Lean preset stack: TorBox cache + Zilean + TorBox Search for fast cached results. Exits as soon as 3 cached 1080p streams found or 4 s elapsed. TorBox Essential required.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -323,7 +323,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Kill Season Packs When Episodes Exist */ count(negate(streams, seasonPack(streams))) >= 3 ? seasonPack(streams) : []",
+        "expression": "/* CB | Kill Season Packs When Episodes Exist */ (latestSeason >= 3 and count(negate(streams, seasonPack(streams))) >= 3) ? seasonPack(streams) : []",
         "enabled": true
       },
       {

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -527,7 +527,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
 </style>
-<script>var _0x34a8b5=_0x346f;(function(_0x2fe1e2,_0x5b535b){var _0x343cd5={_0x413ffe:0xb0,_0x388513:0xbe,_0x5b2de2:0xb4,_0x544232:0xbd},_0x50fea0=_0x346f,_0x26273c=_0x2fe1e2();while(!![]){try{var _0x5a5918=parseInt(_0x50fea0(_0x343cd5._0x413ffe))/(0x6cb+-0x15f6+0x1*0xf2c)+parseInt(_0x50fea0(0xb2))/(0x10cc+-0x1df1+0xd27)+-parseInt(_0x50fea0(_0x343cd5._0x388513))/(-0xbc0+0x28d*-0x6+0x1b11*0x1)*(parseInt(_0x50fea0(0xba))/(-0x5d3+-0x1bb8+0x218f))+parseInt(_0x50fea0(0xb6))/(-0x5b*-0x2b+0x67*0x22+-0x1cf2)*(-parseInt(_0x50fea0(0xb3))/(-0x301+0x129c*-0x2+0x283f))+-parseInt(_0x50fea0(0xbb))/(-0x8*0x143+0x3a9*-0x1+0xa8*0x15)+parseInt(_0x50fea0(_0x343cd5._0x5b2de2))/(0x206e+0x5d6+-0x263c)*(parseInt(_0x50fea0(0xb8))/(0x133+0x5*0x6de+-0x2380))+parseInt(_0x50fea0(_0x343cd5._0x544232))/(0x5be+0x21d*0xd+-0xb0f*0x3);if(_0x5a5918===_0x5b535b)break;else _0x26273c['push'](_0x26273c['shift']());}catch(_0x5ea5bb){_0x26273c['push'](_0x26273c['shift']());}}}(_0x53d0,0x13292c+-0xd5737+0x51e7f));function _0x346f(_0x264669,_0x2e7e80){_0x264669=_0x264669-(-0x1d3b*-0x1+0x415*-0x5+0x823*-0x1);var _0x2158bd=_0x53d0();var _0x1d02a7=_0x2158bd[_0x264669];if(_0x346f['WvAcRR']===undefined){var _0x10ff5b=function(_0x5de790){var _0x289462='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0xddb0dd='',_0x1ec804='';for(var _0x276156=0x2184+0x1b46*0x1+-0x2*0x1e65,_0x2720c1,_0x4257a1,_0x406315=-0x2*0xe6f+-0x425+-0x2103*-0x1;_0x4257a1=_0x5de790['charAt'](_0x406315++);~_0x4257a1&&(_0x2720c1=_0x276156%(0x505+0x47a*0x5+-0x1b63)?_0x2720c1*(0x1*-0xbc9+-0x18a6+0x24af*0x1)+_0x4257a1:_0x4257a1,_0x276156++%(-0x1e68*0x1+-0x10ee+-0x17ad*-0x2))?_0xddb0dd+=String['fromCharCode'](0x2b*-0xc2+0x5c3+0x3*0x946&_0x2720c1>>(-(-0x3f6*-0x1+0x5*0xc4+-0x7c8)*_0x276156&0x612+0xebb*0x1+0x14c7*-0x1)):0x2e*-0x65+0x7*-0x56e+-0xc*-0x4ae){_0x4257a1=_0x289462['indexOf'](_0x4257a1);}for(var _0x44e84f=-0xb69+0x17b2+0x275*-0x5,_0x14cda6=_0xddb0dd['length'];_0x44e84f<_0x14cda6;_0x44e84f++){_0x1ec804+='%'+('00'+_0xddb0dd['charCodeAt'](_0x44e84f)['toString'](0x135f+0x23c8+-0x3717))['slice'](-(0xd6c*-0x1+-0x1abf*-0x1+-0x1e7*0x7));}return decodeURIComponent(_0x1ec804);};_0x346f['UcDvnC']=_0x10ff5b,_0x346f['dvQoJj']={},_0x346f['WvAcRR']=!![];}var _0x3219b1=_0x2158bd[0x1*-0x16ba+-0x8cc*0x3+0x311e],_0x4ce671=_0x264669+_0x3219b1,_0x5f3848=_0x346f['dvQoJj'][_0x4ce671];return!_0x5f3848?(_0x1d02a7=_0x346f['UcDvnC'](_0x1d02a7),_0x346f['dvQoJj'][_0x4ce671]=_0x1d02a7):_0x1d02a7=_0x5f3848,_0x1d02a7;}try{document[_0x34a8b5(0xb9)][_0x34a8b5(0xb5)]('data-theme',localStorage[_0x34a8b5(0xaf)]('cbTheme')||(window['matchMedia'](_0x34a8b5(0xb1))[_0x34a8b5(0xbc)]?_0x34a8b5(0xb7):_0x34a8b5(0xbf)));}catch(_0x14f174){}function _0x53d0(){var _0x46d81a=['nJG2otG0vwzVtwfL','mJu1mhvjwuLzBG','mJaXotm2ChnqzxDw','C2v0qxr0CMLIDxrL','mti0nJvHvKvQruO','zgfYAW','mJi1vu1yAgTU','zg9JDw1LBNrfBgvTzw50','ngjrsKndrW','mta2ndqYn2fltuXhqG','Bwf0y2HLCW','mta4odi1mhjsu1Djzq','odm2nZmWs2nLrePh','BgLNAhq','z2v0sxrLBq','mteYnda0nxnQv0DMuW','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP'];_0x53d0=function(){return _0x46d81a;};return _0x53d0();}</script>
+<script>var _0x3d5b94=_0x4a16;(function(_0x30887f,_0x39496c){var _0x15e6c3={_0x1cd722:0xd6,_0xc1ccaf:0xd9},_0x2bd7fe=_0x4a16,_0x50d1f=_0x30887f();while(!![]){try{var _0x154c37=parseInt(_0x2bd7fe(0xdb))/(0x1059+0xda*0x11+-0xa46*0x3)+-parseInt(_0x2bd7fe(_0x15e6c3._0x1cd722))/(-0x22c2*0x1+-0x13c+0x2400)*(parseInt(_0x2bd7fe(0xd8))/(-0x1b7a+-0x1140+0xd*0x371))+parseInt(_0x2bd7fe(0xda))/(-0x160e+0x1733+-0x1*0x121)+parseInt(_0x2bd7fe(0xdf))/(-0x902+0xa12*-0x3+0xf5*0x29)+parseInt(_0x2bd7fe(0xe1))/(0x1ba+-0xd*-0x24c+-0xfc8*0x2)+-parseInt(_0x2bd7fe(_0x15e6c3._0xc1ccaf))/(-0x21cf+0xf4f*0x1+0x1287)+parseInt(_0x2bd7fe(0xdd))/(-0x1867+0x1d30+-0x4c1);if(_0x154c37===_0x39496c)break;else _0x50d1f['push'](_0x50d1f['shift']());}catch(_0xcc03fe){_0x50d1f['push'](_0x50d1f['shift']());}}}(_0x2c5c,-0x3397d+0xcbff+0xc2533));function _0x4a16(_0x14c51a,_0x4c00a2){_0x14c51a=_0x14c51a-(-0x2503+0xc25*-0x2+0x1*0x3e23);var _0x2419bb=_0x2c5c();var _0xc00f9=_0x2419bb[_0x14c51a];if(_0x4a16['nQtxjH']===undefined){var _0x3ba59e=function(_0x9c24ad){var _0x3d8dcb='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x4de438='',_0x3f986c='';for(var _0x4e0e9c=0xd*0x71+0x1*0x1d3e+-0x22fb,_0x31cb49,_0x54219e,_0xaf9a96=-0x13dc*-0x1+0x15da+-0x14db*0x2;_0x54219e=_0x9c24ad['charAt'](_0xaf9a96++);~_0x54219e&&(_0x31cb49=_0x4e0e9c%(-0x2ff+-0x2408+0x270b)?_0x31cb49*(0xeb*0x22+0x217a+-0x4*0x101c)+_0x54219e:_0x54219e,_0x4e0e9c++%(0x3*-0x3c3+0x7f+0xace))?_0x4de438+=String['fromCharCode'](0x25a9+0x15a*-0x7+-0x6cd*0x4&_0x31cb49>>(-(0x9*0x235+0x2c4*0x6+0x535*-0x7)*_0x4e0e9c&0x21*-0x4d+0x1401*0x1+-0x75*0x16)):-0x1ba+0x1*-0x6a7+0x861){_0x54219e=_0x3d8dcb['indexOf'](_0x54219e);}for(var _0x471a09=0x1179*0x1+-0xf11+0xe*-0x2c,_0x2656ad=_0x4de438['length'];_0x471a09<_0x2656ad;_0x471a09++){_0x3f986c+='%'+('00'+_0x4de438['charCodeAt'](_0x471a09)['toString'](0xda*0x11+-0x1075*0x2+0x1280))['slice'](-(-0x13c+0x105c+-0xf1e));}return decodeURIComponent(_0x3f986c);};_0x4a16['rcOzDI']=_0x3ba59e,_0x4a16['MjTppI']={},_0x4a16['nQtxjH']=!![];}var _0x2524de=_0x2419bb[-0x1b7a+-0x1140+0x19*0x1ca],_0x24b1a2=_0x14c51a+_0x2524de,_0xad0322=_0x4a16['MjTppI'][_0x24b1a2];return!_0xad0322?(_0xc00f9=_0x4a16['rcOzDI'](_0xc00f9),_0x4a16['MjTppI'][_0x24b1a2]=_0xc00f9):_0xc00f9=_0xad0322,_0xc00f9;}try{document[_0x3d5b94(0xe2)][_0x3d5b94(0xd7)](_0x3d5b94(0xe4),localStorage['getItem'](_0x3d5b94(0xe5))||(window[_0x3d5b94(0xde)](_0x3d5b94(0xe3))[_0x3d5b94(0xdc)]?_0x3d5b94(0xe0):'light'));}catch(_0x452873){}function _0x2c5c(){var _0x39c8c3=['zgf0ys10AgvTzq','y2juAgvTzq','mZu0mtC0C3nbqKv6','C2v0qxr0CMLIDxrL','oxrADhPiuW','odiYodeWmxL2EefcBa','mJu4otKYnenRtKXerW','mtq0ode4vvDguxrb','Bwf0y2HLCW','ntK4nZGYneXWuLL5vW','Bwf0y2HnzwrPyq','mZu2mJiZmeHwwLv0tG','zgfYAW','ntqYmda0we1xwufQ','zg9JDw1LBNrfBgvTzw50','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP'];_0x2c5c=function(){return _0x39c8c3;};return _0x2c5c();}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -1391,24 +1391,18 @@ function render() {
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
         <div class="what-next" style="margin:14px 0 12px;padding:14px 16px;background:rgba(0,212,255,.03);border:1px solid rgba(0,212,255,.1);border-radius:12px">
-          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">What to do next</div>
-          <div style="display:grid;grid-template-columns:1fr auto 1fr auto 1fr;align-items:start;gap:6px">
+          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
+          <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Download</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click "Generate &amp; Download" below — saves a <code style="font-size:.63rem;background:rgba(255,255,255,.06);border-radius:3px;padding:0 3px">.json</code> file to your device</div>
+              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Load into AIOStreams</div>
+              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click <strong style="color:#8b949e">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Re-enter your debrid key when prompted.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Import</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">On your AIOStreams configure page → click <strong style="color:#8b949e">Import</strong> → paste the Import URL <em>or</em> upload the JSON</div>
-            </div>
-            <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
-            <div style="display:flex;flex-direction:column;gap:5px">
-              <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">3</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Use the <strong style="color:#8b949e">Generate Manifest</strong> section below — then add the manifest URL to Stremio → Addons</div>
+              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install in Stremio</div>
+              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Fill in your UUID + password in the <strong style="color:#8b949e">Get Install Link</strong> section below → click the button → tap <strong style="color:#8b949e">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
@@ -1416,11 +1410,11 @@ function render() {
         <button data-action="share-config" style="width:100%;margin-top:8px;padding:11px;font-size:.8rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
         <button class="btn-aio" data-action="create-import" id="btnImport" style="margin-top:10px">
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-          Create Import URL
+          Step 1 — Import to AIOStreams
         </button>
         <div id="importUrlResult"></div>
         <div class="aio-section">
-          <h3>Get Manifest URL</h3>
+          <h3>Step 2 — Get Stremio Install Link</h3>
           <div class="aio-fields" style="margin-top:12px">
             <div class="name-row" style="margin-bottom:0">
               <label>AIOStreams Host</label>
@@ -1501,7 +1495,7 @@ function render() {
           </details>
           <button class="btn-manifest" id="btnAio" data-action="install-stremio" style="margin-top:14px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-            Generate Manifest
+            Get Install Link
           </button>
           <div id="aioResult"></div>
           <details id="pasteManifestDetails" style="margin-top:16px;border-top:1px solid #21262d;padding-top:14px" ${pasteMode ? 'open' : ''}>
@@ -2770,13 +2764,13 @@ async function createImportUrl() {
         </div>`;
       }).join('');
       credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">CREDENTIALS TO ENTER IN AIOSTREAMS AFTER IMPORT</div>
-        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Enter these in AIOStreams → Services once your template has loaded.</div>
+        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Your debrid credentials were stripped from the import URL. Once AIOStreams has loaded your template, go to Services and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">This is <em>not</em> a Stremio link — it loads your settings into AIOStreams so you can get a manifest. Debrid credentials are stripped; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">Your browser's security blocked the cross-origin request. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
@@ -2820,7 +2814,7 @@ async function openInAIOStreams() {
       showManifestModal(`${winner.host}/stremio/${winner.uuid}/${encodeURIComponent(pwd)}/manifest.json`, pwd, HOST_LABELS[winner.host] || winner.host.replace('https://','').split('/')[0]);
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">CORS blocked requests or all hosts timed out. Use <strong style="color:#8b949e">Create Import URL</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">CORS blocked requests or all hosts timed out. Use <strong style="color:#8b949e">Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
@@ -2834,7 +2828,7 @@ async function openInAIOStreams() {
 
   /* No UUID, not auto or custom — guide to get UUID */
   if (!uuid && !isCustom && !isAuto) {
-    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Create Import URL</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
+    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
     return;
   }
 
@@ -2853,12 +2847,12 @@ async function openInAIOStreams() {
       } else throw new Error('API Error');
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">The API blocked the request (CORS) or timed out. Use Create Import URL or Download instead.</div></div>`;
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">The API blocked the request (CORS) or timed out. Use Import to AIOStreams or Download instead.</div></div>`;
     }
     return;
   }
 
-  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Create Import URL</strong> above.</div></div>`;
+  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
 }
 </script>
 </body>

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -1391,24 +1391,18 @@ function render() {
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
         <div class="what-next" style="margin:14px 0 12px;padding:14px 16px;background:rgba(0,212,255,.03);border:1px solid rgba(0,212,255,.1);border-radius:12px">
-          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">What to do next</div>
-          <div style="display:grid;grid-template-columns:1fr auto 1fr auto 1fr;align-items:start;gap:6px">
+          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
+          <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Download</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click "Generate &amp; Download" below — saves a <code style="font-size:.63rem;background:rgba(255,255,255,.06);border-radius:3px;padding:0 3px">.json</code> file to your device</div>
+              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Load into AIOStreams</div>
+              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click <strong style="color:#8b949e">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Re-enter your debrid key when prompted.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Import</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">On your AIOStreams configure page → click <strong style="color:#8b949e">Import</strong> → paste the Import URL <em>or</em> upload the JSON</div>
-            </div>
-            <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
-            <div style="display:flex;flex-direction:column;gap:5px">
-              <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">3</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Use the <strong style="color:#8b949e">Generate Manifest</strong> section below — then add the manifest URL to Stremio → Addons</div>
+              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install in Stremio</div>
+              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Fill in your UUID + password in the <strong style="color:#8b949e">Get Install Link</strong> section below → click the button → tap <strong style="color:#8b949e">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
@@ -1416,11 +1410,11 @@ function render() {
         <button data-action="share-config" style="width:100%;margin-top:8px;padding:11px;font-size:.8rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
         <button class="btn-aio" data-action="create-import" id="btnImport" style="margin-top:10px">
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-          Create Import URL
+          Step 1 — Import to AIOStreams
         </button>
         <div id="importUrlResult"></div>
         <div class="aio-section">
-          <h3>Get Manifest URL</h3>
+          <h3>Step 2 — Get Stremio Install Link</h3>
           <div class="aio-fields" style="margin-top:12px">
             <div class="name-row" style="margin-bottom:0">
               <label>AIOStreams Host</label>
@@ -1501,7 +1495,7 @@ function render() {
           </details>
           <button class="btn-manifest" id="btnAio" data-action="install-stremio" style="margin-top:14px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-            Generate Manifest
+            Get Install Link
           </button>
           <div id="aioResult"></div>
           <details id="pasteManifestDetails" style="margin-top:16px;border-top:1px solid #21262d;padding-top:14px" ${pasteMode ? 'open' : ''}>
@@ -2770,13 +2764,13 @@ async function createImportUrl() {
         </div>`;
       }).join('');
       credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">CREDENTIALS TO ENTER IN AIOSTREAMS AFTER IMPORT</div>
-        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Enter these in AIOStreams → Services once your template has loaded.</div>
+        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Your debrid credentials were stripped from the import URL. Once AIOStreams has loaded your template, go to Services and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Click your instance to auto-import</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">Opens AIOStreams with your template pre-loaded. Debrid credentials stripped for security — TMDB keys are included.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy the URL to import manually:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">This is <em>not</em> a Stremio link — it loads your settings into AIOStreams so you can get a manifest. Debrid credentials are stripped; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">Your browser's security blocked the cross-origin request. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
@@ -2820,7 +2814,7 @@ async function openInAIOStreams() {
       showManifestModal(`${winner.host}/stremio/${winner.uuid}/${encodeURIComponent(pwd)}/manifest.json`, pwd, HOST_LABELS[winner.host] || winner.host.replace('https://','').split('/')[0]);
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">CORS blocked requests or all hosts timed out. Use <strong style="color:#8b949e">Create Import URL</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">CORS blocked requests or all hosts timed out. Use <strong style="color:#8b949e">Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
@@ -2834,7 +2828,7 @@ async function openInAIOStreams() {
 
   /* No UUID, not auto or custom — guide to get UUID */
   if (!uuid && !isCustom && !isAuto) {
-    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Create Import URL</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
+    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
     return;
   }
 
@@ -2853,12 +2847,12 @@ async function openInAIOStreams() {
       } else throw new Error('API Error');
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">The API blocked the request (CORS) or timed out. Use Create Import URL or Download instead.</div></div>`;
+      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">The API blocked the request (CORS) or timed out. Use Import to AIOStreams or Download instead.</div></div>`;
     }
     return;
   }
 
-  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Create Import URL</strong> above.</div></div>`;
+  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
 }
 </script>
 </body>

--- a/docs/instance-status.mdx
+++ b/docs/instance-status.mdx
@@ -41,7 +41,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **ATBP** | 🟢 Online | [aio.atbphosting.com](https://aio.atbphosting.com/stremio/configure) |
 | **Omni's** | 🟢 Online | [aiostreams.12312023.xyz](https://aiostreams.12312023.xyz/stremio/configure) |
 
-*Last checked: 2026-07-01 19:45 UTC*
+*Last checked: 2026-07-02 00:07 UTC*
 {/* STATUS_STABLE_END */}
 
 ---
@@ -60,7 +60,7 @@ The short answer: **ElfHosted** for most people, **ElfHosted Private** if you hi
 | **Kuu's Nightly** | 🟢 Online | [aiostreams-nightly.stremio.ru](https://aiostreams-nightly.stremio.ru/stremio/configure) |
 | **Viren's Nightly** | 🟢 Online | [aiostreams.viren070.me](https://aiostreams.viren070.me/stremio/configure) |
 
-*Last checked: 2026-07-01 19:45 UTC*
+*Last checked: 2026-07-02 00:07 UTC*
 {/* STATUS_NIGHTLY_END */}
 
 ---

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -55,7 +55,7 @@ mode: "wide"
       <div style={{ fontSize: '9px', color: '#4b5563', letterSpacing: '1.5px', marginTop: '4px' }}>TEMPLATES</div>
     </div>
     <div style={{ flex: 1, textAlign: 'center', padding: '20px 0' }}>
-      <div style={{ fontSize: '22px', fontWeight: '800', color: '#00d4ff' }}><a href="/changelog" style={{ color: 'inherit', textDecoration: 'none' }}>v3.1.0</a></div>
+      <div style={{ fontSize: '22px', fontWeight: '800', color: '#00d4ff' }}><a href="/changelog" style={{ color: 'inherit', textDecoration: 'none' }}>v3.1.1</a></div>
       <div style={{ fontSize: '9px', color: '#4b5563', letterSpacing: '1.5px', marginTop: '4px' }}>LATEST — <a href="/changelog" style={{ color: '#6b7280', fontSize: '9px', textDecoration: 'none', letterSpacing: '1px' }}>CHANGELOG ↗</a></div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- **`latestSeason >= 3` guard on Kill Season Packs ESE** — the `Kill Season Packs When Episodes Exist` ESE previously fired whenever 3+ episode-level streams existed, regardless of how many seasons the show has. For a show in its first or second season the pack *is* the full show. The guard keeps packs visible for shows with ≤2 seasons and only activates the episode-preference kill for long-running series (3+ seasons). Samsung/Apple TV templates (which use a `>= 10` episode threshold) receive the same guard.
- **44 active templates** + `Filtering/core-builds-eses.json` updated; all receive a patch version bump.
- **CLAUDE.md** — `floor`, `ceil`, `round`, `trunc` documented as confirmed SEL math functions.
- **CHANGELOG** — v3.1.1 entry added; docs intro version badge updated.

## Test plan

- [ ] `python3 -m pytest tests/ -q` — 184 pass, 2 pre-existing failures in Base Config (`preferredEncodes` uses legacy `H.265`/`H.264` values), unrelated to this change
- [ ] Grep confirms the updated ESE string in all 44 active template files
- [ ] JSON validity check passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_