### PR TITLE
configurator v2.4: readability pass — larger buttons, highlighted key info

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -62,7 +62,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .opt-icon svg{width:42px;height:42px}
 .opt-body{display:flex;flex-direction:column;flex:1;min-width:0}
 .opt-name{font-weight:700;font-size:1rem;line-height:1.25}
-.opt-desc{color:#8b949e;font-size:.84rem;margin-top:4px;line-height:1.45}
+.opt-desc{color:#8b949e;font-size:.87rem;margin-top:4px;line-height:1.45}
 .opts.c3d .opt label,.opts.c2d .opt label{flex-direction:row;align-items:center;gap:12px;padding:14px}
 .opts.c3d .opt-icon,.opts.c2d .opt-icon{margin-bottom:0}
 .opts.c3d .opt-icon svg,.opts.c2d .opt-icon svg{width:30px;height:30px}
@@ -78,18 +78,18 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .nav::before{content:'';position:absolute;inset:-28px -16px 0;background:linear-gradient(to bottom,transparent,#0d1117 40%);pointer-events:none;z-index:-1}
 .btn{border:none;cursor:pointer;transition:opacity .15s,transform .1s}
 .btn:active{transform:scale(.97)}
-.btn-back{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#6b7280;font-size:.84rem;font-weight:700;padding:11px 18px;border-radius:11px;align-self:stretch;transition:all .15s;text-align:center;letter-spacing:.01em}
+.btn-back{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#6b7280;font-size:.92rem;font-weight:700;padding:11px 18px;border-radius:11px;align-self:stretch;transition:all .15s;text-align:center;letter-spacing:.01em}
 .btn-back:hover{background:rgba(255,255,255,.08);color:#9ca3af;border-color:rgba(255,255,255,.18)!important;animation:hoverPulse 1.6s ease-in-out infinite}
-.btn-next{width:100%;background:linear-gradient(135deg,#0077a0 0%,#004d72 100%);color:#fff;border-radius:13px;padding:14px 18px;font-size:.95rem;font-weight:800;display:flex;align-items:center;justify-content:space-between;gap:12px;box-shadow:0 4px 24px rgba(0,180,220,.28),inset 0 1px 0 rgba(255,255,255,.1);text-align:left;transition:box-shadow .2s,transform .15s}
+.btn-next{width:100%;background:linear-gradient(135deg,#0077a0 0%,#004d72 100%);color:#fff;border-radius:13px;padding:14px 18px;font-size:1.02rem;font-weight:800;display:flex;align-items:center;justify-content:space-between;gap:12px;box-shadow:0 4px 24px rgba(0,180,220,.28),inset 0 1px 0 rgba(255,255,255,.1);text-align:left;transition:box-shadow .2s,transform .15s}
 .btn-next:hover:not(:disabled){transform:translateY(-1px);animation:btnHoverPulse 1.6s ease-in-out infinite}
 .btn-next:disabled{background:#111820;border:1px solid #1e2a35;color:#374151;box-shadow:none;cursor:not-allowed}
 .cta-step-lbl{font-size:.62rem;font-weight:600;opacity:.6;letter-spacing:.04em;text-transform:uppercase;margin-bottom:2px}
 .cta-step-val{font-size:.95rem;font-weight:800;line-height:1}
 .cta-arr{font-size:1.15rem;opacity:.75;flex-shrink:0}
-.btn-dl{width:100%;padding:16px;font-size:1.08rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:box-shadow .2s,transform .1s,opacity .15s;box-shadow:0 4px 18px rgba(16,185,129,.28);animation:dlPulse 2.2s ease-in-out infinite}
+.btn-dl{width:100%;padding:16px;font-size:1.16rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:box-shadow .2s,transform .1s,opacity .15s;box-shadow:0 4px 18px rgba(16,185,129,.28);animation:dlPulse 2.2s ease-in-out infinite}
 .btn-dl:active{transform:scale(.98);animation:none}
 .btn-dl:hover{opacity:1;box-shadow:0 6px 30px rgba(16,185,129,.55);transform:translateY(-1px);animation:none}
-.btn-aio{width:100%;padding:14px;font-size:1rem;font-weight:700;border-radius:10px;border:2px solid #0e7490;cursor:pointer;background:transparent;color:#00d4ff;margin-top:10px;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px}
+.btn-aio{width:100%;padding:14px;font-size:1.08rem;font-weight:700;border-radius:10px;border:2px solid #0e7490;cursor:pointer;background:transparent;color:#00d4ff;margin-top:10px;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px}
 .btn-aio:hover{background:#00131c;border-color:#00d4ff;animation:hoverPulse 1.6s ease-in-out infinite}
 .btn-aio:active{transform:scale(.98)}
 .aio-section{margin-top:20px;border-top:1px solid #21262d;padding-top:18px}
@@ -104,13 +104,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .manifest-url:hover{border-color:#00d4ff;color:#00d4ff}
 .notice{background:#0d2317;border:1px solid #2ea043;border-radius:9px;padding:13px 16px;font-size:.83rem;color:#8b949e;margin-top:14px;line-height:1.5}
 .inst-chips{display:flex;flex-wrap:wrap;gap:6px;margin:8px 0 4px}
-.inst-chip{display:inline-flex;align-items:center;padding:5px 12px;background:#0d1117;border:1px solid #30363d;border-radius:20px;font-size:.76rem;color:#8b949e;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
+.inst-chip{display:inline-flex;align-items:center;padding:6px 13px;background:#0d1117;border:1px solid #30363d;border-radius:20px;font-size:.84rem;color:#8b949e;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
 .inst-chip:hover{border-color:#00d4ff;color:#00d4ff}
 .inst-chip-import{background:#001428;border-color:#0e7490;color:#00d4ff}
 .inst-chip-import:hover{background:#002a50;border-color:#00d4ff;color:#7ee8ff}
 .notice strong{color:#3fb950;display:block;margin-bottom:3px}
 /* Size limit presets */
-.size-btn{padding:7px 16px;border-radius:8px;border:1.5px solid #30363d;background:#0d1117;color:#8b949e;font-size:.82rem;font-weight:700;cursor:pointer;transition:all .15s}
+.size-btn{padding:7px 16px;border-radius:8px;border:1.5px solid #30363d;background:#0d1117;color:#8b949e;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .15s}
 .size-btn:hover{border-color:#005c7a;color:#e6edf3}
 .size-btn-active{border-color:#00d4ff!important;background:#00131c!important;color:#00d4ff!important}
 /* List layout */
@@ -254,20 +254,20 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .modal-title{font-size:1.18rem;font-weight:800;text-align:center;margin-bottom:4px}
 .modal-sub{color:#6b7280;font-size:.8rem;text-align:center;margin-bottom:18px;line-height:1.5}
 .fmt-tabs{display:flex;gap:5px;margin-bottom:14px;flex-wrap:wrap}
-.fmt-tab{padding:5px 13px;border-radius:7px;border:1.5px solid #30363d;background:#0d1117;color:#6b7280;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .15s;white-space:nowrap}
+.fmt-tab{padding:6px 14px;border-radius:7px;border:1.5px solid #30363d;background:#0d1117;color:#6b7280;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .15s;white-space:nowrap}
 .fmt-tab:hover{border-color:#005c7a;color:#e6edf3}
 .fmt-tab.active{border-color:#00d4ff;background:#00131c;color:#00d4ff}
 .copy-field{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 12px;display:flex;align-items:center;gap:8px;margin-bottom:8px}
 .copy-field-label{color:#6b7280;font-size:.67rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:3px}
 .copy-field-val{font-family:monospace;font-size:.74rem;color:#c9d1d9;word-break:break-all}
 .copy-field-val.pwd-val{font-size:.9rem;letter-spacing:.05em;color:#e6edf3;font-family:inherit}
-.copy-btn{background:#21262d;border:none;border-radius:6px;color:#8b949e;cursor:pointer;padding:5px 9px;flex-shrink:0;font-size:.72rem;font-weight:700;transition:all .15s}
+.copy-btn{background:#21262d;border:none;border-radius:6px;color:#8b949e;cursor:pointer;padding:6px 11px;flex-shrink:0;font-size:.8rem;font-weight:700;transition:all .15s}
 .copy-btn:hover{background:#30363d;color:#e6edf3}
 .copy-btn.copied{background:#061a0e;color:#3fb950}
 .qr-wrap{display:flex;justify-content:center;margin:12px 0 3px}
 .qr-wrap img{border-radius:8px;border:1px solid #21262d;background:#0d1117}
 .modal-actions{display:flex;gap:8px;margin-top:16px;flex-wrap:wrap}
-.m-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:10px 14px;border-radius:8px;font-weight:700;font-size:.88rem;cursor:pointer;border:none;text-decoration:none;transition:all .15s;white-space:nowrap;min-width:0}
+.m-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:11px 14px;border-radius:8px;font-weight:700;font-size:.95rem;cursor:pointer;border:none;text-decoration:none;transition:all .15s;white-space:nowrap;min-width:0}
 .m-btn:active{transform:scale(.97)}
 .m-install{background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000}
 .m-web{background:#1a1f2e;border:1.5px solid #00d4ff!important;color:#00d4ff}
@@ -276,7 +276,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .m-done{background:#21262d;color:#8b949e}
 .m-done:hover{color:#e6edf3}
 /* Manifest primary button */
-.btn-manifest{width:100%;padding:15px;font-size:1.05rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#0891b2,#00d4ff);color:#000;transition:box-shadow .2s,transform .15s,opacity .15s;display:flex;align-items:center;justify-content:center;gap:9px;margin-top:14px;animation:manifestPulse 2s ease-in-out infinite}
+.btn-manifest{width:100%;padding:15px;font-size:1.13rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#0891b2,#00d4ff);color:#000;transition:box-shadow .2s,transform .15s,opacity .15s;display:flex;align-items:center;justify-content:center;gap:9px;margin-top:14px;animation:manifestPulse 2s ease-in-out infinite}
 .btn-manifest:hover{opacity:1;box-shadow:0 6px 36px rgba(0,212,255,.6),inset 0 1px 0 rgba(255,255,255,.25);transform:translateY(-2px);animation:none}
 .btn-manifest:active{transform:scale(.98);animation:none}
 .btn-manifest:disabled{opacity:.38;cursor:not-allowed;animation:none}
@@ -340,7 +340,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .srh-ring{position:relative;width:52px;height:52px;flex-shrink:0}
 .srh-num{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.15rem;font-weight:900;color:#00d4ff}
 .srh-title{font-size:1.15rem;font-weight:900;letter-spacing:-.02em;line-height:1.1;color:#e6edf3}
-.srh-sub{font-size:.75rem;color:#6b8ca5;margin-top:4px;line-height:1.4}
+.srh-sub{font-size:.84rem;color:#7ea4bd;margin-top:4px;line-height:1.4}
 .step-strip{display:flex;align-items:center;padding:10px 0 6px;position:relative}
 .step-unit{display:flex;flex-direction:column;align-items:center;flex:1;position:relative;min-width:0}
 .step-unit:not(:first-child)::before{content:'';position:absolute;top:50%;transform:translateY(-50%);right:50%;width:100%;height:1px;background:#2d333b;z-index:0;transition:background .3s}
@@ -352,7 +352,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .step-lbl{font-size:.52rem;font-weight:600;color:#374151;margin-top:4px;text-align:center;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:36px}
 .step-active .step-lbl{color:#00d4ff;font-weight:700}
 .step-done .step-lbl{color:#4b7c93}
-.btn-reset-strip{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#4b5563;font-size:.6rem;font-weight:700;cursor:pointer;padding:4px 10px;border-radius:20px;transition:all .15s;flex-shrink:0;align-self:center;letter-spacing:.05em;text-transform:uppercase;line-height:1.4}
+.btn-reset-strip{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#4b5563;font-size:.68rem;font-weight:700;cursor:pointer;padding:4px 10px;border-radius:20px;transition:all .15s;flex-shrink:0;align-self:center;letter-spacing:.05em;text-transform:uppercase;line-height:1.4}
 .btn-reset-strip:hover{background:rgba(220,38,38,.08);border-color:rgba(220,38,38,.25)!important;color:#f87171}
 .bc-row{display:flex;flex-wrap:nowrap;gap:5px;padding:1px 0 7px;overflow-x:auto;scrollbar-width:none}
 .bc-row::-webkit-scrollbar{display:none}
@@ -379,7 +379,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .splash-chip{font-size:.69rem;font-weight:700;padding:4px 11px;border-radius:20px;letter-spacing:.02em}
 .splash-chip-svc{border:1px solid rgba(0,212,255,.22);color:#67e8f9;background:rgba(0,212,255,.06)}
 .splash-chip-feat{border:1px solid #1e2a35;color:#4b5563;background:transparent}
-.splash-cta{margin-top:24px;width:100%;max-width:310px;padding:15px 24px;font-size:1rem;font-weight:800;border:none;border-radius:12px;background:linear-gradient(135deg,#0096b4 0%,#006a9a 100%);color:#fff;cursor:pointer;box-shadow:0 4px 20px rgba(0,150,180,.3);transition:all .2s;letter-spacing:.01em}
+.splash-cta{margin-top:24px;width:100%;max-width:310px;padding:15px 24px;font-size:1.08rem;font-weight:800;border:none;border-radius:12px;background:linear-gradient(135deg,#0096b4 0%,#006a9a 100%);color:#fff;cursor:pointer;box-shadow:0 4px 20px rgba(0,150,180,.3);transition:all .2s;letter-spacing:.01em}
 .splash-cta:hover{transform:translateY(-1px);animation:btnHoverPulse 1.6s ease-in-out infinite}
 .splash-paste{margin-top:13px;font-size:.76rem;color:#374151;cursor:pointer;text-decoration:underline;text-underline-offset:3px;transition:color .15s}
 .splash-paste:hover{color:#6b7280}
@@ -500,7 +500,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
-.splash-link{display:flex;align-items:center;gap:4px;font-size:.71rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s}
+.splash-link{display:flex;align-items:center;gap:4px;font-size:.79rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s}
 .splash-link:hover{color:#00d4ff;text-shadow:0 0 12px rgba(0,212,255,.5)}
 [data-theme="light"] .splash-link{color:#0e7490}
 [data-theme="light"] .splash-link:hover{color:#0c4a6e;text-shadow:none}
@@ -508,11 +508,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-pill-wrap{background:rgba(14,116,144,.04);border-color:rgba(14,116,144,.18)}
 .splash-pill{background:rgba(103,232,249,.07);border:1px solid rgba(103,232,249,.18)}
 [data-theme="light"] .splash-pill{background:rgba(14,116,144,.06);border-color:rgba(14,116,144,.22)}
-.community-link{font-size:.73rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s;display:flex;align-items:center;gap:5px}
+.community-link{font-size:.81rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s;display:flex;align-items:center;gap:5px}
 .community-link:hover{color:#00d4ff;text-shadow:0 0 12px rgba(0,212,255,.5)}
 [data-theme="light"] .community-link{color:#0e7490}
 [data-theme="light"] .community-link:hover{color:#0c4a6e;text-shadow:none}
-.host-cfg-link{display:inline-flex;align-items:center;gap:4px;font-size:.74rem;color:#67e8f9;text-decoration:none;font-weight:600;transition:color .15s,text-shadow .15s}
+.host-cfg-link{display:inline-flex;align-items:center;gap:4px;font-size:.81rem;color:#67e8f9;text-decoration:none;font-weight:600;transition:color .15s,text-shadow .15s}
 .host-cfg-link:hover{color:#00d4ff;text-shadow:0 0 10px rgba(0,212,255,.4)}
 [data-theme="light"] .host-cfg-link{color:#0e7490}
 [data-theme="light"] .host-cfg-link:hover{color:#0c4a6e;text-shadow:none}
@@ -527,7 +527,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
 </style>
-<script>function _0x2f87(_0x7dbfa0,_0x2ebb9e){_0x7dbfa0=_0x7dbfa0-(-0x31d+-0x18ca+-0x1*-0x1d3f);var _0x48b427=_0x1d71();var _0x52a1ce=_0x48b427[_0x7dbfa0];if(_0x2f87['nLqSSa']===undefined){var _0x362911=function(_0x42e090){var _0x523704='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x12c510='',_0x5c5d28='';for(var _0x346e2e=-0x5dd+0x1*-0x153+-0x73*-0x10,_0x4940ac,_0x3439b8,_0x2732de=0x309+0x2*0x3ac+-0xa61;_0x3439b8=_0x42e090['charAt'](_0x2732de++);~_0x3439b8&&(_0x4940ac=_0x346e2e%(-0xb93+0x1cb7*-0x1+0x3aa*0xb)?_0x4940ac*(0x1*-0x1ba5+0xb*-0x117+0x27e2)+_0x3439b8:_0x3439b8,_0x346e2e++%(-0x1*0x103d+-0x1a4+0x11e5))?_0x12c510+=String['fromCharCode'](-0x1d2b+-0x25bf+-0x16a3*-0x3&_0x4940ac>>(-(-0x1eaf+-0x1*0xeea+0x5*0x91f)*_0x346e2e&0x2*0x1044+0x21c+-0x229e)):0x5e*-0x33+0x1*-0xbca+0x1e84){_0x3439b8=_0x523704['indexOf'](_0x3439b8);}for(var _0x2ede4b=0x13d9*0x1+-0x198b*-0x1+-0x2d64,_0x476b4e=_0x12c510['length'];_0x2ede4b<_0x476b4e;_0x2ede4b++){_0x5c5d28+='%'+('00'+_0x12c510['charCodeAt'](_0x2ede4b)['toString'](-0x184*-0x1+-0x6f4+-0x16*-0x40))['slice'](-(-0xf3*-0xe+-0x1d00+0x3ee*0x4));}return decodeURIComponent(_0x5c5d28);};_0x2f87['GWBrPT']=_0x362911,_0x2f87['nqRUyg']={},_0x2f87['nLqSSa']=!![];}var _0x489b29=_0x48b427[-0x24eb*0x1+0x8a7+0x4*0x711],_0x25d1cd=_0x7dbfa0+_0x489b29,_0x2d3205=_0x2f87['nqRUyg'][_0x25d1cd];return!_0x2d3205?(_0x52a1ce=_0x2f87['GWBrPT'](_0x52a1ce),_0x2f87['nqRUyg'][_0x25d1cd]=_0x52a1ce):_0x52a1ce=_0x2d3205,_0x52a1ce;}var _0x20545f=_0x2f87;(function(_0xf7a3c8,_0x578cbc){var _0x6e80ba={_0xd5bd17:0x15a,_0x71f0be:0x166,_0x5e8e55:0x15e,_0x222f1f:0x165,_0x7a5cce:0x15c},_0x224c83=_0x2f87,_0x33edf5=_0xf7a3c8();while(!![]){try{var _0x560a38=-parseInt(_0x224c83(0x163))/(0xdd3+0x1ab*-0x11+0xe89)+parseInt(_0x224c83(0x158))/(0x8a7+0x17ca+0x1*-0x206f)+parseInt(_0x224c83(0x168))/(0x1051*-0x2+-0xc8+-0x1*-0x216d)+-parseInt(_0x224c83(0x169))/(-0x20b*0x1+0x3*-0xbe2+0x1*0x25b5)+parseInt(_0x224c83(_0x6e80ba._0xd5bd17))/(0x1*-0x6f5+-0x1*0xac+-0xb2*-0xb)*(parseInt(_0x224c83(_0x6e80ba._0x71f0be))/(-0x1b77*0x1+0x5*-0x55a+0x363f))+parseInt(_0x224c83(_0x6e80ba._0x5e8e55))/(0x1*-0x45f+0x7f6*0x1+0x1c8*-0x2)*(parseInt(_0x224c83(_0x6e80ba._0x222f1f))/(0x12f9+-0x815*-0x3+-0x2b30))+parseInt(_0x224c83(_0x6e80ba._0x7a5cce))/(-0x1*0x1c22+0x184d+-0x14a*-0x3);if(_0x560a38===_0x578cbc)break;else _0x33edf5['push'](_0x33edf5['shift']());}catch(_0x215383){_0x33edf5['push'](_0x33edf5['shift']());}}}(_0x1d71,0x755*0x1b7+-0x25*-0x515+-0x3*0xbb8b));try{document[_0x20545f(0x15f)][_0x20545f(0x164)]('data-theme',localStorage[_0x20545f(0x15d)](_0x20545f(0x15b))||(window[_0x20545f(0x161)](_0x20545f(0x159))[_0x20545f(0x160)]?_0x20545f(0x167):_0x20545f(0x162)));}catch(_0x310cc6){}function _0x1d71(){var _0x220d43=['zgfYAW','odiXndeYz2fHAvLJ','mZqYnJCXnMzXy096tq','mJi2mty2ChLnB3PP','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mZi4otiYnuLwqLfdzG','y2juAgvTzq','nJy3mtq3nwjStg9jzW','z2v0sxrLBq','mJa1oteYqxzouuPA','zg9JDw1LBNrfBgvTzw50','Bwf0y2HLCW','Bwf0y2HnzwrPyq','BgLNAhq','otC2nZmWC0jbt0L0','C2v0qxr0CMLIDxrL','mZjqyMjcDKK','mtjLBNnxtKi'];_0x1d71=function(){return _0x220d43;};return _0x1d71();}</script>
+<script>var _0x2824ab=_0x3b3e;function _0x5ded(){var _0x5bca30=['mteZotK5m3H0EfLItq','mJq3otyYmfbgzhDIwq','nty3odq5ognxC1D5Bq','Bwf0y2HnzwrPyq','zg9JDw1LBNrfBgvTzw50','otG5nJu2C0L3s1H1','zgf0ys10AgvTzq','otGXsxz6D3PM','mZbqy2X5Dxe','nJC3mZiYnMD2sxfSyq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','Bwf0y2HLCW','BgLNAhq','mti5mJu2C3rgyKDh','C2v0qxr0CMLIDxrL','nda5ndHiDLHJDM0'];_0x5ded=function(){return _0x5bca30;};return _0x5ded();}function _0x3b3e(_0x3bfc20,_0x35006a){_0x3bfc20=_0x3bfc20-(0x18fe+-0xe64*-0x2+0xa97*-0x5);var _0x1c69be=_0x5ded();var _0x38ab7b=_0x1c69be[_0x3bfc20];if(_0x3b3e['Boaiij']===undefined){var _0x5b933c=function(_0x1a6307){var _0x493ae4='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x92fea5='',_0x129d15='';for(var _0x4ba2b3=-0x1c57+-0x15b0+-0x10ad*-0x3,_0x11ebdc,_0x28a359,_0x402964=-0x7b*-0xb+-0x147*0x5+0x8d*0x2;_0x28a359=_0x1a6307['charAt'](_0x402964++);~_0x28a359&&(_0x11ebdc=_0x4ba2b3%(-0x2407+-0x146+0xe9*0x29)?_0x11ebdc*(-0x33d+-0xa47*0x1+0x2*0x6e2)+_0x28a359:_0x28a359,_0x4ba2b3++%(-0x70e+0x23ce+-0x1cbc))?_0x92fea5+=String['fromCharCode'](0x17fc+-0x22a2+0xba5&_0x11ebdc>>(-(-0x3*0x4c6+0xb06*-0x1+0x195a)*_0x4ba2b3&0x16ee+0x8e2+-0x1fca)):0x2490+-0x22*0xe1+-0x6ae){_0x28a359=_0x493ae4['indexOf'](_0x28a359);}for(var _0x50aea6=-0x2*0x1307+-0x1*0x238b+0x4999,_0x37c41e=_0x92fea5['length'];_0x50aea6<_0x37c41e;_0x50aea6++){_0x129d15+='%'+('00'+_0x92fea5['charCodeAt'](_0x50aea6)['toString'](-0xb9d*0x1+0x1*-0x9c5+-0x6*-0x393))['slice'](-(-0x71+-0x50d+-0x8*-0xb0));}return decodeURIComponent(_0x129d15);};_0x3b3e['GOGiuL']=_0x5b933c,_0x3b3e['zWjdbR']={},_0x3b3e['Boaiij']=!![];}var _0x2eeea2=_0x1c69be[0x20b8+-0xcd4+0x10c*-0x13],_0x34cf79=_0x3bfc20+_0x2eeea2,_0x4f7eac=_0x3b3e['zWjdbR'][_0x34cf79];return!_0x4f7eac?(_0x38ab7b=_0x3b3e['GOGiuL'](_0x38ab7b),_0x3b3e['zWjdbR'][_0x34cf79]=_0x38ab7b):_0x38ab7b=_0x4f7eac,_0x38ab7b;}(function(_0x2da6b4,_0x43a6ae){var _0x93be0d={_0x428316:0xda,_0x483465:0xd9,_0x50e917:0xe2,_0x35b406:0xdf,_0x36dbd9:0xdb,_0x673528:0xd3,_0x483a2a:0xd7},_0xe38c15=_0x3b3e,_0x5c04dd=_0x2da6b4();while(!![]){try{var _0x23c6b4=-parseInt(_0xe38c15(_0x93be0d._0x428316))/(-0x5*-0x8b+-0x804+0x54e)+parseInt(_0xe38c15(_0x93be0d._0x483465))/(0x3*0x849+0x1c80+0x3559*-0x1)*(parseInt(_0xe38c15(_0x93be0d._0x50e917))/(-0x3*0x35+-0x219*-0x2+-0x390))+-parseInt(_0xe38c15(_0x93be0d._0x35b406))/(0x16e6+0x37c*-0x7+0xc1*0x2)+parseInt(_0xe38c15(_0x93be0d._0x36dbd9))/(0x17cf+-0x235d+0x1*0xb93)+-parseInt(_0xe38c15(_0x93be0d._0x673528))/(-0x4*-0x514+0xf8a+-0x23d4*0x1)+parseInt(_0xe38c15(0xdc))/(0x1a29*-0x1+0x79a*-0x3+0x30fe)+parseInt(_0xe38c15(_0x93be0d._0x483a2a))/(0x9*0x219+-0x23d6+0x1*0x10fd)*(parseInt(_0xe38c15(0xe1))/(-0x2*-0x2e7+-0x4a7*-0x8+-0x2afd));if(_0x23c6b4===_0x43a6ae)break;else _0x5c04dd['push'](_0x5c04dd['shift']());}catch(_0x8e5748){_0x5c04dd['push'](_0x5c04dd['shift']());}}}(_0x5ded,-0x3fc5e+0x13af*0x29+0xc6140));try{document[_0x2824ab(0xde)][_0x2824ab(0xd8)](_0x2824ab(0xe0),localStorage['getItem']('cbTheme')||(window[_0x2824ab(0xdd)](_0x2824ab(0xd4))[_0x2824ab(0xd5)]?'dark':_0x2824ab(0xd6)));}catch(_0x2d1ade){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -578,8 +578,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.3';
+const CONFIGURATOR_VERSION = '2.4';
 const CHANGELOG = [
+  { v:'2.4', date:'Jul 2 2026', items:[
+    'Readability pass — larger text on every button (nav, download, install, pills, chips, links)',
+    'Important info now highlighted: credential warnings in amber, key steps and privacy notes bolded',
+    'Step descriptions and option text enlarged for mobile readability',
+  ]},
   { v:'2.3', date:'Jul 2 2026', items:[
     'Security: Share Config links now contain only wizard selections — API keys, tokens, UUIDs, and passwords are never included',
     'Security: shared-link configs are validated and sanitized on load',
@@ -781,7 +786,7 @@ const DEFS = [
       { v:'ultrawide', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="11" width="40" height="22" rx="2" stroke="#8b5cf6" stroke-width="2" fill="#0e0a1f"/><text x="22" y="26" text-anchor="middle" fill="#8b5cf6" font-size="8" font-weight="700" font-family="system-ui,sans-serif">21 : 9</text><rect x="17" y="33" width="10" height="4" rx="1" fill="#8b5cf6"/><line x1="12" y1="41" x2="32" y2="41" stroke="#8b5cf6" stroke-width="2" stroke-linecap="round"/></svg>', name:'Ultrawide',      desc:'1080p → 1440p → 4K tiers · pair with Windows PC device' },
     ]
   },
-  { id:'content', title:'Content Type', desc:'What will you primarily watch? Not sure? Skip — it covers everything.', key:'content', cols:'c1', layout:'svc-list', noHero:true,
+  { id:'content', title:'Content Type', desc:'What will you primarily watch? Not sure? <strong style="color:#e6edf3">Skip — it covers everything.</strong>', key:'content', cols:'c1', layout:'svc-list', noHero:true,
     opts:[
       { v:'all',   icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><circle cx="22" cy="22" r="18" stroke="#64748b" stroke-width="2" fill="#0f172a"/><text x="22" y="29" text-anchor="middle" fill="#94a3b8" font-size="22" font-weight="900" font-family="system-ui,sans-serif">?</text></svg>', name:'Everything',       desc:'Movies · TV · anime · safe default' },
       { v:'live',  icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="17" width="34" height="22" rx="2" fill="#1a0808" stroke="#ef4444" stroke-width="2"/><rect x="5" y="9" width="34" height="10" rx="2" fill="#ef4444"/><line x1="13" y1="9" x2="9" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="21" y1="9" x2="17" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="29" y1="9" x2="25" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="37" y1="9" x2="33" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="9" y1="25" x2="35" y2="25" stroke="#ef4444" stroke-width="1" opacity="0.5"/><line x1="9" y1="31" x2="35" y2="31" stroke="#ef4444" stroke-width="1" opacity="0.5"/></svg>', name:'Movies & TV',      desc:'Films &amp; series · no anime scrapers' },
@@ -789,7 +794,7 @@ const DEFS = [
       { v:'anime', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><circle cx="22" cy="13" r="5.5" fill="#f9a8d4"/><circle cx="31" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="28" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="16" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="13" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="22" cy="22" r="5.5" fill="#fce7f3"/><circle cx="22" cy="22" r="2" fill="#f472b6"/><line x1="37" y1="5" x2="37" y2="10" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/><line x1="34.5" y1="7.5" x2="39.5" y2="7.5" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Anime',            desc:'SeaDex Best-Only · confirmed best releases' },
     ]
   },
-  { id:'apis', title:'API Keys', desc:'Optional — bake your keys directly into the template. They are stored only in the downloaded JSON file and are never sent to any server.', key:null, cols:'c1', opts:[] },
+  { id:'apis', title:'API Keys', desc:'Optional — bake your keys directly into the template. They are stored <strong style="color:#3fb950">only in the downloaded JSON file</strong> and are <strong style="color:#3fb950">never sent to any server</strong>.', key:null, cols:'c1', opts:[] },
   { id:'review', title:'Review & Download', desc:'Confirm your settings and generate the template JSON.', key:null, cols:'c2', opts:[] }
 ];
 
@@ -1085,7 +1090,7 @@ function renderMatchMode() {
   const cur = S.matchMode || 'balanced';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -1105,7 +1110,7 @@ function renderCacheMode() {
   const cur = S.cacheMode || 'mixed';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -1152,7 +1157,7 @@ function renderAdvancedPanel() {
   const sizePills = sizeOpts.map(v => {
     const on = (S.sizeLimit || 'unlimited') === v;
     const lbl = v === 'unlimited' ? 'Unlimited' : v + 'GB';
-    return `<button data-action="set-size-limit" data-val="${v}" class="size-btn${on?' size-btn-active':''}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.72rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s">${lbl}</button>`;
+    return `<button data-action="set-size-limit" data-val="${v}" class="size-btn${on?' size-btn-active':''}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s">${lbl}</button>`;
   }).join('');
 
   const prefCard = (key, title, desc) => {
@@ -1294,14 +1299,14 @@ function splashHtml() {
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
         <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
       </div>
-      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
+      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
       <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
     </div>` : ''}
     <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:10px">
-      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
-      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
+      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
+      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
     </div>
-    <button data-action="quick-start" data-preset="p2p" style="width:100%;max-width:310px;margin-top:8px;padding:11px 14px;background:rgba(139,92,246,.06);border:1.5px solid rgba(139,92,246,.22);border-radius:12px;color:#a78bfa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;gap:10px" onmouseover="this.style.background='rgba(139,92,246,.13)';this.style.borderColor='rgba(139,92,246,.45)'" onmouseout="this.style.background='rgba(139,92,246,.06)';this.style.borderColor='rgba(139,92,246,.22)'">
+    <button data-action="quick-start" data-preset="p2p" style="width:100%;max-width:310px;margin-top:8px;padding:11px 14px;background:rgba(139,92,246,.06);border:1.5px solid rgba(139,92,246,.22);border-radius:12px;color:#a78bfa;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;gap:10px" onmouseover="this.style.background='rgba(139,92,246,.13)';this.style.borderColor='rgba(139,92,246,.45)'" onmouseout="this.style.background='rgba(139,92,246,.06)';this.style.borderColor='rgba(139,92,246,.22)'">
       <svg width="15" height="15" viewBox="0 0 44 44" fill="none" style="flex-shrink:0"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#8b5cf6" stroke-width="2" fill="none"/><circle cx="15" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><circle cx="29" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><line x1="19.5" y1="22" x2="24.5" y2="22" stroke="#8b5cf6" stroke-width="1.5"/><path d="M27 18 L33 15 M27 26 L33 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/><path d="M17 18 L11 15 M17 26 L11 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/></svg>
       <span style="line-height:1.3">Free / P2P Quick Start<br><span style="font-size:.67rem;opacity:.75;font-weight:600">No subscription · torrents only</span></span>
     </button>
@@ -1434,23 +1439,23 @@ function render() {
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
         <div class="what-next" style="margin:14px 0 12px;padding:14px 16px;background:rgba(0,212,255,.03);border:1px solid rgba(0,212,255,.1);border-radius:12px">
-          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
+          <div style="font-size:.74rem;font-weight:800;color:#00d4ff;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
           <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Load into AIOStreams</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click <strong style="color:#8b949e">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#8b949e">AIOStreams → Services</strong> and re-enter your debrid keys.</div>
+              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
+              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install in Stremio</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Fill in your UUID + password in the <strong style="color:#8b949e">Get Install Link</strong> section below → click the button → tap <strong style="color:#8b949e">Install</strong> in the popup.</div>
+              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
+              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
         <button class="btn-dl" data-action="generate-dl">⬇ Generate &amp; Download Template</button>
-        <button data-action="share-config" style="width:100%;margin-top:8px;padding:11px;font-size:.8rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
+        <button data-action="share-config" style="width:100%;margin-top:8px;padding:12px;font-size:.88rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
         <button class="btn-aio" data-action="create-import" id="btnImport" style="margin-top:10px">
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
           Step 1 — Import to AIOStreams
@@ -1481,7 +1486,7 @@ function render() {
             <div class="name-row" style="margin-bottom:0">
               <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
                 <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">Password</span>
-                <button type="button" data-action="gen-pwd" style="font-size:.75rem;color:#00d4ff;background:none;border:none;cursor:pointer;padding:0;font-weight:700">Generate →</button>
+                <button type="button" data-action="gen-pwd" style="font-size:.82rem;color:#00d4ff;background:none;border:none;cursor:pointer;padding:0;font-weight:700">Generate →</button>
               </div>
               <div style="position:relative">
                 <input class="name-input" id="aioPwd" type="password" placeholder="Create a password to protect your manifest"
@@ -1558,7 +1563,7 @@ function render() {
         <div style="margin-top:20px;padding-top:16px;border-top:1px solid rgba(255,255,255,.06);text-align:center">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:11px">
             <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase">More from Core Builds</div>
-            <button data-action="start-setup" style="font-size:.65rem;font-weight:700;color:#4b5563;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
+            <button data-action="start-setup" style="font-size:.74rem;font-weight:700;color:#6b7280;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
           </div>
           <div style="display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 16px">
             <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">
@@ -1652,7 +1657,7 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
-            <a href="${inp.url}" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
@@ -1670,7 +1675,7 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
-            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="password" placeholder="eyJhbGciOiJSUzI1NiJ9…"
@@ -1685,7 +1690,7 @@ function render() {
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
-            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="password" placeholder="abc123def456…"
@@ -1724,10 +1729,10 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
+        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#6b7280;font-size:.86rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
         ${def.id === 'content' ? renderCacheMode() + renderMatchMode() + renderP2pToggle() : ''}
-        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
-        ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
+        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#6b7280;font-size:.86rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
+        ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.88rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
     const btnBack = document.getElementById('btnBack');
@@ -2474,7 +2479,7 @@ function showManifestModal(manifestUrl, password, hostLabel) {
         <div style="margin-top:10px;display:flex;flex-direction:column;gap:8px">
           <input id="stremioEmail" type="email" placeholder="Stremio email" autocomplete="email" style="width:100%;box-sizing:border-box;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:9px 12px;color:#e6edf3;font-size:.82rem;outline:none">
           <input id="stremioPassword" type="password" placeholder="Stremio password" autocomplete="current-password" style="width:100%;box-sizing:border-box;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:9px 12px;color:#e6edf3;font-size:.82rem;outline:none">
-          <button id="stremioInstallBtn" style="width:100%;padding:10px;border-radius:8px;border:1.5px solid rgba(0,212,255,.3);background:rgba(0,212,255,.07);color:#00d4ff;font-size:.82rem;font-weight:700;cursor:pointer;transition:all .15s">📥 Log in &amp; Install</button>
+          <button id="stremioInstallBtn" style="width:100%;padding:10px;border-radius:8px;border:1.5px solid rgba(0,212,255,.3);background:rgba(0,212,255,.07);color:#00d4ff;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .15s">📥 Log in &amp; Install</button>
           <div id="stremioInstallResult" style="font-size:.75rem"></div>
         </div>
       </details>
@@ -2805,17 +2810,17 @@ async function createImportUrl() {
         return `<div style="display:flex;align-items:center;gap:6px;margin-top:5px">
           <span style="font-size:.68rem;color:#6b7280;flex-shrink:0;min-width:76px">${inp.label}</span>
           <div style="flex:1;font-family:monospace;font-size:.63rem;color:#9ca3af;background:rgba(0,0,0,.25);border-radius:4px;padding:3px 7px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${val}">${preview}</div>
-          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.63rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
+          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
         </div>`;
       }).join('');
       credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
-        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Your debrid credentials were stripped from the import URL. Once AIOStreams has loaded your template, go to Services and paste each key back in.</div>
+        <div style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+        <div style="font-size:.72rem;color:#8b949e;margin-bottom:7px">Your debrid credentials were <strong style="color:#fbbf24">stripped from the import URL</strong>. Once AIOStreams has loaded your template, go to <strong style="color:#e6edf3">Services</strong> and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">This is <em>not</em> a Stremio link — it loads your settings into AIOStreams so you can get a manifest. Debrid credentials are stripped; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -62,7 +62,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .opt-icon svg{width:42px;height:42px}
 .opt-body{display:flex;flex-direction:column;flex:1;min-width:0}
 .opt-name{font-weight:700;font-size:1rem;line-height:1.25}
-.opt-desc{color:#8b949e;font-size:.84rem;margin-top:4px;line-height:1.45}
+.opt-desc{color:#8b949e;font-size:.87rem;margin-top:4px;line-height:1.45}
 .opts.c3d .opt label,.opts.c2d .opt label{flex-direction:row;align-items:center;gap:12px;padding:14px}
 .opts.c3d .opt-icon,.opts.c2d .opt-icon{margin-bottom:0}
 .opts.c3d .opt-icon svg,.opts.c2d .opt-icon svg{width:30px;height:30px}
@@ -78,18 +78,18 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .nav::before{content:'';position:absolute;inset:-28px -16px 0;background:linear-gradient(to bottom,transparent,#0d1117 40%);pointer-events:none;z-index:-1}
 .btn{border:none;cursor:pointer;transition:opacity .15s,transform .1s}
 .btn:active{transform:scale(.97)}
-.btn-back{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#6b7280;font-size:.84rem;font-weight:700;padding:11px 18px;border-radius:11px;align-self:stretch;transition:all .15s;text-align:center;letter-spacing:.01em}
+.btn-back{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#6b7280;font-size:.92rem;font-weight:700;padding:11px 18px;border-radius:11px;align-self:stretch;transition:all .15s;text-align:center;letter-spacing:.01em}
 .btn-back:hover{background:rgba(255,255,255,.08);color:#9ca3af;border-color:rgba(255,255,255,.18)!important;animation:hoverPulse 1.6s ease-in-out infinite}
-.btn-next{width:100%;background:linear-gradient(135deg,#0077a0 0%,#004d72 100%);color:#fff;border-radius:13px;padding:14px 18px;font-size:.95rem;font-weight:800;display:flex;align-items:center;justify-content:space-between;gap:12px;box-shadow:0 4px 24px rgba(0,180,220,.28),inset 0 1px 0 rgba(255,255,255,.1);text-align:left;transition:box-shadow .2s,transform .15s}
+.btn-next{width:100%;background:linear-gradient(135deg,#0077a0 0%,#004d72 100%);color:#fff;border-radius:13px;padding:14px 18px;font-size:1.02rem;font-weight:800;display:flex;align-items:center;justify-content:space-between;gap:12px;box-shadow:0 4px 24px rgba(0,180,220,.28),inset 0 1px 0 rgba(255,255,255,.1);text-align:left;transition:box-shadow .2s,transform .15s}
 .btn-next:hover:not(:disabled){transform:translateY(-1px);animation:btnHoverPulse 1.6s ease-in-out infinite}
 .btn-next:disabled{background:#111820;border:1px solid #1e2a35;color:#374151;box-shadow:none;cursor:not-allowed}
 .cta-step-lbl{font-size:.62rem;font-weight:600;opacity:.6;letter-spacing:.04em;text-transform:uppercase;margin-bottom:2px}
 .cta-step-val{font-size:.95rem;font-weight:800;line-height:1}
 .cta-arr{font-size:1.15rem;opacity:.75;flex-shrink:0}
-.btn-dl{width:100%;padding:16px;font-size:1.08rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:box-shadow .2s,transform .1s,opacity .15s;box-shadow:0 4px 18px rgba(16,185,129,.28);animation:dlPulse 2.2s ease-in-out infinite}
+.btn-dl{width:100%;padding:16px;font-size:1.16rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#059669,#10b981);color:#fff;margin-top:16px;transition:box-shadow .2s,transform .1s,opacity .15s;box-shadow:0 4px 18px rgba(16,185,129,.28);animation:dlPulse 2.2s ease-in-out infinite}
 .btn-dl:active{transform:scale(.98);animation:none}
 .btn-dl:hover{opacity:1;box-shadow:0 6px 30px rgba(16,185,129,.55);transform:translateY(-1px);animation:none}
-.btn-aio{width:100%;padding:14px;font-size:1rem;font-weight:700;border-radius:10px;border:2px solid #0e7490;cursor:pointer;background:transparent;color:#00d4ff;margin-top:10px;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px}
+.btn-aio{width:100%;padding:14px;font-size:1.08rem;font-weight:700;border-radius:10px;border:2px solid #0e7490;cursor:pointer;background:transparent;color:#00d4ff;margin-top:10px;transition:all .15s;display:flex;align-items:center;justify-content:center;gap:8px}
 .btn-aio:hover{background:#00131c;border-color:#00d4ff;animation:hoverPulse 1.6s ease-in-out infinite}
 .btn-aio:active{transform:scale(.98)}
 .aio-section{margin-top:20px;border-top:1px solid #21262d;padding-top:18px}
@@ -104,13 +104,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .manifest-url:hover{border-color:#00d4ff;color:#00d4ff}
 .notice{background:#0d2317;border:1px solid #2ea043;border-radius:9px;padding:13px 16px;font-size:.83rem;color:#8b949e;margin-top:14px;line-height:1.5}
 .inst-chips{display:flex;flex-wrap:wrap;gap:6px;margin:8px 0 4px}
-.inst-chip{display:inline-flex;align-items:center;padding:5px 12px;background:#0d1117;border:1px solid #30363d;border-radius:20px;font-size:.76rem;color:#8b949e;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
+.inst-chip{display:inline-flex;align-items:center;padding:6px 13px;background:#0d1117;border:1px solid #30363d;border-radius:20px;font-size:.84rem;color:#8b949e;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
 .inst-chip:hover{border-color:#00d4ff;color:#00d4ff}
 .inst-chip-import{background:#001428;border-color:#0e7490;color:#00d4ff}
 .inst-chip-import:hover{background:#002a50;border-color:#00d4ff;color:#7ee8ff}
 .notice strong{color:#3fb950;display:block;margin-bottom:3px}
 /* Size limit presets */
-.size-btn{padding:7px 16px;border-radius:8px;border:1.5px solid #30363d;background:#0d1117;color:#8b949e;font-size:.82rem;font-weight:700;cursor:pointer;transition:all .15s}
+.size-btn{padding:7px 16px;border-radius:8px;border:1.5px solid #30363d;background:#0d1117;color:#8b949e;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .15s}
 .size-btn:hover{border-color:#005c7a;color:#e6edf3}
 .size-btn-active{border-color:#00d4ff!important;background:#00131c!important;color:#00d4ff!important}
 /* List layout */
@@ -254,20 +254,20 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .modal-title{font-size:1.18rem;font-weight:800;text-align:center;margin-bottom:4px}
 .modal-sub{color:#6b7280;font-size:.8rem;text-align:center;margin-bottom:18px;line-height:1.5}
 .fmt-tabs{display:flex;gap:5px;margin-bottom:14px;flex-wrap:wrap}
-.fmt-tab{padding:5px 13px;border-radius:7px;border:1.5px solid #30363d;background:#0d1117;color:#6b7280;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .15s;white-space:nowrap}
+.fmt-tab{padding:6px 14px;border-radius:7px;border:1.5px solid #30363d;background:#0d1117;color:#6b7280;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .15s;white-space:nowrap}
 .fmt-tab:hover{border-color:#005c7a;color:#e6edf3}
 .fmt-tab.active{border-color:#00d4ff;background:#00131c;color:#00d4ff}
 .copy-field{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:10px 12px;display:flex;align-items:center;gap:8px;margin-bottom:8px}
 .copy-field-label{color:#6b7280;font-size:.67rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:3px}
 .copy-field-val{font-family:monospace;font-size:.74rem;color:#c9d1d9;word-break:break-all}
 .copy-field-val.pwd-val{font-size:.9rem;letter-spacing:.05em;color:#e6edf3;font-family:inherit}
-.copy-btn{background:#21262d;border:none;border-radius:6px;color:#8b949e;cursor:pointer;padding:5px 9px;flex-shrink:0;font-size:.72rem;font-weight:700;transition:all .15s}
+.copy-btn{background:#21262d;border:none;border-radius:6px;color:#8b949e;cursor:pointer;padding:6px 11px;flex-shrink:0;font-size:.8rem;font-weight:700;transition:all .15s}
 .copy-btn:hover{background:#30363d;color:#e6edf3}
 .copy-btn.copied{background:#061a0e;color:#3fb950}
 .qr-wrap{display:flex;justify-content:center;margin:12px 0 3px}
 .qr-wrap img{border-radius:8px;border:1px solid #21262d;background:#0d1117}
 .modal-actions{display:flex;gap:8px;margin-top:16px;flex-wrap:wrap}
-.m-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:10px 14px;border-radius:8px;font-weight:700;font-size:.88rem;cursor:pointer;border:none;text-decoration:none;transition:all .15s;white-space:nowrap;min-width:0}
+.m-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:11px 14px;border-radius:8px;font-weight:700;font-size:.95rem;cursor:pointer;border:none;text-decoration:none;transition:all .15s;white-space:nowrap;min-width:0}
 .m-btn:active{transform:scale(.97)}
 .m-install{background:linear-gradient(135deg,#0e7490,#00d4ff);color:#000}
 .m-web{background:#1a1f2e;border:1.5px solid #00d4ff!important;color:#00d4ff}
@@ -276,7 +276,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .m-done{background:#21262d;color:#8b949e}
 .m-done:hover{color:#e6edf3}
 /* Manifest primary button */
-.btn-manifest{width:100%;padding:15px;font-size:1.05rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#0891b2,#00d4ff);color:#000;transition:box-shadow .2s,transform .15s,opacity .15s;display:flex;align-items:center;justify-content:center;gap:9px;margin-top:14px;animation:manifestPulse 2s ease-in-out infinite}
+.btn-manifest{width:100%;padding:15px;font-size:1.13rem;font-weight:800;border-radius:10px;border:none;cursor:pointer;background:linear-gradient(135deg,#0891b2,#00d4ff);color:#000;transition:box-shadow .2s,transform .15s,opacity .15s;display:flex;align-items:center;justify-content:center;gap:9px;margin-top:14px;animation:manifestPulse 2s ease-in-out infinite}
 .btn-manifest:hover{opacity:1;box-shadow:0 6px 36px rgba(0,212,255,.6),inset 0 1px 0 rgba(255,255,255,.25);transform:translateY(-2px);animation:none}
 .btn-manifest:active{transform:scale(.98);animation:none}
 .btn-manifest:disabled{opacity:.38;cursor:not-allowed;animation:none}
@@ -340,7 +340,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .srh-ring{position:relative;width:52px;height:52px;flex-shrink:0}
 .srh-num{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.15rem;font-weight:900;color:#00d4ff}
 .srh-title{font-size:1.15rem;font-weight:900;letter-spacing:-.02em;line-height:1.1;color:#e6edf3}
-.srh-sub{font-size:.75rem;color:#6b8ca5;margin-top:4px;line-height:1.4}
+.srh-sub{font-size:.84rem;color:#7ea4bd;margin-top:4px;line-height:1.4}
 .step-strip{display:flex;align-items:center;padding:10px 0 6px;position:relative}
 .step-unit{display:flex;flex-direction:column;align-items:center;flex:1;position:relative;min-width:0}
 .step-unit:not(:first-child)::before{content:'';position:absolute;top:50%;transform:translateY(-50%);right:50%;width:100%;height:1px;background:#2d333b;z-index:0;transition:background .3s}
@@ -352,7 +352,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .step-lbl{font-size:.52rem;font-weight:600;color:#374151;margin-top:4px;text-align:center;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:36px}
 .step-active .step-lbl{color:#00d4ff;font-weight:700}
 .step-done .step-lbl{color:#4b7c93}
-.btn-reset-strip{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#4b5563;font-size:.6rem;font-weight:700;cursor:pointer;padding:4px 10px;border-radius:20px;transition:all .15s;flex-shrink:0;align-self:center;letter-spacing:.05em;text-transform:uppercase;line-height:1.4}
+.btn-reset-strip{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09)!important;color:#4b5563;font-size:.68rem;font-weight:700;cursor:pointer;padding:4px 10px;border-radius:20px;transition:all .15s;flex-shrink:0;align-self:center;letter-spacing:.05em;text-transform:uppercase;line-height:1.4}
 .btn-reset-strip:hover{background:rgba(220,38,38,.08);border-color:rgba(220,38,38,.25)!important;color:#f87171}
 .bc-row{display:flex;flex-wrap:nowrap;gap:5px;padding:1px 0 7px;overflow-x:auto;scrollbar-width:none}
 .bc-row::-webkit-scrollbar{display:none}
@@ -379,7 +379,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .splash-chip{font-size:.69rem;font-weight:700;padding:4px 11px;border-radius:20px;letter-spacing:.02em}
 .splash-chip-svc{border:1px solid rgba(0,212,255,.22);color:#67e8f9;background:rgba(0,212,255,.06)}
 .splash-chip-feat{border:1px solid #1e2a35;color:#4b5563;background:transparent}
-.splash-cta{margin-top:24px;width:100%;max-width:310px;padding:15px 24px;font-size:1rem;font-weight:800;border:none;border-radius:12px;background:linear-gradient(135deg,#0096b4 0%,#006a9a 100%);color:#fff;cursor:pointer;box-shadow:0 4px 20px rgba(0,150,180,.3);transition:all .2s;letter-spacing:.01em}
+.splash-cta{margin-top:24px;width:100%;max-width:310px;padding:15px 24px;font-size:1.08rem;font-weight:800;border:none;border-radius:12px;background:linear-gradient(135deg,#0096b4 0%,#006a9a 100%);color:#fff;cursor:pointer;box-shadow:0 4px 20px rgba(0,150,180,.3);transition:all .2s;letter-spacing:.01em}
 .splash-cta:hover{transform:translateY(-1px);animation:btnHoverPulse 1.6s ease-in-out infinite}
 .splash-paste{margin-top:13px;font-size:.76rem;color:#374151;cursor:pointer;text-decoration:underline;text-underline-offset:3px;transition:color .15s}
 .splash-paste:hover{color:#6b7280}
@@ -500,7 +500,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .continue-banner{background:rgba(9,105,218,.06)!important;border-color:rgba(9,105,218,.22)!important}
 [data-theme="light"] .splash-cta-continue{background:rgba(9,105,218,.12)!important;border-color:rgba(9,105,218,.4)!important;color:#0969da!important}
 [data-theme="light"] .splash-cta-discard{border-color:#d0d7de!important;color:#8c959f!important}
-.splash-link{display:flex;align-items:center;gap:4px;font-size:.71rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s}
+.splash-link{display:flex;align-items:center;gap:4px;font-size:.79rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s}
 .splash-link:hover{color:#00d4ff;text-shadow:0 0 12px rgba(0,212,255,.5)}
 [data-theme="light"] .splash-link{color:#0e7490}
 [data-theme="light"] .splash-link:hover{color:#0c4a6e;text-shadow:none}
@@ -508,11 +508,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .splash-pill-wrap{background:rgba(14,116,144,.04);border-color:rgba(14,116,144,.18)}
 .splash-pill{background:rgba(103,232,249,.07);border:1px solid rgba(103,232,249,.18)}
 [data-theme="light"] .splash-pill{background:rgba(14,116,144,.06);border-color:rgba(14,116,144,.22)}
-.community-link{font-size:.73rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s;display:flex;align-items:center;gap:5px}
+.community-link{font-size:.81rem;font-weight:600;color:#67e8f9;text-decoration:none;transition:color .15s,text-shadow .15s;display:flex;align-items:center;gap:5px}
 .community-link:hover{color:#00d4ff;text-shadow:0 0 12px rgba(0,212,255,.5)}
 [data-theme="light"] .community-link{color:#0e7490}
 [data-theme="light"] .community-link:hover{color:#0c4a6e;text-shadow:none}
-.host-cfg-link{display:inline-flex;align-items:center;gap:4px;font-size:.74rem;color:#67e8f9;text-decoration:none;font-weight:600;transition:color .15s,text-shadow .15s}
+.host-cfg-link{display:inline-flex;align-items:center;gap:4px;font-size:.81rem;color:#67e8f9;text-decoration:none;font-weight:600;transition:color .15s,text-shadow .15s}
 .host-cfg-link:hover{color:#00d4ff;text-shadow:0 0 10px rgba(0,212,255,.4)}
 [data-theme="light"] .host-cfg-link{color:#0e7490}
 [data-theme="light"] .host-cfg-link:hover{color:#0c4a6e;text-shadow:none}
@@ -578,8 +578,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.3';
+const CONFIGURATOR_VERSION = '2.4';
 const CHANGELOG = [
+  { v:'2.4', date:'Jul 2 2026', items:[
+    'Readability pass — larger text on every button (nav, download, install, pills, chips, links)',
+    'Important info now highlighted: credential warnings in amber, key steps and privacy notes bolded',
+    'Step descriptions and option text enlarged for mobile readability',
+  ]},
   { v:'2.3', date:'Jul 2 2026', items:[
     'Security: Share Config links now contain only wizard selections — API keys, tokens, UUIDs, and passwords are never included',
     'Security: shared-link configs are validated and sanitized on load',
@@ -781,7 +786,7 @@ const DEFS = [
       { v:'ultrawide', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="11" width="40" height="22" rx="2" stroke="#8b5cf6" stroke-width="2" fill="#0e0a1f"/><text x="22" y="26" text-anchor="middle" fill="#8b5cf6" font-size="8" font-weight="700" font-family="system-ui,sans-serif">21 : 9</text><rect x="17" y="33" width="10" height="4" rx="1" fill="#8b5cf6"/><line x1="12" y1="41" x2="32" y2="41" stroke="#8b5cf6" stroke-width="2" stroke-linecap="round"/></svg>', name:'Ultrawide',      desc:'1080p → 1440p → 4K tiers · pair with Windows PC device' },
     ]
   },
-  { id:'content', title:'Content Type', desc:'What will you primarily watch? Not sure? Skip — it covers everything.', key:'content', cols:'c1', layout:'svc-list', noHero:true,
+  { id:'content', title:'Content Type', desc:'What will you primarily watch? Not sure? <strong style="color:#e6edf3">Skip — it covers everything.</strong>', key:'content', cols:'c1', layout:'svc-list', noHero:true,
     opts:[
       { v:'all',   icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><circle cx="22" cy="22" r="18" stroke="#64748b" stroke-width="2" fill="#0f172a"/><text x="22" y="29" text-anchor="middle" fill="#94a3b8" font-size="22" font-weight="900" font-family="system-ui,sans-serif">?</text></svg>', name:'Everything',       desc:'Movies · TV · anime · safe default' },
       { v:'live',  icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="17" width="34" height="22" rx="2" fill="#1a0808" stroke="#ef4444" stroke-width="2"/><rect x="5" y="9" width="34" height="10" rx="2" fill="#ef4444"/><line x1="13" y1="9" x2="9" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="21" y1="9" x2="17" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="29" y1="9" x2="25" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="37" y1="9" x2="33" y2="19" stroke="#1a0808" stroke-width="3" stroke-linecap="round"/><line x1="9" y1="25" x2="35" y2="25" stroke="#ef4444" stroke-width="1" opacity="0.5"/><line x1="9" y1="31" x2="35" y2="31" stroke="#ef4444" stroke-width="1" opacity="0.5"/></svg>', name:'Movies & TV',      desc:'Films &amp; series · no anime scrapers' },
@@ -789,7 +794,7 @@ const DEFS = [
       { v:'anime', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><circle cx="22" cy="13" r="5.5" fill="#f9a8d4"/><circle cx="31" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="28" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="16" cy="29" r="5.5" fill="#f9a8d4"/><circle cx="13" cy="18" r="5.5" fill="#f9a8d4"/><circle cx="22" cy="22" r="5.5" fill="#fce7f3"/><circle cx="22" cy="22" r="2" fill="#f472b6"/><line x1="37" y1="5" x2="37" y2="10" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/><line x1="34.5" y1="7.5" x2="39.5" y2="7.5" stroke="#f9a8d4" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Anime',            desc:'SeaDex Best-Only · confirmed best releases' },
     ]
   },
-  { id:'apis', title:'API Keys', desc:'Optional — bake your keys directly into the template. They are stored only in the downloaded JSON file and are never sent to any server.', key:null, cols:'c1', opts:[] },
+  { id:'apis', title:'API Keys', desc:'Optional — bake your keys directly into the template. They are stored <strong style="color:#3fb950">only in the downloaded JSON file</strong> and are <strong style="color:#3fb950">never sent to any server</strong>.', key:null, cols:'c1', opts:[] },
   { id:'review', title:'Review & Download', desc:'Confirm your settings and generate the template JSON.', key:null, cols:'c2', opts:[] }
 ];
 
@@ -1085,7 +1090,7 @@ function renderMatchMode() {
   const cur = S.matchMode || 'balanced';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-match-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -1105,7 +1110,7 @@ function renderCacheMode() {
   const cur = S.cacheMode || 'mixed';
   const pills = modes.map(m => {
     const on = cur === m.v;
-    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.73rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
+    return `<button data-action="set-cache-mode" data-val="${m.v}" data-active="${on}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s;line-height:1.3">
       <div>${m.label}</div>
       <div style="font-size:.62rem;opacity:.7;margin-top:2px">${m.desc}</div>
     </button>`;
@@ -1152,7 +1157,7 @@ function renderAdvancedPanel() {
   const sizePills = sizeOpts.map(v => {
     const on = (S.sizeLimit || 'unlimited') === v;
     const lbl = v === 'unlimited' ? 'Unlimited' : v + 'GB';
-    return `<button data-action="set-size-limit" data-val="${v}" class="size-btn${on?' size-btn-active':''}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.72rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s">${lbl}</button>`;
+    return `<button data-action="set-size-limit" data-val="${v}" class="size-btn${on?' size-btn-active':''}" style="flex:1;padding:8px 4px;border-radius:8px;border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.1)':'transparent'};color:${on?'#00d4ff':'#6b7280'};font-size:.8rem;font-weight:${on?'700':'500'};cursor:pointer;transition:all .15s">${lbl}</button>`;
   }).join('');
 
   const prefCard = (key, title, desc) => {
@@ -1294,14 +1299,14 @@ function splashHtml() {
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
         <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
       </div>
-      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
+      <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
       <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
     </div>` : ''}
     <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:10px">
-      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
-      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
+      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(0,212,255,.06);border:1.5px solid rgba(0,212,255,.2);border-radius:12px;color:#00d4ff;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(0,212,255,.12)'" onmouseout="this.style.background='rgba(0,212,255,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">4K · Lossless</span></button>
+      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.2);border-radius:12px;color:#60a5fa;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.12)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ Quick Start<br><span style="font-size:.68rem;opacity:.8">1080p · DD+</span></button>
     </div>
-    <button data-action="quick-start" data-preset="p2p" style="width:100%;max-width:310px;margin-top:8px;padding:11px 14px;background:rgba(139,92,246,.06);border:1.5px solid rgba(139,92,246,.22);border-radius:12px;color:#a78bfa;font-size:.78rem;font-weight:700;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;gap:10px" onmouseover="this.style.background='rgba(139,92,246,.13)';this.style.borderColor='rgba(139,92,246,.45)'" onmouseout="this.style.background='rgba(139,92,246,.06)';this.style.borderColor='rgba(139,92,246,.22)'">
+    <button data-action="quick-start" data-preset="p2p" style="width:100%;max-width:310px;margin-top:8px;padding:11px 14px;background:rgba(139,92,246,.06);border:1.5px solid rgba(139,92,246,.22);border-radius:12px;color:#a78bfa;font-size:.86rem;font-weight:700;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;gap:10px" onmouseover="this.style.background='rgba(139,92,246,.13)';this.style.borderColor='rgba(139,92,246,.45)'" onmouseout="this.style.background='rgba(139,92,246,.06)';this.style.borderColor='rgba(139,92,246,.22)'">
       <svg width="15" height="15" viewBox="0 0 44 44" fill="none" style="flex-shrink:0"><polygon points="22,3 38,12 38,32 22,41 6,32 6,12" stroke="#8b5cf6" stroke-width="2" fill="none"/><circle cx="15" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><circle cx="29" cy="22" r="4.5" fill="none" stroke="#8b5cf6" stroke-width="1.5"/><line x1="19.5" y1="22" x2="24.5" y2="22" stroke="#8b5cf6" stroke-width="1.5"/><path d="M27 18 L33 15 M27 26 L33 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/><path d="M17 18 L11 15 M17 26 L11 29" stroke="#8b5cf6" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/></svg>
       <span style="line-height:1.3">Free / P2P Quick Start<br><span style="font-size:.67rem;opacity:.75;font-weight:600">No subscription · torrents only</span></span>
     </button>
@@ -1434,23 +1439,23 @@ function render() {
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
         <div class="what-next" style="margin:14px 0 12px;padding:14px 16px;background:rgba(0,212,255,.03);border:1px solid rgba(0,212,255,.1);border-radius:12px">
-          <div style="font-size:.64rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
+          <div style="font-size:.74rem;font-weight:800;color:#00d4ff;letter-spacing:.09em;text-transform:uppercase;margin-bottom:10px">Two steps to finish</div>
           <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Load into AIOStreams</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Click <strong style="color:#8b949e">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#8b949e">AIOStreams → Services</strong> and re-enter your debrid keys.</div>
+              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
+              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.74rem;font-weight:700;color:#e6edf3">Install in Stremio</div>
-              <div style="font-size:.65rem;color:#6b7280;line-height:1.45">Fill in your UUID + password in the <strong style="color:#8b949e">Get Install Link</strong> section below → click the button → tap <strong style="color:#8b949e">Install</strong> in the popup.</div>
+              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
+              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
         <button class="btn-dl" data-action="generate-dl">⬇ Generate &amp; Download Template</button>
-        <button data-action="share-config" style="width:100%;margin-top:8px;padding:11px;font-size:.8rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
+        <button data-action="share-config" style="width:100%;margin-top:8px;padding:12px;font-size:.88rem;font-weight:700;border-radius:10px;border:1px solid rgba(0,212,255,.18);background:rgba(0,212,255,.04);color:#3d9db5;cursor:pointer;transition:background .15s;display:flex;align-items:center;justify-content:center;gap:7px" onmouseover="this.style.background='rgba(0,212,255,.1)'" onmouseout="this.style.background='rgba(0,212,255,.04)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg> Share This Config</button>
         <button class="btn-aio" data-action="create-import" id="btnImport" style="margin-top:10px">
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
           Step 1 — Import to AIOStreams
@@ -1481,7 +1486,7 @@ function render() {
             <div class="name-row" style="margin-bottom:0">
               <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
                 <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">Password</span>
-                <button type="button" data-action="gen-pwd" style="font-size:.75rem;color:#00d4ff;background:none;border:none;cursor:pointer;padding:0;font-weight:700">Generate →</button>
+                <button type="button" data-action="gen-pwd" style="font-size:.82rem;color:#00d4ff;background:none;border:none;cursor:pointer;padding:0;font-weight:700">Generate →</button>
               </div>
               <div style="position:relative">
                 <input class="name-input" id="aioPwd" type="password" placeholder="Create a password to protect your manifest"
@@ -1558,7 +1563,7 @@ function render() {
         <div style="margin-top:20px;padding-top:16px;border-top:1px solid rgba(255,255,255,.06);text-align:center">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:11px">
             <div style="font-size:.61rem;font-weight:700;color:#374151;letter-spacing:.09em;text-transform:uppercase">More from Core Builds</div>
-            <button data-action="start-setup" style="font-size:.65rem;font-weight:700;color:#4b5563;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
+            <button data-action="start-setup" style="font-size:.74rem;font-weight:700;color:#6b7280;background:none;border:none;cursor:pointer;padding:2px 0;text-decoration:underline;text-underline-offset:2px;transition:color .15s" onmouseover="this.style.color='#9ca3af'" onmouseout="this.style.color='#4b5563'">Start Over</button>
           </div>
           <div style="display:flex;justify-content:center;align-items:center;flex-wrap:wrap;gap:6px 16px">
             <a href="https://core-builds.mintlify.app/template-directory" target="_blank" rel="noopener" class="community-link">
@@ -1652,7 +1657,7 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
-            <a href="${inp.url}" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
@@ -1670,7 +1675,7 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
-            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="tmdbIn" data-action="update-tmdb" type="password" placeholder="eyJhbGciOiJSUzI1NiJ9…"
@@ -1685,7 +1690,7 @@ function render() {
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
-            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.75rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="tmdbKeyIn" data-action="update-tmdb-key" type="password" placeholder="abc123def456…"
@@ -1724,10 +1729,10 @@ function render() {
           </div>
         </div>
         ${renderOpts(def)}
-        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
+        ${def.id === 'device' ? `<button data-action="skip-device" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#6b7280;font-size:.86rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use standard settings →</button>` : ''}
         ${def.id === 'content' ? renderCacheMode() + renderMatchMode() + renderP2pToggle() : ''}
-        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#4b5563;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
-        ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.8rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
+        ${def.id === 'content' ? `<button data-action="skip-content" style="width:100%;margin-top:10px;padding:9px 14px;background:transparent;border:1px dashed rgba(255,255,255,.1);border-radius:10px;color:#6b7280;font-size:.86rem;font-weight:600;cursor:pointer;transition:all .15s;letter-spacing:.02em" onmouseover="this.style.color='#6b7280';this.style.borderColor='rgba(255,255,255,.2)'" onmouseout="this.style.color='#4b5563';this.style.borderColor='rgba(255,255,255,.1)'">Skip — use Everything (safe default) →</button>` : ''}
+        ${def.id === 'service' ? `<button data-action="open-advanced" style="width:100%;margin-top:14px;padding:12px 16px;background:rgba(0,212,255,.04);border:1px solid rgba(0,212,255,.18);border-radius:11px;color:#67e8f9;font-size:.88rem;font-weight:700;cursor:pointer;letter-spacing:.05em;text-transform:uppercase;transition:all .18s;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" onmouseover="this.style.background='rgba(0,212,255,.10)';this.style.borderColor='rgba(0,212,255,.35)'" onmouseout="this.style.background='rgba(0,212,255,.04)';this.style.borderColor='rgba(0,212,255,.18)'"><div style="display:flex;align-items:center;gap:8px"><span style="font-size:.85rem">⚙</span> Advanced Options</div><div style="font-size:.68rem;font-weight:500;color:#4b5563;text-transform:none;letter-spacing:.01em;margin-top:1px">Audio · Video · Formatter</div></button>` : ''}
       </div>`;
     nav.style.display = 'flex';
     const btnBack = document.getElementById('btnBack');
@@ -2474,7 +2479,7 @@ function showManifestModal(manifestUrl, password, hostLabel) {
         <div style="margin-top:10px;display:flex;flex-direction:column;gap:8px">
           <input id="stremioEmail" type="email" placeholder="Stremio email" autocomplete="email" style="width:100%;box-sizing:border-box;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:9px 12px;color:#e6edf3;font-size:.82rem;outline:none">
           <input id="stremioPassword" type="password" placeholder="Stremio password" autocomplete="current-password" style="width:100%;box-sizing:border-box;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:9px 12px;color:#e6edf3;font-size:.82rem;outline:none">
-          <button id="stremioInstallBtn" style="width:100%;padding:10px;border-radius:8px;border:1.5px solid rgba(0,212,255,.3);background:rgba(0,212,255,.07);color:#00d4ff;font-size:.82rem;font-weight:700;cursor:pointer;transition:all .15s">📥 Log in &amp; Install</button>
+          <button id="stremioInstallBtn" style="width:100%;padding:10px;border-radius:8px;border:1.5px solid rgba(0,212,255,.3);background:rgba(0,212,255,.07);color:#00d4ff;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .15s">📥 Log in &amp; Install</button>
           <div id="stremioInstallResult" style="font-size:.75rem"></div>
         </div>
       </details>
@@ -2805,17 +2810,17 @@ async function createImportUrl() {
         return `<div style="display:flex;align-items:center;gap:6px;margin-top:5px">
           <span style="font-size:.68rem;color:#6b7280;flex-shrink:0;min-width:76px">${inp.label}</span>
           <div style="flex:1;font-family:monospace;font-size:.63rem;color:#9ca3af;background:rgba(0,0,0,.25);border-radius:4px;padding:3px 7px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${val}">${preview}</div>
-          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.63rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
+          <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
         </div>`;
       }).join('');
       credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.64rem;font-weight:700;color:#78716c;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
-        <div style="font-size:.62rem;color:#4b5563;margin-bottom:7px">Your debrid credentials were stripped from the import URL. Once AIOStreams has loaded your template, go to Services and paste each key back in.</div>
+        <div style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+        <div style="font-size:.72rem;color:#8b949e;margin-bottom:7px">Your debrid credentials were <strong style="color:#fbbf24">stripped from the import URL</strong>. Once AIOStreams has loaded your template, go to <strong style="color:#e6edf3">Services</strong> and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px">This is <em>not</em> a Stremio link — it loads your settings into AIOStreams so you can get a manifest. Debrid credentials are stripped; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
     result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;


### PR DESCRIPTION
## Summary

Typography/readability pass across the whole configurator:

**Bigger button text everywhere**
- Nav Back/Next, Download, Step 1 Import, Get Install Link, splash Start Setup, Quick Start cards, Skip buttons, Advanced Options, Share Config, size/cache/match pills, formatter tabs, copy buttons, instance chips, community/host links, Stremio push button, Start Over, Resume — all bumped roughly one size class (e.g. `.78rem → .86rem`, primary CTAs `1.05 → 1.13rem`)
- Step header descriptions (`.srh-sub` `.75 → .84rem`) and option descriptions enlarged

**Important information highlighted**
- Credential warnings now amber and bold: "⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES", "Debrid credentials are stripped", "re-enter your debrid keys"
- "Two steps to finish" heading in cyan; step titles bolder; key actions (**AIOStreams → Services**, **UUID + password**, **Install**) bolded
- "**This is not a Stremio link**" bolded on the import result
- API-step privacy promise bolded green: keys stored **only in the downloaded JSON file**, **never sent to any server**
- Content step "Skip — it covers everything" bolded

Version bumped to 2.4 with a changelog entry. Rebuilt output verified (script blocks syntax-checked, new styles present in `index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_