### PR TITLE
configurator v2.5: local QR, key testing, light theme, device help, config diff

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -526,8 +526,55 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] #cb-loader-sub{color:#8c959f}
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
+
+/* v2.5 — theme-aware panels, test keys, device help */
+.import-error{border-color:#4b1a1a!important;background:#1a0606!important}
+.import-info{border-color:#374151!important;background:#111827!important}
+[data-theme="light"] .import-error{border-color:#f1aeb5!important;background:#fff5f5!important}
+[data-theme="light"] .import-error strong[style]{color:#cf222e!important}
+[data-theme="light"] .import-info{border-color:#d0d7de!important;background:#f6f8fa!important}
+[data-theme="light"] .import-info strong[style]{color:#1f2328!important}
+.insights-box{background:#060e15;border:1px solid #162030;border-radius:10px;padding:14px 16px;margin-bottom:16px}
+.insights-hdr{color:#7eeeff;font-size:.72rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:8px}
+.insights-box li{color:#8b949e;font-size:.85rem;line-height:1.45;display:flex;gap:6px}
+[data-theme="light"] .insights-box{background:#f0f9ff;border-color:#bae6fd}
+[data-theme="light"] .insights-hdr{color:#0369a1}
+[data-theme="light"] .insights-box li{color:#57606a}
+[data-theme="light"] .what-next strong[style]{color:#9a3412!important}
+[data-theme="light"] .wn-title{color:#1f2328!important}
+[data-theme="light"] .wn-body{color:#57606a!important}
+[data-theme="light"] .cred-remind strong[style]{color:#9a3412!important}
+[data-theme="light"] .cred-remind .cr-hdr{color:#b45309!important}
+[data-theme="light"] .import-success strong[style*="e6edf3"]{color:#1f2328!important}
+[data-theme="light"] .import-success strong[style*="fbbf24"]{color:#9a3412!important}
+.fmt-card{border:1.5px solid rgba(255,255,255,.13);border-radius:12px;background:rgba(8,12,18,.9);cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;overflow:hidden}
+.fmt-card[data-active="true"]{border-color:rgba(0,212,255,.65);background:rgba(0,212,255,.08);box-shadow:0 0 0 1px rgba(0,212,255,.22)}
+.fmt-card .fmt-lbl{color:#e6edf3}
+.fmt-card[data-active="true"] .fmt-lbl{color:#00d4ff!important}
+.fmt-card .fmt-preview-wrap{display:none;padding:0 13px 11px}
+.fmt-card[data-active="true"] .fmt-preview-wrap{display:block}
+.fmt-arr{color:#374151;font-size:.9rem;flex-shrink:0}
+.fmt-card[data-active="true"] .fmt-arr{color:#00d4ff}
+.fmt-arr::after{content:'›'}
+.fmt-card[data-active="true"] .fmt-arr::after{content:'✓'}
+[data-theme="light"] .fmt-card{background:#fff;border-color:#d0d7de}
+[data-theme="light"] .fmt-card[data-active="true"]{background:rgba(9,105,218,.06);border-color:#0969da;box-shadow:0 0 0 1px rgba(9,105,218,.2)}
+[data-theme="light"] .fmt-card .fmt-lbl{color:#1f2328}
+[data-theme="light"] .fmt-card[data-active="true"] .fmt-lbl{color:#0969da!important}
+.test-key-btn{font-size:.75rem;font-weight:700;color:#a5b4fc;background:rgba(99,102,241,.08);border:1px solid rgba(99,102,241,.3);border-radius:6px;padding:2px 10px;cursor:pointer;transition:all .15s;margin-right:10px}
+.test-key-btn:hover{background:rgba(99,102,241,.18)}
+.test-key-btn:disabled{opacity:.5;cursor:wait}
+.cred-status{font-size:.74rem;margin-top:4px;min-height:16px;display:block}
+[data-theme="light"] .test-key-btn{color:#4f46e5;background:rgba(79,70,229,.06);border-color:rgba(79,70,229,.3)}
+.help-btn{width:20px;height:20px;border-radius:50%;border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.05);color:#6b7280;font-size:.7rem;font-weight:800;cursor:pointer;flex-shrink:0;line-height:1;margin-right:8px;transition:all .15s;padding:0}
+.help-btn:hover{color:#00d4ff;border-color:rgba(0,212,255,.4)}
+.device-help{font-size:.8rem;color:#8b949e;line-height:1.55;padding:9px 14px 11px;border-top:1px dashed rgba(255,255,255,.09);display:none}
+.device-help b{color:#c9d1d9}
+[data-theme="light"] .device-help{color:#57606a;border-color:rgba(0,0,0,.12)}
+[data-theme="light"] .device-help b{color:#1f2328}
+[data-theme="light"] .help-btn{border-color:rgba(0,0,0,.15);background:rgba(0,0,0,.03);color:#8c959f}
 </style>
-<script>var _0x2824ab=_0x3b3e;function _0x5ded(){var _0x5bca30=['mteZotK5m3H0EfLItq','mJq3otyYmfbgzhDIwq','nty3odq5ognxC1D5Bq','Bwf0y2HnzwrPyq','zg9JDw1LBNrfBgvTzw50','otG5nJu2C0L3s1H1','zgf0ys10AgvTzq','otGXsxz6D3PM','mZbqy2X5Dxe','nJC3mZiYnMD2sxfSyq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','Bwf0y2HLCW','BgLNAhq','mti5mJu2C3rgyKDh','C2v0qxr0CMLIDxrL','nda5ndHiDLHJDM0'];_0x5ded=function(){return _0x5bca30;};return _0x5ded();}function _0x3b3e(_0x3bfc20,_0x35006a){_0x3bfc20=_0x3bfc20-(0x18fe+-0xe64*-0x2+0xa97*-0x5);var _0x1c69be=_0x5ded();var _0x38ab7b=_0x1c69be[_0x3bfc20];if(_0x3b3e['Boaiij']===undefined){var _0x5b933c=function(_0x1a6307){var _0x493ae4='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x92fea5='',_0x129d15='';for(var _0x4ba2b3=-0x1c57+-0x15b0+-0x10ad*-0x3,_0x11ebdc,_0x28a359,_0x402964=-0x7b*-0xb+-0x147*0x5+0x8d*0x2;_0x28a359=_0x1a6307['charAt'](_0x402964++);~_0x28a359&&(_0x11ebdc=_0x4ba2b3%(-0x2407+-0x146+0xe9*0x29)?_0x11ebdc*(-0x33d+-0xa47*0x1+0x2*0x6e2)+_0x28a359:_0x28a359,_0x4ba2b3++%(-0x70e+0x23ce+-0x1cbc))?_0x92fea5+=String['fromCharCode'](0x17fc+-0x22a2+0xba5&_0x11ebdc>>(-(-0x3*0x4c6+0xb06*-0x1+0x195a)*_0x4ba2b3&0x16ee+0x8e2+-0x1fca)):0x2490+-0x22*0xe1+-0x6ae){_0x28a359=_0x493ae4['indexOf'](_0x28a359);}for(var _0x50aea6=-0x2*0x1307+-0x1*0x238b+0x4999,_0x37c41e=_0x92fea5['length'];_0x50aea6<_0x37c41e;_0x50aea6++){_0x129d15+='%'+('00'+_0x92fea5['charCodeAt'](_0x50aea6)['toString'](-0xb9d*0x1+0x1*-0x9c5+-0x6*-0x393))['slice'](-(-0x71+-0x50d+-0x8*-0xb0));}return decodeURIComponent(_0x129d15);};_0x3b3e['GOGiuL']=_0x5b933c,_0x3b3e['zWjdbR']={},_0x3b3e['Boaiij']=!![];}var _0x2eeea2=_0x1c69be[0x20b8+-0xcd4+0x10c*-0x13],_0x34cf79=_0x3bfc20+_0x2eeea2,_0x4f7eac=_0x3b3e['zWjdbR'][_0x34cf79];return!_0x4f7eac?(_0x38ab7b=_0x3b3e['GOGiuL'](_0x38ab7b),_0x3b3e['zWjdbR'][_0x34cf79]=_0x38ab7b):_0x38ab7b=_0x4f7eac,_0x38ab7b;}(function(_0x2da6b4,_0x43a6ae){var _0x93be0d={_0x428316:0xda,_0x483465:0xd9,_0x50e917:0xe2,_0x35b406:0xdf,_0x36dbd9:0xdb,_0x673528:0xd3,_0x483a2a:0xd7},_0xe38c15=_0x3b3e,_0x5c04dd=_0x2da6b4();while(!![]){try{var _0x23c6b4=-parseInt(_0xe38c15(_0x93be0d._0x428316))/(-0x5*-0x8b+-0x804+0x54e)+parseInt(_0xe38c15(_0x93be0d._0x483465))/(0x3*0x849+0x1c80+0x3559*-0x1)*(parseInt(_0xe38c15(_0x93be0d._0x50e917))/(-0x3*0x35+-0x219*-0x2+-0x390))+-parseInt(_0xe38c15(_0x93be0d._0x35b406))/(0x16e6+0x37c*-0x7+0xc1*0x2)+parseInt(_0xe38c15(_0x93be0d._0x36dbd9))/(0x17cf+-0x235d+0x1*0xb93)+-parseInt(_0xe38c15(_0x93be0d._0x673528))/(-0x4*-0x514+0xf8a+-0x23d4*0x1)+parseInt(_0xe38c15(0xdc))/(0x1a29*-0x1+0x79a*-0x3+0x30fe)+parseInt(_0xe38c15(_0x93be0d._0x483a2a))/(0x9*0x219+-0x23d6+0x1*0x10fd)*(parseInt(_0xe38c15(0xe1))/(-0x2*-0x2e7+-0x4a7*-0x8+-0x2afd));if(_0x23c6b4===_0x43a6ae)break;else _0x5c04dd['push'](_0x5c04dd['shift']());}catch(_0x8e5748){_0x5c04dd['push'](_0x5c04dd['shift']());}}}(_0x5ded,-0x3fc5e+0x13af*0x29+0xc6140));try{document[_0x2824ab(0xde)][_0x2824ab(0xd8)](_0x2824ab(0xe0),localStorage['getItem']('cbTheme')||(window[_0x2824ab(0xdd)](_0x2824ab(0xd4))[_0x2824ab(0xd5)]?'dark':_0x2824ab(0xd6)));}catch(_0x2d1ade){}</script>
+<script>function _0x3ccf(){var _0x2fdda1=['y2juAgvTzq','mZq3nJrmyMHHAwW','Bwf0y2HLCW','mte1B1L3uxbQ','mtm3mtK3ndbusfzPCK0','Bwf0y2HnzwrPyq','mJaYndaZn1LzCuvKAG','ntuYmtq2DNvvv1Py','ntyWmtbYyNL5twS','z2v0sxrLBq','BgLNAhq','mtu1nZe1m2vUqMfVzG','mtmZmZi0ne94vKHlAW','mZjKD1DNtNq','mtfrzND1sMO'];_0x3ccf=function(){return _0x2fdda1;};return _0x3ccf();}var _0x3f1479=_0x3501;function _0x3501(_0x3d13b1,_0x36900e){_0x3d13b1=_0x3d13b1-(0x2*0x1072+0x1*0x1f75+-0x3ec4);var _0x392ce2=_0x3ccf();var _0x222ccd=_0x392ce2[_0x3d13b1];if(_0x3501['DkpUFv']===undefined){var _0x469cb5=function(_0x225d60){var _0x535fda='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x58ec35='',_0x32232b='';for(var _0x250c99=0x1*-0xd6f+0x1*-0x18af+-0x11*-0x23e,_0xec061a,_0x5644a2,_0x7e9a1=-0x78c+0x5*-0x8e+0xa52;_0x5644a2=_0x225d60['charAt'](_0x7e9a1++);~_0x5644a2&&(_0xec061a=_0x250c99%(-0x1fe6+0x1791+-0x1*-0x859)?_0xec061a*(-0x4fe+0x1908+-0x13ca)+_0x5644a2:_0x5644a2,_0x250c99++%(-0xe25*-0x1+-0x18df+0xabe))?_0x58ec35+=String['fromCharCode'](-0x1a41+-0x15f3+-0x3133*-0x1&_0xec061a>>(-(-0x1*0x11e3+0x2*-0xfc2+-0x8b*-0x5b)*_0x250c99&-0x11fd+-0x11*-0x223+-0x1250)):-0xc2e+-0x2425+-0x8b*-0x59){_0x5644a2=_0x535fda['indexOf'](_0x5644a2);}for(var _0x3fcf3f=0x765*-0x1+0x80b*-0x1+0xf70,_0x5b23ea=_0x58ec35['length'];_0x3fcf3f<_0x5b23ea;_0x3fcf3f++){_0x32232b+='%'+('00'+_0x58ec35['charCodeAt'](_0x3fcf3f)['toString'](-0x492+-0x8*-0x431+0x1ce6*-0x1))['slice'](-(-0xebb+0x6f9+0x7*0x11c));}return decodeURIComponent(_0x32232b);};_0x3501['EpLhNv']=_0x469cb5,_0x3501['QOkMnc']={},_0x3501['DkpUFv']=!![];}var _0x5e6a9f=_0x392ce2[0x1ff5+-0x1ad2*0x1+-0x1*0x523],_0x53ce9d=_0x3d13b1+_0x5e6a9f,_0xf282f1=_0x3501['QOkMnc'][_0x53ce9d];return!_0xf282f1?(_0x222ccd=_0x3501['EpLhNv'](_0x222ccd),_0x3501['QOkMnc'][_0x53ce9d]=_0x222ccd):_0x222ccd=_0xf282f1,_0x222ccd;}(function(_0x35d6bf,_0xa3408a){var _0x5c1c85={_0x3669f0:0x1a1,_0x2db7e5:0x1a2,_0x100367:0x19e,_0x4b97c6:0x1a3},_0x199c9f=_0x3501,_0x495f99=_0x35d6bf();while(!![]){try{var _0x25967f=parseInt(_0x199c9f(0x195))/(-0x208d+0x2*0x61d+-0x1454*-0x1)*(parseInt(_0x199c9f(0x197))/(-0x4b2*-0x4+0x2649+0x1305*-0x3))+parseInt(_0x199c9f(_0x5c1c85._0x3669f0))/(0x202+-0x8b8*0x1+0x6b9*0x1)+-parseInt(_0x199c9f(_0x5c1c85._0x2db7e5))/(-0x4cb*-0x1+0x1e16+-0x22dd)+-parseInt(_0x199c9f(0x199))/(0x174d+-0x152f+-0x219)*(parseInt(_0x199c9f(_0x5c1c85._0x100367))/(0x2*0x4e5+-0x145d+-0x1*-0xa99))+-parseInt(_0x199c9f(0x19d))/(-0x8e3*0x2+-0x2010+0x31dd)+-parseInt(_0x199c9f(_0x5c1c85._0x4b97c6))/(-0x1cd4+-0x31*-0x67+0x925)*(parseInt(_0x199c9f(0x19c))/(-0x761*0x5+0x26eb+0x1*-0x1fd))+parseInt(_0x199c9f(0x19a))/(-0x1312+-0xd*-0xbf+0x969);if(_0x25967f===_0xa3408a)break;else _0x495f99['push'](_0x495f99['shift']());}catch(_0x19ce5f){_0x495f99['push'](_0x495f99['shift']());}}}(_0x3ccf,-0x5db65+-0x30f8e+0x1165e4));try{document['documentElement']['setAttribute']('data-theme',localStorage[_0x3f1479(0x19f)](_0x3f1479(0x196))||(window[_0x3f1479(0x19b)]('(prefers-color-scheme:dark)')[_0x3f1479(0x198)]?'dark':_0x3f1479(0x1a0)));}catch(_0x377124){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -575,11 +622,25 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   </div>
 </div>
 <button id="themeToggle" onclick="toggleTheme()" title="Toggle light/dark theme" aria-label="Toggle theme"> Mode</button>
+<script>/*! qrcode-generator v2.0.4 | (c) Kazuhiko Arase | MIT | github.com/kazuhikoarase/qrcode-generator */
+var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],f={},c=function(t,r){o=function(t){for(var r=new Array(t),e=0;e<t;e+=1){r[e]=new Array(t);for(var n=0;n<t;n+=1)r[e][n]=null}return r}(i=4*e+17),l(0,0),l(i-7,0),l(0,i-7),s(),h(),d(t,r),e>=7&&v(t),null==a&&(a=p(e,n,u)),w(a,r)},l=function(t,r){for(var e=-1;e<=7;e+=1)if(!(t+e<=-1||i<=t+e))for(var n=-1;n<=7;n+=1)r+n<=-1||i<=r+n||(o[t+e][r+n]=0<=e&&e<=6&&(0==n||6==n)||0<=n&&n<=6&&(0==e||6==e)||2<=e&&e<=4&&2<=n&&n<=4)},h=function(){for(var t=8;t<i-8;t+=1)null==o[t][6]&&(o[t][6]=t%2==0);for(var r=8;r<i-8;r+=1)null==o[6][r]&&(o[6][r]=r%2==0)},s=function(){for(var t=B.getPatternPosition(e),r=0;r<t.length;r+=1)for(var n=0;n<t.length;n+=1){var i=t[r],a=t[n];if(null==o[i][a])for(var u=-2;u<=2;u+=1)for(var f=-2;f<=2;f+=1)o[i+u][a+f]=-2==u||2==u||-2==f||2==f||0==u&&0==f}},v=function(t){for(var r=B.getBCHTypeNumber(e),n=0;n<18;n+=1){var a=!t&&1==(r>>n&1);o[Math.floor(n/3)][n%3+i-8-3]=a}for(n=0;n<18;n+=1){a=!t&&1==(r>>n&1);o[n%3+i-8-3][Math.floor(n/3)]=a}},d=function(t,r){for(var e=n<<3|r,a=B.getBCHTypeInfo(e),u=0;u<15;u+=1){var f=!t&&1==(a>>u&1);u<6?o[u][8]=f:u<8?o[u+1][8]=f:o[i-15+u][8]=f}for(u=0;u<15;u+=1){f=!t&&1==(a>>u&1);u<8?o[8][i-u-1]=f:u<9?o[8][15-u-1+1]=f:o[8][15-u-1]=f}o[i-8][8]=!t},w=function(t,r){for(var e=-1,n=i-1,a=7,u=0,f=B.getMaskFunction(r),c=i-1;c>0;c-=2)for(6==c&&(c-=1);;){for(var g=0;g<2;g+=1)if(null==o[n][c-g]){var l=!1;u<t.length&&(l=1==(t[u]>>>a&1)),f(n,c-g)&&(l=!l),o[n][c-g]=l,-1==(a-=1)&&(u+=1,a=7)}if((n+=e)<0||i<=n){n-=e,e=-e;break}}},p=function(t,r,e){for(var n=A.getRSBlocks(t,r),o=b(),i=0;i<e.length;i+=1){var a=e[i];o.put(a.getMode(),4),o.put(a.getLength(),B.getLengthInBits(a.getMode(),t)),a.write(o)}var u=0;for(i=0;i<n.length;i+=1)u+=n[i].dataCount;if(o.getLengthInBits()>8*u)throw"code length overflow. ("+o.getLengthInBits()+">"+8*u+")";for(o.getLengthInBits()+4<=8*u&&o.put(0,4);o.getLengthInBits()%8!=0;)o.putBit(!1);for(;!(o.getLengthInBits()>=8*u||(o.put(236,8),o.getLengthInBits()>=8*u));)o.put(17,8);return function(t,r){for(var e=0,n=0,o=0,i=new Array(r.length),a=new Array(r.length),u=0;u<r.length;u+=1){var f=r[u].dataCount,c=r[u].totalCount-f;n=Math.max(n,f),o=Math.max(o,c),i[u]=new Array(f);for(var g=0;g<i[u].length;g+=1)i[u][g]=255&t.getBuffer()[g+e];e+=f;var l=B.getErrorCorrectPolynomial(c),h=k(i[u],l.getLength()-1).mod(l);for(a[u]=new Array(l.getLength()-1),g=0;g<a[u].length;g+=1){var s=g+h.getLength()-a[u].length;a[u][g]=s>=0?h.getAt(s):0}}var v=0;for(g=0;g<r.length;g+=1)v+=r[g].totalCount;var d=new Array(v),w=0;for(g=0;g<n;g+=1)for(u=0;u<r.length;u+=1)g<i[u].length&&(d[w]=i[u][g],w+=1);for(g=0;g<o;g+=1)for(u=0;u<r.length;u+=1)g<a[u].length&&(d[w]=a[u][g],w+=1);return d}(o,n)};f.addData=function(t,r){var e=null;switch(r=r||"Byte"){case"Numeric":e=M(t);break;case"Alphanumeric":e=x(t);break;case"Byte":e=m(t);break;case"Kanji":e=L(t);break;default:throw"mode:"+r}u.push(e),a=null},f.isDark=function(t,r){if(t<0||i<=t||r<0||i<=r)throw t+","+r;return o[t][r]},f.getModuleCount=function(){return i},f.make=function(){if(e<1){for(var t=1;t<40;t++){for(var r=A.getRSBlocks(t,n),o=b(),i=0;i<u.length;i++){var a=u[i];o.put(a.getMode(),4),o.put(a.getLength(),B.getLengthInBits(a.getMode(),t)),a.write(o)}var g=0;for(i=0;i<r.length;i++)g+=r[i].dataCount;if(o.getLengthInBits()<=8*g)break}e=t}c(!1,function(){for(var t=0,r=0,e=0;e<8;e+=1){c(!0,e);var n=B.getLostPoint(f);(0==e||t>n)&&(t=n,r=e)}return r}())},f.createTableTag=function(t,r){t=t||2;var e="";e+='<table style="',e+=" border-width: 0px; border-style: none;",e+=" border-collapse: collapse;",e+=" padding: 0px; margin: "+(r=void 0===r?4*t:r)+"px;",e+='">',e+="<tbody>";for(var n=0;n<f.getModuleCount();n+=1){e+="<tr>";for(var o=0;o<f.getModuleCount();o+=1)e+='<td style="',e+=" border-width: 0px; border-style: none;",e+=" border-collapse: collapse;",e+=" padding: 0px; margin: 0px;",e+=" width: "+t+"px;",e+=" height: "+t+"px;",e+=" background-color: ",e+=f.isDark(n,o)?"#000000":"#ffffff",e+=";",e+='"/>';e+="</tr>"}return e+="</tbody>",e+="</table>"},f.createSvgTag=function(t,r,e,n){var o={};"object"==typeof arguments[0]&&(t=(o=arguments[0]).cellSize,r=o.margin,e=o.alt,n=o.title),t=t||2,r=void 0===r?4*t:r,(e="string"==typeof e?{text:e}:e||{}).text=e.text||null,e.id=e.text?e.id||"qrcode-description":null,(n="string"==typeof n?{text:n}:n||{}).text=n.text||null,n.id=n.text?n.id||"qrcode-title":null;var i,a,u,c,g=f.getModuleCount()*t+2*r,l="";for(c="l"+t+",0 0,"+t+" -"+t+",0 0,-"+t+"z ",l+='<svg version="1.1" xmlns="http://www.w3.org/2000/svg"',l+=o.scalable?"":' width="'+g+'px" height="'+g+'px"',l+=' viewBox="0 0 '+g+" "+g+'" ',l+=' preserveAspectRatio="xMinYMin meet"',l+=n.text||e.text?' role="img" aria-labelledby="'+y([n.id,e.id].join(" ").trim())+'"':"",l+=">",l+=n.text?'<title id="'+y(n.id)+'">'+y(n.text)+"</title>":"",l+=e.text?'<description id="'+y(e.id)+'">'+y(e.text)+"</description>":"",l+='<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>',l+='<path d="',a=0;a<f.getModuleCount();a+=1)for(u=a*t+r,i=0;i<f.getModuleCount();i+=1)f.isDark(a,i)&&(l+="M"+(i*t+r)+","+u+c);return l+='" stroke="transparent" fill="black"/>',l+="</svg>"},f.createDataURL=function(t,r){t=t||2,r=void 0===r?4*t:r;var e=f.getModuleCount()*t+2*r,n=r,o=e-r;return I(e,e,function(r,e){if(n<=r&&r<o&&n<=e&&e<o){var i=Math.floor((r-n)/t),a=Math.floor((e-n)/t);return f.isDark(a,i)?0:1}return 1})},f.createImgTag=function(t,r,e){t=t||2,r=void 0===r?4*t:r;var n=f.getModuleCount()*t+2*r,o="";return o+="<img",o+=' src="',o+=f.createDataURL(t,r),o+='"',o+=' width="',o+=n,o+='"',o+=' height="',o+=n,o+='"',e&&(o+=' alt="',o+=y(e),o+='"'),o+="/>"};var y=function(t){for(var r="",e=0;e<t.length;e+=1){var n=t.charAt(e);switch(n){case"<":r+="&lt;";break;case">":r+="&gt;";break;case"&":r+="&amp;";break;case'"':r+="&quot;";break;default:r+=n}}return r};return f.createASCII=function(t,r){if((t=t||1)<2)return function(t){t=void 0===t?2:t;var r,e,n,o,i,a=1*f.getModuleCount()+2*t,u=t,c=a-t,g={"██":"█","█ ":"▀"," █":"▄","  ":" "},l={"██":"▀","█ ":"▀"," █":" ","  ":" "},h="";for(r=0;r<a;r+=2){for(n=Math.floor((r-u)/1),o=Math.floor((r+1-u)/1),e=0;e<a;e+=1)i="█",u<=e&&e<c&&u<=r&&r<c&&f.isDark(n,Math.floor((e-u)/1))&&(i=" "),u<=e&&e<c&&u<=r+1&&r+1<c&&f.isDark(o,Math.floor((e-u)/1))?i+=" ":i+="█",h+=t<1&&r+1>=c?l[i]:g[i];h+="\n"}return a%2&&t>0?h.substring(0,h.length-a-1)+Array(a+1).join("▀"):h.substring(0,h.length-1)}(r);t-=1,r=void 0===r?2*t:r;var e,n,o,i,a=f.getModuleCount()*t+2*r,u=r,c=a-r,g=Array(t+1).join("██"),l=Array(t+1).join("  "),h="",s="";for(e=0;e<a;e+=1){for(o=Math.floor((e-u)/t),s="",n=0;n<a;n+=1)i=1,u<=n&&n<c&&u<=e&&e<c&&f.isDark(o,Math.floor((n-u)/t))&&(i=0),s+=i?g:l;for(o=0;o<t;o+=1)h+=s+"\n"}return h.substring(0,h.length-1)},f.renderTo2dContext=function(t,r){r=r||2;for(var e=f.getModuleCount(),n=0;n<e;n++)for(var o=0;o<e;o++)t.fillStyle=f.isDark(n,o)?"black":"white",t.fillRect(o*r,n*r,r,r)},f};t.stringToBytes=(t.stringToBytesFuncs={default:function(t){for(var r=[],e=0;e<t.length;e+=1){var n=t.charCodeAt(e);r.push(255&n)}return r}}).default,t.createStringToBytes=function(t,r){var e=function(){for(var e=S(t),n=function(){var t=e.read();if(-1==t)throw"eof";return t},o=0,i={};;){var a=e.read();if(-1==a)break;var u=n(),f=n()<<8|n();i[String.fromCharCode(a<<8|u)]=f,o+=1}if(o!=r)throw o+" != "+r;return i}(),n="?".charCodeAt(0);return function(t){for(var r=[],o=0;o<t.length;o+=1){var i=t.charCodeAt(o);if(i<128)r.push(i);else{var a=e[t.charAt(o)];"number"==typeof a?(255&a)==a?r.push(a):(r.push(a>>>8),r.push(255&a)):r.push(n)}}return r}};var r,e,n,o,i,a=1,u=2,f=4,c=8,g={L:1,M:0,Q:3,H:2},l=0,h=1,s=2,v=3,d=4,w=5,p=6,y=7,B=(r=[[],[6,18],[6,22],[6,26],[6,30],[6,34],[6,22,38],[6,24,42],[6,26,46],[6,28,50],[6,30,54],[6,32,58],[6,34,62],[6,26,46,66],[6,26,48,70],[6,26,50,74],[6,30,54,78],[6,30,56,82],[6,30,58,86],[6,34,62,90],[6,28,50,72,94],[6,26,50,74,98],[6,30,54,78,102],[6,28,54,80,106],[6,32,58,84,110],[6,30,58,86,114],[6,34,62,90,118],[6,26,50,74,98,122],[6,30,54,78,102,126],[6,26,52,78,104,130],[6,30,56,82,108,134],[6,34,60,86,112,138],[6,30,58,86,114,142],[6,34,62,90,118,146],[6,30,54,78,102,126,150],[6,24,50,76,102,128,154],[6,28,54,80,106,132,158],[6,32,58,84,110,136,162],[6,26,54,82,110,138,166],[6,30,58,86,114,142,170]],e=1335,n=7973,i=function(t){for(var r=0;0!=t;)r+=1,t>>>=1;return r},(o={}).getBCHTypeInfo=function(t){for(var r=t<<10;i(r)-i(e)>=0;)r^=e<<i(r)-i(e);return 21522^(t<<10|r)},o.getBCHTypeNumber=function(t){for(var r=t<<12;i(r)-i(n)>=0;)r^=n<<i(r)-i(n);return t<<12|r},o.getPatternPosition=function(t){return r[t-1]},o.getMaskFunction=function(t){switch(t){case l:return function(t,r){return(t+r)%2==0};case h:return function(t,r){return t%2==0};case s:return function(t,r){return r%3==0};case v:return function(t,r){return(t+r)%3==0};case d:return function(t,r){return(Math.floor(t/2)+Math.floor(r/3))%2==0};case w:return function(t,r){return t*r%2+t*r%3==0};case p:return function(t,r){return(t*r%2+t*r%3)%2==0};case y:return function(t,r){return(t*r%3+(t+r)%2)%2==0};default:throw"bad maskPattern:"+t}},o.getErrorCorrectPolynomial=function(t){for(var r=k([1],0),e=0;e<t;e+=1)r=r.multiply(k([1,C.gexp(e)],0));return r},o.getLengthInBits=function(t,r){if(1<=r&&r<10)switch(t){case a:return 10;case u:return 9;case f:case c:return 8;default:throw"mode:"+t}else if(r<27)switch(t){case a:return 12;case u:return 11;case f:return 16;case c:return 10;default:throw"mode:"+t}else{if(!(r<41))throw"type:"+r;switch(t){case a:return 14;case u:return 13;case f:return 16;case c:return 12;default:throw"mode:"+t}}},o.getLostPoint=function(t){for(var r=t.getModuleCount(),e=0,n=0;n<r;n+=1)for(var o=0;o<r;o+=1){for(var i=0,a=t.isDark(n,o),u=-1;u<=1;u+=1)if(!(n+u<0||r<=n+u))for(var f=-1;f<=1;f+=1)o+f<0||r<=o+f||0==u&&0==f||a==t.isDark(n+u,o+f)&&(i+=1);i>5&&(e+=3+i-5)}for(n=0;n<r-1;n+=1)for(o=0;o<r-1;o+=1){var c=0;t.isDark(n,o)&&(c+=1),t.isDark(n+1,o)&&(c+=1),t.isDark(n,o+1)&&(c+=1),t.isDark(n+1,o+1)&&(c+=1),0!=c&&4!=c||(e+=3)}for(n=0;n<r;n+=1)for(o=0;o<r-6;o+=1)t.isDark(n,o)&&!t.isDark(n,o+1)&&t.isDark(n,o+2)&&t.isDark(n,o+3)&&t.isDark(n,o+4)&&!t.isDark(n,o+5)&&t.isDark(n,o+6)&&(e+=40);for(o=0;o<r;o+=1)for(n=0;n<r-6;n+=1)t.isDark(n,o)&&!t.isDark(n+1,o)&&t.isDark(n+2,o)&&t.isDark(n+3,o)&&t.isDark(n+4,o)&&!t.isDark(n+5,o)&&t.isDark(n+6,o)&&(e+=40);var g=0;for(o=0;o<r;o+=1)for(n=0;n<r;n+=1)t.isDark(n,o)&&(g+=1);return e+=Math.abs(100*g/r/r-50)/5*10},o),C=function(){for(var t=new Array(256),r=new Array(256),e=0;e<8;e+=1)t[e]=1<<e;for(e=8;e<256;e+=1)t[e]=t[e-4]^t[e-5]^t[e-6]^t[e-8];for(e=0;e<255;e+=1)r[t[e]]=e;var n={glog:function(t){if(t<1)throw"glog("+t+")";return r[t]},gexp:function(r){for(;r<0;)r+=255;for(;r>=256;)r-=255;return t[r]}};return n}();function k(t,r){if(void 0===t.length)throw t.length+"/"+r;var e=function(){for(var e=0;e<t.length&&0==t[e];)e+=1;for(var n=new Array(t.length-e+r),o=0;o<t.length-e;o+=1)n[o]=t[o+e];return n}(),n={getAt:function(t){return e[t]},getLength:function(){return e.length},multiply:function(t){for(var r=new Array(n.getLength()+t.getLength()-1),e=0;e<n.getLength();e+=1)for(var o=0;o<t.getLength();o+=1)r[e+o]^=C.gexp(C.glog(n.getAt(e))+C.glog(t.getAt(o)));return k(r,0)},mod:function(t){if(n.getLength()-t.getLength()<0)return n;for(var r=C.glog(n.getAt(0))-C.glog(t.getAt(0)),e=new Array(n.getLength()),o=0;o<n.getLength();o+=1)e[o]=n.getAt(o);for(o=0;o<t.getLength();o+=1)e[o]^=C.gexp(C.glog(t.getAt(o))+r);return k(e,0).mod(t)}};return n}var A=function(){var t=[[1,26,19],[1,26,16],[1,26,13],[1,26,9],[1,44,34],[1,44,28],[1,44,22],[1,44,16],[1,70,55],[1,70,44],[2,35,17],[2,35,13],[1,100,80],[2,50,32],[2,50,24],[4,25,9],[1,134,108],[2,67,43],[2,33,15,2,34,16],[2,33,11,2,34,12],[2,86,68],[4,43,27],[4,43,19],[4,43,15],[2,98,78],[4,49,31],[2,32,14,4,33,15],[4,39,13,1,40,14],[2,121,97],[2,60,38,2,61,39],[4,40,18,2,41,19],[4,40,14,2,41,15],[2,146,116],[3,58,36,2,59,37],[4,36,16,4,37,17],[4,36,12,4,37,13],[2,86,68,2,87,69],[4,69,43,1,70,44],[6,43,19,2,44,20],[6,43,15,2,44,16],[4,101,81],[1,80,50,4,81,51],[4,50,22,4,51,23],[3,36,12,8,37,13],[2,116,92,2,117,93],[6,58,36,2,59,37],[4,46,20,6,47,21],[7,42,14,4,43,15],[4,133,107],[8,59,37,1,60,38],[8,44,20,4,45,21],[12,33,11,4,34,12],[3,145,115,1,146,116],[4,64,40,5,65,41],[11,36,16,5,37,17],[11,36,12,5,37,13],[5,109,87,1,110,88],[5,65,41,5,66,42],[5,54,24,7,55,25],[11,36,12,7,37,13],[5,122,98,1,123,99],[7,73,45,3,74,46],[15,43,19,2,44,20],[3,45,15,13,46,16],[1,135,107,5,136,108],[10,74,46,1,75,47],[1,50,22,15,51,23],[2,42,14,17,43,15],[5,150,120,1,151,121],[9,69,43,4,70,44],[17,50,22,1,51,23],[2,42,14,19,43,15],[3,141,113,4,142,114],[3,70,44,11,71,45],[17,47,21,4,48,22],[9,39,13,16,40,14],[3,135,107,5,136,108],[3,67,41,13,68,42],[15,54,24,5,55,25],[15,43,15,10,44,16],[4,144,116,4,145,117],[17,68,42],[17,50,22,6,51,23],[19,46,16,6,47,17],[2,139,111,7,140,112],[17,74,46],[7,54,24,16,55,25],[34,37,13],[4,151,121,5,152,122],[4,75,47,14,76,48],[11,54,24,14,55,25],[16,45,15,14,46,16],[6,147,117,4,148,118],[6,73,45,14,74,46],[11,54,24,16,55,25],[30,46,16,2,47,17],[8,132,106,4,133,107],[8,75,47,13,76,48],[7,54,24,22,55,25],[22,45,15,13,46,16],[10,142,114,2,143,115],[19,74,46,4,75,47],[28,50,22,6,51,23],[33,46,16,4,47,17],[8,152,122,4,153,123],[22,73,45,3,74,46],[8,53,23,26,54,24],[12,45,15,28,46,16],[3,147,117,10,148,118],[3,73,45,23,74,46],[4,54,24,31,55,25],[11,45,15,31,46,16],[7,146,116,7,147,117],[21,73,45,7,74,46],[1,53,23,37,54,24],[19,45,15,26,46,16],[5,145,115,10,146,116],[19,75,47,10,76,48],[15,54,24,25,55,25],[23,45,15,25,46,16],[13,145,115,3,146,116],[2,74,46,29,75,47],[42,54,24,1,55,25],[23,45,15,28,46,16],[17,145,115],[10,74,46,23,75,47],[10,54,24,35,55,25],[19,45,15,35,46,16],[17,145,115,1,146,116],[14,74,46,21,75,47],[29,54,24,19,55,25],[11,45,15,46,46,16],[13,145,115,6,146,116],[14,74,46,23,75,47],[44,54,24,7,55,25],[59,46,16,1,47,17],[12,151,121,7,152,122],[12,75,47,26,76,48],[39,54,24,14,55,25],[22,45,15,41,46,16],[6,151,121,14,152,122],[6,75,47,34,76,48],[46,54,24,10,55,25],[2,45,15,64,46,16],[17,152,122,4,153,123],[29,74,46,14,75,47],[49,54,24,10,55,25],[24,45,15,46,46,16],[4,152,122,18,153,123],[13,74,46,32,75,47],[48,54,24,14,55,25],[42,45,15,32,46,16],[20,147,117,4,148,118],[40,75,47,7,76,48],[43,54,24,22,55,25],[10,45,15,67,46,16],[19,148,118,6,149,119],[18,75,47,31,76,48],[34,54,24,34,55,25],[20,45,15,61,46,16]],r=function(t,r){var e={};return e.totalCount=t,e.dataCount=r,e},e={};return e.getRSBlocks=function(e,n){var o=function(r,e){switch(e){case g.L:return t[4*(r-1)+0];case g.M:return t[4*(r-1)+1];case g.Q:return t[4*(r-1)+2];case g.H:return t[4*(r-1)+3];default:return}}(e,n);if(void 0===o)throw"bad rs block @ typeNumber:"+e+"/errorCorrectionLevel:"+n;for(var i=o.length/3,a=[],u=0;u<i;u+=1)for(var f=o[3*u+0],c=o[3*u+1],l=o[3*u+2],h=0;h<f;h+=1)a.push(r(c,l));return a},e}(),b=function(){var t=[],r=0,e={getBuffer:function(){return t},getAt:function(r){var e=Math.floor(r/8);return 1==(t[e]>>>7-r%8&1)},put:function(t,r){for(var n=0;n<r;n+=1)e.putBit(1==(t>>>r-n-1&1))},getLengthInBits:function(){return r},putBit:function(e){var n=Math.floor(r/8);t.length<=n&&t.push(0),e&&(t[n]|=128>>>r%8),r+=1}};return e},M=function(t){var r=a,e=t,n={getMode:function(){return r},getLength:function(t){return e.length},write:function(t){for(var r=e,n=0;n+2<r.length;)t.put(o(r.substring(n,n+3)),10),n+=3;n<r.length&&(r.length-n==1?t.put(o(r.substring(n,n+1)),4):r.length-n==2&&t.put(o(r.substring(n,n+2)),7))}},o=function(t){for(var r=0,e=0;e<t.length;e+=1)r=10*r+i(t.charAt(e));return r},i=function(t){if("0"<=t&&t<="9")return t.charCodeAt(0)-"0".charCodeAt(0);throw"illegal char :"+t};return n},x=function(t){var r=u,e=t,n={getMode:function(){return r},getLength:function(t){return e.length},write:function(t){for(var r=e,n=0;n+1<r.length;)t.put(45*o(r.charAt(n))+o(r.charAt(n+1)),11),n+=2;n<r.length&&t.put(o(r.charAt(n)),6)}},o=function(t){if("0"<=t&&t<="9")return t.charCodeAt(0)-"0".charCodeAt(0);if("A"<=t&&t<="Z")return t.charCodeAt(0)-"A".charCodeAt(0)+10;switch(t){case" ":return 36;case"$":return 37;case"%":return 38;case"*":return 39;case"+":return 40;case"-":return 41;case".":return 42;case"/":return 43;case":":return 44;default:throw"illegal char :"+t}};return n},m=function(r){var e=f,n=t.stringToBytes(r),o={getMode:function(){return e},getLength:function(t){return n.length},write:function(t){for(var r=0;r<n.length;r+=1)t.put(n[r],8)}};return o},L=function(r){var e=c,n=t.stringToBytesFuncs.SJIS;if(!n)throw"sjis not supported.";!function(){var t=n("友");if(2!=t.length||38726!=(t[0]<<8|t[1]))throw"sjis not supported."}();var o=n(r),i={getMode:function(){return e},getLength:function(t){return~~(o.length/2)},write:function(t){for(var r=o,e=0;e+1<r.length;){var n=(255&r[e])<<8|255&r[e+1];if(33088<=n&&n<=40956)n-=33088;else{if(!(57408<=n&&n<=60351))throw"illegal char at "+(e+1)+"/"+n;n-=49472}n=192*(n>>>8&255)+(255&n),t.put(n,13),e+=2}if(e<r.length)throw"illegal char at "+(e+1)}};return i},D=function(){var t=[],r={writeByte:function(r){t.push(255&r)},writeShort:function(t){r.writeByte(t),r.writeByte(t>>>8)},writeBytes:function(t,e,n){e=e||0,n=n||t.length;for(var o=0;o<n;o+=1)r.writeByte(t[o+e])},writeString:function(t){for(var e=0;e<t.length;e+=1)r.writeByte(t.charCodeAt(e))},toByteArray:function(){return t},toString:function(){var r="";r+="[";for(var e=0;e<t.length;e+=1)e>0&&(r+=","),r+=t[e];return r+="]"}};return r},S=function(t){var r=t,e=0,n=0,o=0,i={read:function(){for(;o<8;){if(e>=r.length){if(0==o)return-1;throw"unexpected end of file./"+o}var t=r.charAt(e);if(e+=1,"="==t)return o=0,-1;t.match(/^\s$/)||(n=n<<6|a(t.charCodeAt(0)),o+=6)}var i=n>>>o-8&255;return o-=8,i}},a=function(t){if(65<=t&&t<=90)return t-65;if(97<=t&&t<=122)return t-97+26;if(48<=t&&t<=57)return t-48+52;if(43==t)return 62;if(47==t)return 63;throw"c:"+t};return i},I=function(t,r,e){for(var n=function(t,r){var e=t,n=r,o=new Array(t*r),i={setPixel:function(t,r,n){o[r*e+t]=n},write:function(t){t.writeString("GIF87a"),t.writeShort(e),t.writeShort(n),t.writeByte(128),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(255),t.writeByte(255),t.writeByte(255),t.writeString(","),t.writeShort(0),t.writeShort(0),t.writeShort(e),t.writeShort(n),t.writeByte(0);var r=a(2);t.writeByte(2);for(var o=0;r.length-o>255;)t.writeByte(255),t.writeBytes(r,o,255),o+=255;t.writeByte(r.length-o),t.writeBytes(r,o,r.length-o),t.writeByte(0),t.writeString(";")}},a=function(t){for(var r=1<<t,e=1+(1<<t),n=t+1,i=u(),a=0;a<r;a+=1)i.add(String.fromCharCode(a));i.add(String.fromCharCode(r)),i.add(String.fromCharCode(e));var f,c,g,l=D(),h=(f=l,c=0,g=0,{write:function(t,r){if(t>>>r!=0)throw"length over";for(;c+r>=8;)f.writeByte(255&(t<<c|g)),r-=8-c,t>>>=8-c,g=0,c=0;g|=t<<c,c+=r},flush:function(){c>0&&f.writeByte(g)}});h.write(r,n);var s=0,v=String.fromCharCode(o[s]);for(s+=1;s<o.length;){var d=String.fromCharCode(o[s]);s+=1,i.contains(v+d)?v+=d:(h.write(i.indexOf(v),n),i.size()<4095&&(i.size()==1<<n&&(n+=1),i.add(v+d)),v=d)}return h.write(i.indexOf(v),n),h.write(e,n),h.flush(),l.toByteArray()},u=function(){var t={},r=0,e={add:function(n){if(e.contains(n))throw"dup key:"+n;t[n]=r,r+=1},size:function(){return r},indexOf:function(r){return t[r]},contains:function(r){return void 0!==t[r]}};return e};return i}(t,r),o=0;o<r;o+=1)for(var i=0;i<t;i+=1)n.setPixel(i,o,e(i,o));var a=D();n.write(a);for(var u=function(){var t=0,r=0,e=0,n="",o={},i=function(t){n+=String.fromCharCode(a(63&t))},a=function(t){if(t<0);else{if(t<26)return 65+t;if(t<52)return t-26+97;if(t<62)return t-52+48;if(62==t)return 43;if(63==t)return 47}throw"n:"+t};return o.writeByte=function(n){for(t=t<<8|255&n,r+=8,e+=1;r>=6;)i(t>>>r-6),r-=6},o.flush=function(){if(r>0&&(i(t<<6-r),t=0,r=0),e%3!=0)for(var o=3-e%3,a=0;a<o;a+=1)n+="="},o.toString=function(){return n},o}(),f=a.toByteArray(),c=0;c<f.length;c+=1)u.writeByte(f[c]);return u.flush(),"data:image/gif;base64,"+u};return t}();qrcode.stringToBytesFuncs["UTF-8"]=function(t){return function(t){for(var r=[],e=0;e<t.length;e++){var n=t.charCodeAt(e);n<128?r.push(n):n<2048?r.push(192|n>>6,128|63&n):n<55296||n>=57344?r.push(224|n>>12,128|n>>6&63,128|63&n):(e++,n=65536+((1023&n)<<10|1023&t.charCodeAt(e)),r.push(240|n>>18,128|n>>12&63,128|n>>6&63,128|63&n))}return r}(t)},function(t){"function"==typeof define&&define.amd?define([],t):"object"==typeof exports&&(module.exports=t())}(function(){return qrcode});
+</script>
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.4';
+const CONFIGURATOR_VERSION = '2.5';
+// Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
+// Leave empty to keep the feature fully disabled and hidden.
+const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.5', date:'Jul 2 2026', items:[
+    'QR codes now generated locally in your browser — manifest URLs (with your UUID and password) are no longer sent to an external QR service',
+    'Test buttons on API keys — verify TorBox / Real-Debrid / AllDebrid / Premiumize / Debrid-Link keys before generating',
+    'Light theme completed — result boxes, highlights, formatter cards, and warnings now readable in light mode',
+    'Device step ? buttons — plain-English explanations of DV-Only Kill, AV1, VC-1, eARC and other jargon',
+    'Resume banner shows what changed since your last downloaded template',
+    'Import URL result notes that paste.rs links can expire — keep the JSON as backup',
+  ]},
   { v:'2.4', date:'Jul 2 2026', items:[
     'Readability pass — larger text on every button (nav, download, install, pills, chips, links)',
     'Important info now highlighted: credential warnings in amber, key steps and privacy notes bolded',
@@ -701,7 +762,7 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', telemetryOk: false };
 
 const FORMATTERS = [
   {
@@ -768,15 +829,15 @@ const DEFS = [
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
     opts:[
-      { v:'generic',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="13" width="38" height="22" rx="3" stroke="#a78bfa" stroke-width="2"/><rect x="7" y="16" width="30" height="15" fill="#1a0a3a"/><line x1="15" y1="35" x2="12" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="29" y1="35" x2="32" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="10" y1="42" x2="34" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="16" y1="13" x2="12" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/><line x1="28" y1="13" x2="32" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/></svg>', name:'Standard TV',          desc:'Broadest compatibility · no restrictions' },
-      { v:'samsung',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="9" width="40" height="24" rx="2" stroke="#3d72e8" stroke-width="2"/><rect x="4" y="11" width="36" height="20" fill="#040e22"/><rect x="19" y="33" width="6" height="3" fill="#3d72e8"/><path d="M12 41 Q22 37 32 41" stroke="#3d72e8" stroke-width="2" stroke-linecap="round" fill="none"/><line x1="8" y1="21" x2="36" y2="21" stroke="#3d72e8" stroke-width="0.5" opacity="0.5"/></svg>', name:'Samsung TV',           desc:'DV-Only Kill · AV1/VC-1 excluded · HDR10+' },
-      { v:'appletv-old',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="14" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#888" stroke-width="1.5"/><path d="M19 22.5 C19 19.5 21 18 22.5 18 C23 18 23.5 18.3 24 18.5 24.5 18.3 25 18 25.5 18 C27 18 29 19.5 29 22.5 C29 25.5 27.5 27 25.5 27 C25 27 24.5 26.7 24 26.5 23.5 26.7 23 27 22.5 27 C21 27 19 25.5 19 22.5Z" fill="#888"/><line x1="23.5" y1="16" x2="25" y2="14" stroke="#888" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#f59e0b"/><text x="22" y="12" text-anchor="middle" fill="#666" font-size="6" font-family="system-ui,sans-serif">GEN 1 · 2</text></svg>', name:'Apple TV 4K Gen 1–2', desc:'DV · TrueHD · Atmos · no AV1 · 7.1' },
-      { v:'appletv-new',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="13" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#a0a0a8" stroke-width="1.5"/><path d="M19 21.5 C19 18.5 21 17 22.5 17 C23 17 23.5 17.3 24 17.5 24.5 17.3 25 17 25.5 17 C27 17 29 18.5 29 21.5 C29 24.5 27.5 26 25.5 26 C25 26 24.5 25.7 24 25.5 23.5 25.7 23 26 22.5 26 C21 26 19 24.5 19 21.5Z" fill="#a0a0a8"/><line x1="23.5" y1="15" x2="25" y2="13" stroke="#a0a0a8" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#fff" opacity="0.8"/><text x="22" y="11" text-anchor="middle" fill="#7ab4ff" font-size="6" font-family="system-ui,sans-serif">A15 · AV1</text></svg>', name:'Apple TV 4K Gen 3',   desc:'DV · TrueHD · Atmos · AV1 · 7.1' },
-      { v:'lgtv',            icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="7" width="40" height="27" rx="2" stroke="#c00000" stroke-width="2"/><rect x="4" y="9" width="36" height="23" fill="#080000"/><circle cx="12" cy="21" r="3.5" fill="#cc0000" opacity="0.7"/><circle cx="22" cy="21" r="3.5" fill="#00bb44" opacity="0.7"/><circle cx="32" cy="21" r="3.5" fill="#0044cc" opacity="0.7"/><rect x="17" y="34" width="10" height="4" rx="1" fill="#c00000"/><line x1="12" y1="42" x2="32" y2="42" stroke="#c00000" stroke-width="2" stroke-linecap="round"/></svg>', name:'LG TV webOS',          desc:'DV · AV1 · eARC · TrueHD · 7.1' },
-      { v:'windows',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="6" width="38" height="26" rx="3" stroke="#0078d4" stroke-width="2"/><rect x="7" y="9" width="30" height="20" fill="#001428"/><rect x="10" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="10" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="18" y="32" width="8" height="4" rx="1" fill="#0078d4"/><line x1="12" y1="40" x2="32" y2="40" stroke="#0078d4" stroke-width="2" stroke-linecap="round"/></svg>', name:'Windows PC',           desc:'Full lossless · AV1 · HDR-first · 7.1' },
-      { v:'firestick-hd',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff6b00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff6b00"/><path d="M16 20 C16 16 14 13 16 10 C16 10 17.5 12 19 11 C19 8 21.5 5 23 3 C23 3 23 7.5 26 10 C27.5 11 27 13.5 25 15.5 C25 15.5 25 13 23 14 C23 17 21 20 16 20Z" fill="#ff6b00"/><text x="19" y="29" text-anchor="middle" fill="#ff6b00" font-size="7.5" font-weight="800" font-family="system-ui,sans-serif">HD</text></svg>', name:'Fire Stick HD',        desc:'DV-Only Kill · no AV1/lossless · HDR10/HLG' },
-      { v:'firestick-4kmax', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff8c00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff8c00"/><path d="M15 20 C15 15 13 11 16 8 C16 8 18 11 20 10 C20 6 23 2 24 1 C24 1 24 6 28 9 C30 11 29.5 14 27 17 C27 17 27 14 24 15 C24 18 22 20 15 20Z" fill="#ff8c00"/><text x="19" y="29" text-anchor="middle" fill="#ff8c00" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">4K MAX</text></svg>', name:'Fire Stick 4K Max',   desc:'DV · AV1 · VC-1 excluded · no lossless' },
-      { v:'shield', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="4" y="21" width="29" height="11" rx="3" fill="#0d1a0a" stroke="#76b900" stroke-width="1.5"/><rect x="34" y="23" width="7" height="7" rx="2" fill="#76b900"/><path d="M22 6 L30 10 L30 19 Q30 22 22 25 Q14 22 14 19 L14 10 Z" fill="none" stroke="#76b900" stroke-width="1.5" stroke-linejoin="round"/><path d="M22 8 L28 11.5 L28 19 Q28 21 22 23.5" stroke="#76b900" stroke-width="0.5" stroke-linejoin="round" fill="#76b900" opacity="0.2"/></svg>', name:'Streaming Box', desc:'No AV1 · no HLG · Nvidia Shield / Android TV' },
+      { v:'generic',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="13" width="38" height="22" rx="3" stroke="#a78bfa" stroke-width="2"/><rect x="7" y="16" width="30" height="15" fill="#1a0a3a"/><line x1="15" y1="35" x2="12" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="29" y1="35" x2="32" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="10" y1="42" x2="34" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="16" y1="13" x2="12" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/><line x1="28" y1="13" x2="32" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/></svg>', name:'Standard TV',          desc:'Broadest compatibility · no restrictions', help:'No format restrictions — every stream type is allowed. Pick this if you are unsure of your TV specs; everything will play, though rare formats may need transcoding.' },
+      { v:'samsung',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="9" width="40" height="24" rx="2" stroke="#3d72e8" stroke-width="2"/><rect x="4" y="11" width="36" height="20" fill="#040e22"/><rect x="19" y="33" width="6" height="3" fill="#3d72e8"/><path d="M12 41 Q22 37 32 41" stroke="#3d72e8" stroke-width="2" stroke-linecap="round" fill="none"/><line x1="8" y1="21" x2="36" y2="21" stroke="#3d72e8" stroke-width="0.5" opacity="0.5"/></svg>', name:'Samsung TV',           desc:'DV-Only Kill · AV1/VC-1 excluded · HDR10+', help:'<b>DV-Only Kill</b>: Samsung TVs have no Dolby Vision support — DV streams without an HDR10 fallback show a purple/green tint, so they are removed. <b>AV1 / VC-1 excluded</b>: 2018–2022 Samsung models lack these video decoders. <b>HDR10+</b> is Samsung&#39;s own HDR format and is prioritised.' },
+      { v:'appletv-old',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="14" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#888" stroke-width="1.5"/><path d="M19 22.5 C19 19.5 21 18 22.5 18 C23 18 23.5 18.3 24 18.5 24.5 18.3 25 18 25.5 18 C27 18 29 19.5 29 22.5 C29 25.5 27.5 27 25.5 27 C25 27 24.5 26.7 24 26.5 23.5 26.7 23 27 22.5 27 C21 27 19 25.5 19 22.5Z" fill="#888"/><line x1="23.5" y1="16" x2="25" y2="14" stroke="#888" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#f59e0b"/><text x="22" y="12" text-anchor="middle" fill="#666" font-size="6" font-family="system-ui,sans-serif">GEN 1 · 2</text></svg>', name:'Apple TV 4K Gen 1–2', desc:'DV · TrueHD · Atmos · no AV1 · 7.1', help:'<b>DV</b>: Dolby Vision fully supported. <b>TrueHD / Atmos</b>: lossless audio passes through. <b>No AV1</b>: Gen 1–2 have no AV1 hardware decoder, so those streams are excluded. <b>7.1</b>: full surround channels ranked first.' },
+      { v:'appletv-new',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="13" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#a0a0a8" stroke-width="1.5"/><path d="M19 21.5 C19 18.5 21 17 22.5 17 C23 17 23.5 17.3 24 17.5 24.5 17.3 25 17 25.5 17 C27 17 29 18.5 29 21.5 C29 24.5 27.5 26 25.5 26 C25 26 24.5 25.7 24 25.5 23.5 25.7 23 26 22.5 26 C21 26 19 24.5 19 21.5Z" fill="#a0a0a8"/><line x1="23.5" y1="15" x2="25" y2="13" stroke="#a0a0a8" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#fff" opacity="0.8"/><text x="22" y="11" text-anchor="middle" fill="#7ab4ff" font-size="6" font-family="system-ui,sans-serif">A15 · AV1</text></svg>', name:'Apple TV 4K Gen 3',   desc:'DV · TrueHD · Atmos · AV1 · 7.1', help:'Same profile as Gen 1–2 plus <b>AV1</b>: the A15 chip decodes AV1 in hardware, so those smaller, more efficient streams are allowed and ranked.' },
+      { v:'lgtv',            icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="7" width="40" height="27" rx="2" stroke="#c00000" stroke-width="2"/><rect x="4" y="9" width="36" height="23" fill="#080000"/><circle cx="12" cy="21" r="3.5" fill="#cc0000" opacity="0.7"/><circle cx="22" cy="21" r="3.5" fill="#00bb44" opacity="0.7"/><circle cx="32" cy="21" r="3.5" fill="#0044cc" opacity="0.7"/><rect x="17" y="34" width="10" height="4" rx="1" fill="#c00000"/><line x1="12" y1="42" x2="32" y2="42" stroke="#c00000" stroke-width="2" stroke-linecap="round"/></svg>', name:'LG TV webOS',          desc:'DV · AV1 · eARC · TrueHD · 7.1', help:'<b>eARC</b>: passes lossless audio (TrueHD, DTS-HD MA) to a soundbar or receiver over HDMI. LG OLED/QNED supports Dolby Vision and AV1 — nothing is excluded on this profile.' },
+      { v:'windows',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="6" width="38" height="26" rx="3" stroke="#0078d4" stroke-width="2"/><rect x="7" y="9" width="30" height="20" fill="#001428"/><rect x="10" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="10" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="18" y="32" width="8" height="4" rx="1" fill="#0078d4"/><line x1="12" y1="40" x2="32" y2="40" stroke="#0078d4" stroke-width="2" stroke-linecap="round"/></svg>', name:'Windows PC',           desc:'Full lossless · AV1 · HDR-first · 7.1', help:'PCs can decode anything in software if needed, so nothing is excluded. <b>HDR-first</b>: HDR streams ranked above SDR. Full lossless audio ranked for external DACs and receivers.' },
+      { v:'firestick-hd',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff6b00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff6b00"/><path d="M16 20 C16 16 14 13 16 10 C16 10 17.5 12 19 11 C19 8 21.5 5 23 3 C23 3 23 7.5 26 10 C27.5 11 27 13.5 25 15.5 C25 15.5 25 13 23 14 C23 17 21 20 16 20Z" fill="#ff6b00"/><text x="19" y="29" text-anchor="middle" fill="#ff6b00" font-size="7.5" font-weight="800" font-family="system-ui,sans-serif">HD</text></svg>', name:'Fire Stick HD',        desc:'DV-Only Kill · no AV1/lossless · HDR10/HLG', help:'The HD stick has no Dolby Vision, no AV1 decoder, and no lossless audio passthrough — those streams are removed or down-ranked so everything actually plays. <b>HDR10 / HLG</b> still work.' },
+      { v:'firestick-4kmax', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff8c00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff8c00"/><path d="M15 20 C15 15 13 11 16 8 C16 8 18 11 20 10 C20 6 23 2 24 1 C24 1 24 6 28 9 C30 11 29.5 14 27 17 C27 17 27 14 24 15 C24 18 22 20 15 20Z" fill="#ff8c00"/><text x="19" y="29" text-anchor="middle" fill="#ff8c00" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">4K MAX</text></svg>', name:'Fire Stick 4K Max',   desc:'DV · AV1 · VC-1 excluded · no lossless', help:'<b>DV + AV1</b> are supported on the 4K Max. <b>VC-1 excluded</b>: an old Blu-ray codec the stick struggles with. <b>No lossless</b>: Fire OS does not bitstream TrueHD or DTS-HD MA, so DD+/Atmos is the ceiling.' },
+      { v:'shield', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="4" y="21" width="29" height="11" rx="3" fill="#0d1a0a" stroke="#76b900" stroke-width="1.5"/><rect x="34" y="23" width="7" height="7" rx="2" fill="#76b900"/><path d="M22 6 L30 10 L30 19 Q30 22 22 25 Q14 22 14 19 L14 10 Z" fill="none" stroke="#76b900" stroke-width="1.5" stroke-linejoin="round"/><path d="M22 8 L28 11.5 L28 19 Q28 21 22 23.5" stroke="#76b900" stroke-width="0.5" stroke-linejoin="round" fill="#76b900" opacity="0.2"/></svg>', name:'Streaming Box', desc:'No AV1 · no HLG · Nvidia Shield / Android TV', help:'<b>No AV1</b>: the Nvidia Shield (2019) has no AV1 decoder. <b>No HLG</b>: a broadcast HDR format with known Shield playback issues. Everything else, including Dolby Vision and lossless audio, works.' },
     ]
   },
   { id:'resolution', title:'Resolution', desc:'Primary resolution target for this template.', key:'resolution', cols:'c1', layout:'svc-list', noHero:true,
@@ -835,6 +896,27 @@ function sanitizeSharedConfig(d) {
   if (Array.isArray(d.langs)) { const l = d.langs.filter(v => LANG_OPTS.some(o => o.v === v)); if (l.length) out.langs = l; }
   if (typeof d.name === 'string') out.name = d.name.replace(/[<>"'&`]/g, '').slice(0, 60);
   return out;
+}
+
+function saveLastGen() {
+  try { const snap = {}; SHARE_KEYS.forEach(k => { snap[k] = S[k]; }); localStorage.setItem('coreBuildLastGen', JSON.stringify(snap)); } catch(e) {}
+}
+function lastGenDiff() {
+  try {
+    const last = JSON.parse(localStorage.getItem('coreBuildLastGen') || 'null');
+    if (!last) return [];
+    const NICE = { sizeLimit: v => v === 'unlimited' ? 'Unlimited' : v + 'GB', cacheMode: v => ({ mixed:'Mixed', cached:'Cached Only', uncached:'Uncached' })[v] || v };
+    const KEYS = [['device','Device'],['resolution','Resolution'],['audio','Audio'],['content','Content'],['formatter','Formatter'],['sizeLimit','Size limit'],['cacheMode','Cache']];
+    const out = [];
+    KEYS.forEach(([k, lbl]) => {
+      const a = last[k], b = S[k];
+      if (a == null || b == null || a === b) return;
+      const fmt = v => NICE[k] ? NICE[k](v) : (label(k, v) || v);
+      out.push(lbl + ': ' + fmt(a) + ' → ' + fmt(b));
+    });
+    if (Array.isArray(last.multiServices) && JSON.stringify([...last.multiServices].sort()) !== JSON.stringify([...(S.multiServices||[])].sort())) out.push('Services changed');
+    return out;
+  } catch(e) { return []; }
 }
 
 function loadState() {
@@ -903,19 +985,19 @@ function renderOpts(def) {
   if (def.layout === 'formatter-picker') return '<div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.65)':'rgba(255,255,255,.13)'};border-radius:12px;background:${on?'rgba(0,212,255,.1)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;overflow:hidden;${on?'box-shadow:0 0 0 1px rgba(0,212,255,.22),0 4px 22px rgba(0,180,220,.2);':''}">
+      return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}">
         <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
           <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0;box-shadow:0 0 8px ${f.bc}88"></div>
           <div style="flex:1;min-width:0">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
-              <span class="fmt-lbl" style="font-weight:700;font-size:.9rem;color:${on?'#00d4ff':'#e6edf3'}">${f.label}</span>
+              <span class="fmt-lbl" style="font-weight:700;font-size:.9rem">${f.label}</span>
               <span style="font-size:.62rem;font-weight:700;padding:2px 7px;border-radius:5px;background:${f.bc}22;color:${f.bc}">${f.badge}</span>
             </div>
             <div style="color:#6b7280;font-size:.72rem">${f.desc}</div>
           </div>
-          ${on ? '<span style="color:#00d4ff;font-size:.9rem;flex-shrink:0">✓</span>' : '<span style="color:#374151;font-size:.9rem;flex-shrink:0">›</span>'}
+          <span class="fmt-arr"></span>
         </div>
-        <div class="fmt-preview-wrap" style="padding:0 13px 11px;${on?'':'display:none'}">${fmtPreviewHtml(f.id)}</div>
+        <div class="fmt-preview-wrap">${fmtPreviewHtml(f.id)}</div>
       </div>`;
     }).join('') +
   '</div>';
@@ -926,8 +1008,9 @@ function renderOpts(def) {
       const rows = def.opts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
         <div class="opt-icon">${o.icon}</div>
         <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc.replace(/<[^>]*>/g,'')}</div></div>
+        ${o.help ? `<button type="button" class="help-btn" data-action="toggle-device-help" data-v="${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>` : ''}
         <span class="svc-list-arr">›</span>
-      </label></div>`).join('');
+      </label>${o.help ? `<div class="device-help" id="help_${o.v}">${o.help}</div>` : ''}</div>`).join('');
       if (def.id === 'resolution') {
         const AUDIO_OPTS = [
           { v:'lossless', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#10b981" stroke-width="1.5" stroke-linejoin="round" fill="#0a1f16"/><path d="M26 14 Q32 22 26 30" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M30 9 Q39 22 30 35" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M34 5 Q44 22 34 39" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Full Lossless', desc:'TrueHD · Atmos · DTS-HD MA · FLAC · eARC required' },
@@ -1139,17 +1222,17 @@ function renderAdvancedPanel() {
 
   const fmtCards = FORMATTERS.map(f => {
     const on = S.formatter === f.id;
-    return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+    return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}">
       <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
         <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0"></div>
         <div style="flex:1;min-width:0">
-          <span class="fmt-lbl" style="font-weight:700;font-size:.9rem;color:${on?'#00d4ff':'#e6edf3'}">${f.label}</span>
+          <span class="fmt-lbl" style="font-weight:700;font-size:.9rem">${f.label}</span>
           <span style="margin-left:6px;background:rgba(255,255,255,.06);border-radius:4px;padding:2px 6px;font-size:.65rem;color:#6b7280">${f.badge}</span>
           <div style="color:#6b7280;font-size:.72rem;margin-top:2px">${f.desc}</div>
         </div>
-        ${on ? '<span style="color:#00d4ff;font-size:.85rem;flex-shrink:0">✓</span>' : '<span style="color:#374151;font-size:.85rem;flex-shrink:0">›</span>'}
+        <span class="fmt-arr"></span>
       </div>
-      <div class="fmt-preview-wrap" style="padding:0 13px 11px;${on?'':'display:none'}">${fmtPreviewHtml(f.id)}</div>
+      <div class="fmt-preview-wrap">${fmtPreviewHtml(f.id)}</div>
     </div>`;
   }).join('');
 
@@ -1298,6 +1381,7 @@ function splashHtml() {
       <div style="flex:1;min-width:0">
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
         <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
+        ${(() => { const d = lastGenDiff(); return d.length ? `<div style="font-size:.66rem;color:#f59e0b;margin-top:3px;line-height:1.4">Changed since last download — ${d.slice(0,2).join(' · ')}${d.length > 2 ? ` +${d.length - 2} more` : ''}</div>` : ''; })()}
       </div>
       <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
       <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
@@ -1426,6 +1510,7 @@ function render() {
         </div>
         ${insightsHtml()}
         ${sizeLimitHtml()}
+        ${telemetryHtml()}
         <details id="fmtPickerDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
             <span style="display:flex;align-items:center;gap:8px"><span>🎨</span> Stream Formatter <span style="font-weight:600;color:#374151;text-transform:none;letter-spacing:0;font-size:.72rem">— ${label('formatter', S.formatter)}</span></span><span style="font-size:.7rem;color:#374151">›</span>
@@ -1443,14 +1528,14 @@ function render() {
           <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
-              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
+              <div class="wn-title" style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
+              <div class="wn-body" style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
-              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
+              <div class="wn-title" style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
+              <div class="wn-body" style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
@@ -1657,7 +1742,10 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
-            <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <span style="display:flex;align-items:center">
+              <button type="button" class="test-key-btn" data-action="test-cred" data-service="${inp.id}">Test</button>
+              <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            </span>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
@@ -1668,6 +1756,7 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <span class="cred-status" id="credStatus_${inp.id}"></span>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1883,6 +1972,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const inp = document.getElementById(e.target.closest('[data-target]').dataset.target);
       if (inp) inp.type = inp.type === 'password' ? 'text' : 'password';
     }
+    if (action === 'test-cred') {
+      const el2 = e.target.closest('[data-service]') || e.target;
+      testCred(el2.dataset.service, e.target.closest('button'));
+    }
+    if (action === 'toggle-device-help') {
+      e.preventDefault();
+      const v = (e.target.closest('[data-v]') || e.target).dataset.v;
+      const h = document.getElementById('help_' + v);
+      if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
+    }
     if (action === 'install-stremio') openInAIOStreams();
     if (action === 'copy-manifest') {
       const url = e.target.dataset.url || e.target.closest('[data-url]')?.dataset.url;
@@ -1947,16 +2046,7 @@ document.addEventListener('DOMContentLoaded', () => {
       S.formatter = (e.target.closest('[data-action="set-formatter"]') || e.target).dataset.val;
       saveState();
       document.querySelectorAll('[data-action="set-formatter"]').forEach(card => {
-        const on = card.dataset.val === S.formatter;
-        card.style.borderColor = on ? 'rgba(0,212,255,.4)' : 'rgba(255,255,255,.1)';
-        card.style.background  = on ? 'rgba(0,212,255,.07)' : 'rgba(8,12,18,.9)';
-        card.style.boxShadow   = on ? '0 0 0 3px rgba(0,212,255,.1)' : 'none';
-        const lbl = card.querySelector('.fmt-lbl');
-        if (lbl) lbl.style.color = on ? '#00d4ff' : '#e6edf3';
-        const pw = card.querySelector('.fmt-preview-wrap');
-        if (pw) pw.style.display = on ? '' : 'none';
-        const arr = card.querySelector('[style*="flex-shrink:0"]');
-        if (arr && (arr.textContent === '✓' || arr.textContent === '›')) arr.textContent = on ? '✓' : '›';
+        card.dataset.active = String(card.dataset.val === S.formatter);
       });
       // Update the receipt row and summary label in-place when on Review step
       const fmtLbl = label('formatter', S.formatter);
@@ -1988,6 +2078,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       saveState();
       syncNext();
+    }
+    if (e.target.dataset.action === 'toggle-telemetry') {
+      S.telemetryOk = e.target.checked;
+      saveState();
     }
     if (e.target.dataset.action === 'toggle-p2p') {
       S.p2pEnabled = e.target.checked;
@@ -2103,7 +2197,12 @@ function insights() {
 function insightsHtml() {
   const pts = insights();
   if (!pts.length) return '';
-  return '<div style="background:#060e15;border:1px solid #162030;border-radius:10px;padding:14px 16px;margin-bottom:16px"><div style="color:#7eeeff;font-size:.72rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:8px">Template Highlights</div><ul style="list-style:none;display:flex;flex-direction:column;gap:5px">' + pts.map(p => '<li style="color:#8b949e;font-size:.8rem;line-height:1.4;display:flex;gap:6px"><span style="color:#3fb950;flex-shrink:0">✓</span><span>' + p + '</span></li>').join('') + '</ul></div>';
+  return '<div class="insights-box"><div class="insights-hdr">Template Highlights</div><ul style="list-style:none;display:flex;flex-direction:column;gap:5px">' + pts.map(p => '<li><span style="color:#3fb950;flex-shrink:0">✓</span><span>' + p + '</span></li>').join('') + '</ul></div>';
+}
+
+function telemetryHtml() {
+  if (!USAGE_BEACON_URL) return '';
+  return `<label style="display:flex;align-items:center;gap:9px;margin-bottom:14px;cursor:pointer;font-size:.78rem;color:#8b949e"><input type="checkbox" data-action="toggle-telemetry" ${S.telemetryOk ? 'checked' : ''} style="accent-color:#00d4ff;flex-shrink:0">Share an anonymous usage ping on download (service + device only — never keys or names)</label>`;
 }
 
 function sizeLimitHtml() {
@@ -2114,10 +2213,10 @@ function formatterPickerHtml() {
   return '<div style="margin-bottom:16px"><div style="color:#8b949e;font-size:.75rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px">Stream Layout</div><div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'#00d4ff':'#30363d'};border-radius:10px;background:${on?'#00131c':'#0d1117'};cursor:pointer;overflow:hidden;transition:border-color .15s,background .15s">` +
+      return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border-radius:10px">` +
         `<img src="${f.img}" alt="${f.label} preview" style="width:100%;display:block;border-bottom:1px solid #1e2837" loading="lazy" onerror="this.style.display='none'">` +
         `<div style="padding:8px 12px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">` +
-        `<span class="fmt-lbl" style="font-weight:700;font-size:.85rem;color:${on?'#00d4ff':'#e6edf3'};min-width:52px">${f.label}</span>` +
+        `<span class="fmt-lbl" style="font-weight:700;font-size:.85rem;min-width:52px">${f.label}</span>` +
         `<span style="font-size:.7rem;font-weight:700;padding:2px 7px;border-radius:4px;background:${f.bc}22;color:${f.bc};flex-shrink:0">${f.badge}</span>` +
         `<span style="color:#6b7280;font-size:.77rem">${f.desc}</span>` +
         `</div></div>`;
@@ -2406,6 +2505,10 @@ function generate() {
   const json = JSON.stringify(build(), null, 2), blob = new Blob([json], {type:'application/json'}), url = URL.createObjectURL(blob), a = document.createElement('a');
   a.href = url; a.download = (S.name.trim()||defaultName()).toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') + '.json';
   document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(() => URL.revokeObjectURL(url), 100);
+  saveLastGen();
+  if (USAGE_BEACON_URL && S.telemetryOk && navigator.sendBeacon) {
+    try { navigator.sendBeacon(USAGE_BEACON_URL, JSON.stringify({ v: CONFIGURATOR_VERSION, service: S.service, device: S.device, resolution: S.resolution })); } catch(e) {}
+  }
   const dlBtn = document.querySelector('.btn-dl');
   if (dlBtn) {
     const orig = dlBtn.innerHTML;
@@ -2425,7 +2528,14 @@ function showManifestModal(manifestUrl, password, hostLabel) {
     { key:'wuplay', label:'WuPlay',      getUrl: u => u, action:'open', configUrl:'https://config.wuplay.app/#addons' },
     { key:'nuvio',  label:'Nuvio',       getUrl: u => u, action:'open', configUrl:'https://nuvio.tv/account?tab=addons' },
   ];
-  const qrSrc = u => `https://api.qrserver.com/v1/create-qr-code/?size=160x160&color=00d4ff&bgcolor=0d1117&qzone=2&data=${encodeURIComponent(u)}`;
+  const qrSrc = u => {
+    try {
+      const qr = qrcode(0, 'M'); qr.addData(u); qr.make();
+      let svg = qr.createSvgTag({ cellSize: 4, margin: 2 });
+      svg = svg.replace('fill="white"', 'fill="#0d1117"').replace(/fill="black"/g, 'fill="#00d4ff"');
+      return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+    } catch(e) { return ''; }
+  };
   const esc  = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
 
   // Extract password from AIOStreams URL format if not provided
@@ -2759,6 +2869,32 @@ function instanceChips(templateUrl) {
   return `<div class="inst-chips">${hosts.map(([n,u])=>`<a href="${u}${templateUrl?`?template=${encodeURIComponent(templateUrl)}`:''}" target="_blank" class="inst-chip ${templateUrl?'inst-chip-import':''}">${templateUrl?'▶ ':''}${n}</a>`).join('')}</div>`;
 }
 
+const CRED_TESTS = {
+  torbox:      k => fetchWithTimeout('https://api.torbox.app/v1/api/user/me?settings=false', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+  realdebrid:  k => fetchWithTimeout('https://api.real-debrid.com/rest/1.0/user', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+  alldebrid:   k => fetchWithTimeout('https://api.alldebrid.com/v4/user?agent=CoreBuilds&apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
+  premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
+  debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+};
+async function testCred(id, btn) {
+  const key = (S.creds[id] || '').trim();
+  const status = document.getElementById('credStatus_' + id);
+  if (!status) return;
+  if (!key) { status.innerHTML = '<span style="color:#f87171">Enter a key first</span>'; return; }
+  const tester = CRED_TESTS[id];
+  if (!tester) { status.innerHTML = '<span style="color:#8b949e">No online check available for this service — the key is saved as entered</span>'; return; }
+  if (btn) { btn.disabled = true; btn.textContent = '…'; }
+  try {
+    const ok = await tester(key);
+    status.innerHTML = ok
+      ? '<span style="color:#3fb950;font-weight:700">✓ Key is valid</span>'
+      : '<span style="color:#f87171;font-weight:700">✗ Key rejected by the service — check for typos</span>';
+  } catch(e) {
+    status.innerHTML = '<span style="color:#f59e0b">⚠ Could not verify — the browser blocked the check. The key is saved as entered.</span>';
+  }
+  if (btn) { btn.disabled = false; btn.textContent = 'Test'; }
+}
+
 async function fetchWithTimeout(url, options = {}, timeout = 6000) {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeout);
@@ -2798,6 +2934,7 @@ async function createImportUrl() {
   btn.disabled = false; btn.innerHTML = origHtml;
 
   if (url) {
+    saveLastGen();
     navigator.clipboard.writeText(url).catch(()=>{});
 
     // Build credential reminder block — keys were stripped from import URL
@@ -2813,17 +2950,17 @@ async function createImportUrl() {
           <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
         </div>`;
       }).join('');
-      credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+      credBlock = `<div class="cred-remind" style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
+        <div class="cr-hdr" style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
         <div style="font-size:.72rem;color:#8b949e;margin-bottom:7px">Your debrid credentials were <strong style="color:#fbbf24">stripped from the import URL</strong>. Once AIOStreams has loaded your template, go to <strong style="color:#e6edf3">Services</strong> and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div><div style="font-size:.72rem;color:#6b7280;margin-top:8px">⏳ This link is hosted on paste.rs and can expire — keep the downloaded JSON as a backup.</div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
-    result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
+    result.innerHTML = `<div class="import-success import-error" style="margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
     showToast('Paste service unreachable', true);
   }
 }
@@ -2872,7 +3009,7 @@ async function openInAIOStreams() {
       showManifestModal(`${winner.host}/stremio/${winner.uuid}/${encodeURIComponent(pwd)}/manifest.json`, pwd, HOST_LABELS[winner.host] || winner.host.replace('https://','').split('/')[0]);
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">All hosts timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success import-error" style="margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">All hosts timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
@@ -2886,7 +3023,7 @@ async function openInAIOStreams() {
 
   /* No UUID, not auto or custom — guide to get UUID */
   if (!uuid && !isCustom && !isAuto) {
-    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
+    result.innerHTML = `<div class="import-success import-info" style="margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
     return;
   }
 
@@ -2905,12 +3042,12 @@ async function openInAIOStreams() {
       } else throw new Error('API Error');
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">Host timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success import-error" style="margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">Host timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
 
-  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
+  result.innerHTML = `<div class="import-success import-info" style="margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
 }
 </script>
 </body>

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -526,6 +526,53 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] #cb-loader-sub{color:#8c959f}
 @keyframes cbLoad{0%{opacity:0}10%{opacity:1}75%{opacity:1}100%{opacity:0}}
 @keyframes cbIconPop{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
+
+/* v2.5 — theme-aware panels, test keys, device help */
+.import-error{border-color:#4b1a1a!important;background:#1a0606!important}
+.import-info{border-color:#374151!important;background:#111827!important}
+[data-theme="light"] .import-error{border-color:#f1aeb5!important;background:#fff5f5!important}
+[data-theme="light"] .import-error strong[style]{color:#cf222e!important}
+[data-theme="light"] .import-info{border-color:#d0d7de!important;background:#f6f8fa!important}
+[data-theme="light"] .import-info strong[style]{color:#1f2328!important}
+.insights-box{background:#060e15;border:1px solid #162030;border-radius:10px;padding:14px 16px;margin-bottom:16px}
+.insights-hdr{color:#7eeeff;font-size:.72rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:8px}
+.insights-box li{color:#8b949e;font-size:.85rem;line-height:1.45;display:flex;gap:6px}
+[data-theme="light"] .insights-box{background:#f0f9ff;border-color:#bae6fd}
+[data-theme="light"] .insights-hdr{color:#0369a1}
+[data-theme="light"] .insights-box li{color:#57606a}
+[data-theme="light"] .what-next strong[style]{color:#9a3412!important}
+[data-theme="light"] .wn-title{color:#1f2328!important}
+[data-theme="light"] .wn-body{color:#57606a!important}
+[data-theme="light"] .cred-remind strong[style]{color:#9a3412!important}
+[data-theme="light"] .cred-remind .cr-hdr{color:#b45309!important}
+[data-theme="light"] .import-success strong[style*="e6edf3"]{color:#1f2328!important}
+[data-theme="light"] .import-success strong[style*="fbbf24"]{color:#9a3412!important}
+.fmt-card{border:1.5px solid rgba(255,255,255,.13);border-radius:12px;background:rgba(8,12,18,.9);cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;overflow:hidden}
+.fmt-card[data-active="true"]{border-color:rgba(0,212,255,.65);background:rgba(0,212,255,.08);box-shadow:0 0 0 1px rgba(0,212,255,.22)}
+.fmt-card .fmt-lbl{color:#e6edf3}
+.fmt-card[data-active="true"] .fmt-lbl{color:#00d4ff!important}
+.fmt-card .fmt-preview-wrap{display:none;padding:0 13px 11px}
+.fmt-card[data-active="true"] .fmt-preview-wrap{display:block}
+.fmt-arr{color:#374151;font-size:.9rem;flex-shrink:0}
+.fmt-card[data-active="true"] .fmt-arr{color:#00d4ff}
+.fmt-arr::after{content:'›'}
+.fmt-card[data-active="true"] .fmt-arr::after{content:'✓'}
+[data-theme="light"] .fmt-card{background:#fff;border-color:#d0d7de}
+[data-theme="light"] .fmt-card[data-active="true"]{background:rgba(9,105,218,.06);border-color:#0969da;box-shadow:0 0 0 1px rgba(9,105,218,.2)}
+[data-theme="light"] .fmt-card .fmt-lbl{color:#1f2328}
+[data-theme="light"] .fmt-card[data-active="true"] .fmt-lbl{color:#0969da!important}
+.test-key-btn{font-size:.75rem;font-weight:700;color:#a5b4fc;background:rgba(99,102,241,.08);border:1px solid rgba(99,102,241,.3);border-radius:6px;padding:2px 10px;cursor:pointer;transition:all .15s;margin-right:10px}
+.test-key-btn:hover{background:rgba(99,102,241,.18)}
+.test-key-btn:disabled{opacity:.5;cursor:wait}
+.cred-status{font-size:.74rem;margin-top:4px;min-height:16px;display:block}
+[data-theme="light"] .test-key-btn{color:#4f46e5;background:rgba(79,70,229,.06);border-color:rgba(79,70,229,.3)}
+.help-btn{width:20px;height:20px;border-radius:50%;border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.05);color:#6b7280;font-size:.7rem;font-weight:800;cursor:pointer;flex-shrink:0;line-height:1;margin-right:8px;transition:all .15s;padding:0}
+.help-btn:hover{color:#00d4ff;border-color:rgba(0,212,255,.4)}
+.device-help{font-size:.8rem;color:#8b949e;line-height:1.55;padding:9px 14px 11px;border-top:1px dashed rgba(255,255,255,.09);display:none}
+.device-help b{color:#c9d1d9}
+[data-theme="light"] .device-help{color:#57606a;border-color:rgba(0,0,0,.12)}
+[data-theme="light"] .device-help b{color:#1f2328}
+[data-theme="light"] .help-btn{border-color:rgba(0,0,0,.15);background:rgba(0,0,0,.03);color:#8c959f}
 </style>
 <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('cbTheme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'))}catch(e){}</script>
 </head>
@@ -575,11 +622,25 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   </div>
 </div>
 <button id="themeToggle" onclick="toggleTheme()" title="Toggle light/dark theme" aria-label="Toggle theme"> Mode</button>
+<script>/*! qrcode-generator v2.0.4 | (c) Kazuhiko Arase | MIT | github.com/kazuhikoarase/qrcode-generator */
+var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],f={},c=function(t,r){o=function(t){for(var r=new Array(t),e=0;e<t;e+=1){r[e]=new Array(t);for(var n=0;n<t;n+=1)r[e][n]=null}return r}(i=4*e+17),l(0,0),l(i-7,0),l(0,i-7),s(),h(),d(t,r),e>=7&&v(t),null==a&&(a=p(e,n,u)),w(a,r)},l=function(t,r){for(var e=-1;e<=7;e+=1)if(!(t+e<=-1||i<=t+e))for(var n=-1;n<=7;n+=1)r+n<=-1||i<=r+n||(o[t+e][r+n]=0<=e&&e<=6&&(0==n||6==n)||0<=n&&n<=6&&(0==e||6==e)||2<=e&&e<=4&&2<=n&&n<=4)},h=function(){for(var t=8;t<i-8;t+=1)null==o[t][6]&&(o[t][6]=t%2==0);for(var r=8;r<i-8;r+=1)null==o[6][r]&&(o[6][r]=r%2==0)},s=function(){for(var t=B.getPatternPosition(e),r=0;r<t.length;r+=1)for(var n=0;n<t.length;n+=1){var i=t[r],a=t[n];if(null==o[i][a])for(var u=-2;u<=2;u+=1)for(var f=-2;f<=2;f+=1)o[i+u][a+f]=-2==u||2==u||-2==f||2==f||0==u&&0==f}},v=function(t){for(var r=B.getBCHTypeNumber(e),n=0;n<18;n+=1){var a=!t&&1==(r>>n&1);o[Math.floor(n/3)][n%3+i-8-3]=a}for(n=0;n<18;n+=1){a=!t&&1==(r>>n&1);o[n%3+i-8-3][Math.floor(n/3)]=a}},d=function(t,r){for(var e=n<<3|r,a=B.getBCHTypeInfo(e),u=0;u<15;u+=1){var f=!t&&1==(a>>u&1);u<6?o[u][8]=f:u<8?o[u+1][8]=f:o[i-15+u][8]=f}for(u=0;u<15;u+=1){f=!t&&1==(a>>u&1);u<8?o[8][i-u-1]=f:u<9?o[8][15-u-1+1]=f:o[8][15-u-1]=f}o[i-8][8]=!t},w=function(t,r){for(var e=-1,n=i-1,a=7,u=0,f=B.getMaskFunction(r),c=i-1;c>0;c-=2)for(6==c&&(c-=1);;){for(var g=0;g<2;g+=1)if(null==o[n][c-g]){var l=!1;u<t.length&&(l=1==(t[u]>>>a&1)),f(n,c-g)&&(l=!l),o[n][c-g]=l,-1==(a-=1)&&(u+=1,a=7)}if((n+=e)<0||i<=n){n-=e,e=-e;break}}},p=function(t,r,e){for(var n=A.getRSBlocks(t,r),o=b(),i=0;i<e.length;i+=1){var a=e[i];o.put(a.getMode(),4),o.put(a.getLength(),B.getLengthInBits(a.getMode(),t)),a.write(o)}var u=0;for(i=0;i<n.length;i+=1)u+=n[i].dataCount;if(o.getLengthInBits()>8*u)throw"code length overflow. ("+o.getLengthInBits()+">"+8*u+")";for(o.getLengthInBits()+4<=8*u&&o.put(0,4);o.getLengthInBits()%8!=0;)o.putBit(!1);for(;!(o.getLengthInBits()>=8*u||(o.put(236,8),o.getLengthInBits()>=8*u));)o.put(17,8);return function(t,r){for(var e=0,n=0,o=0,i=new Array(r.length),a=new Array(r.length),u=0;u<r.length;u+=1){var f=r[u].dataCount,c=r[u].totalCount-f;n=Math.max(n,f),o=Math.max(o,c),i[u]=new Array(f);for(var g=0;g<i[u].length;g+=1)i[u][g]=255&t.getBuffer()[g+e];e+=f;var l=B.getErrorCorrectPolynomial(c),h=k(i[u],l.getLength()-1).mod(l);for(a[u]=new Array(l.getLength()-1),g=0;g<a[u].length;g+=1){var s=g+h.getLength()-a[u].length;a[u][g]=s>=0?h.getAt(s):0}}var v=0;for(g=0;g<r.length;g+=1)v+=r[g].totalCount;var d=new Array(v),w=0;for(g=0;g<n;g+=1)for(u=0;u<r.length;u+=1)g<i[u].length&&(d[w]=i[u][g],w+=1);for(g=0;g<o;g+=1)for(u=0;u<r.length;u+=1)g<a[u].length&&(d[w]=a[u][g],w+=1);return d}(o,n)};f.addData=function(t,r){var e=null;switch(r=r||"Byte"){case"Numeric":e=M(t);break;case"Alphanumeric":e=x(t);break;case"Byte":e=m(t);break;case"Kanji":e=L(t);break;default:throw"mode:"+r}u.push(e),a=null},f.isDark=function(t,r){if(t<0||i<=t||r<0||i<=r)throw t+","+r;return o[t][r]},f.getModuleCount=function(){return i},f.make=function(){if(e<1){for(var t=1;t<40;t++){for(var r=A.getRSBlocks(t,n),o=b(),i=0;i<u.length;i++){var a=u[i];o.put(a.getMode(),4),o.put(a.getLength(),B.getLengthInBits(a.getMode(),t)),a.write(o)}var g=0;for(i=0;i<r.length;i++)g+=r[i].dataCount;if(o.getLengthInBits()<=8*g)break}e=t}c(!1,function(){for(var t=0,r=0,e=0;e<8;e+=1){c(!0,e);var n=B.getLostPoint(f);(0==e||t>n)&&(t=n,r=e)}return r}())},f.createTableTag=function(t,r){t=t||2;var e="";e+='<table style="',e+=" border-width: 0px; border-style: none;",e+=" border-collapse: collapse;",e+=" padding: 0px; margin: "+(r=void 0===r?4*t:r)+"px;",e+='">',e+="<tbody>";for(var n=0;n<f.getModuleCount();n+=1){e+="<tr>";for(var o=0;o<f.getModuleCount();o+=1)e+='<td style="',e+=" border-width: 0px; border-style: none;",e+=" border-collapse: collapse;",e+=" padding: 0px; margin: 0px;",e+=" width: "+t+"px;",e+=" height: "+t+"px;",e+=" background-color: ",e+=f.isDark(n,o)?"#000000":"#ffffff",e+=";",e+='"/>';e+="</tr>"}return e+="</tbody>",e+="</table>"},f.createSvgTag=function(t,r,e,n){var o={};"object"==typeof arguments[0]&&(t=(o=arguments[0]).cellSize,r=o.margin,e=o.alt,n=o.title),t=t||2,r=void 0===r?4*t:r,(e="string"==typeof e?{text:e}:e||{}).text=e.text||null,e.id=e.text?e.id||"qrcode-description":null,(n="string"==typeof n?{text:n}:n||{}).text=n.text||null,n.id=n.text?n.id||"qrcode-title":null;var i,a,u,c,g=f.getModuleCount()*t+2*r,l="";for(c="l"+t+",0 0,"+t+" -"+t+",0 0,-"+t+"z ",l+='<svg version="1.1" xmlns="http://www.w3.org/2000/svg"',l+=o.scalable?"":' width="'+g+'px" height="'+g+'px"',l+=' viewBox="0 0 '+g+" "+g+'" ',l+=' preserveAspectRatio="xMinYMin meet"',l+=n.text||e.text?' role="img" aria-labelledby="'+y([n.id,e.id].join(" ").trim())+'"':"",l+=">",l+=n.text?'<title id="'+y(n.id)+'">'+y(n.text)+"</title>":"",l+=e.text?'<description id="'+y(e.id)+'">'+y(e.text)+"</description>":"",l+='<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>',l+='<path d="',a=0;a<f.getModuleCount();a+=1)for(u=a*t+r,i=0;i<f.getModuleCount();i+=1)f.isDark(a,i)&&(l+="M"+(i*t+r)+","+u+c);return l+='" stroke="transparent" fill="black"/>',l+="</svg>"},f.createDataURL=function(t,r){t=t||2,r=void 0===r?4*t:r;var e=f.getModuleCount()*t+2*r,n=r,o=e-r;return I(e,e,function(r,e){if(n<=r&&r<o&&n<=e&&e<o){var i=Math.floor((r-n)/t),a=Math.floor((e-n)/t);return f.isDark(a,i)?0:1}return 1})},f.createImgTag=function(t,r,e){t=t||2,r=void 0===r?4*t:r;var n=f.getModuleCount()*t+2*r,o="";return o+="<img",o+=' src="',o+=f.createDataURL(t,r),o+='"',o+=' width="',o+=n,o+='"',o+=' height="',o+=n,o+='"',e&&(o+=' alt="',o+=y(e),o+='"'),o+="/>"};var y=function(t){for(var r="",e=0;e<t.length;e+=1){var n=t.charAt(e);switch(n){case"<":r+="&lt;";break;case">":r+="&gt;";break;case"&":r+="&amp;";break;case'"':r+="&quot;";break;default:r+=n}}return r};return f.createASCII=function(t,r){if((t=t||1)<2)return function(t){t=void 0===t?2:t;var r,e,n,o,i,a=1*f.getModuleCount()+2*t,u=t,c=a-t,g={"██":"█","█ ":"▀"," █":"▄","  ":" "},l={"██":"▀","█ ":"▀"," █":" ","  ":" "},h="";for(r=0;r<a;r+=2){for(n=Math.floor((r-u)/1),o=Math.floor((r+1-u)/1),e=0;e<a;e+=1)i="█",u<=e&&e<c&&u<=r&&r<c&&f.isDark(n,Math.floor((e-u)/1))&&(i=" "),u<=e&&e<c&&u<=r+1&&r+1<c&&f.isDark(o,Math.floor((e-u)/1))?i+=" ":i+="█",h+=t<1&&r+1>=c?l[i]:g[i];h+="\n"}return a%2&&t>0?h.substring(0,h.length-a-1)+Array(a+1).join("▀"):h.substring(0,h.length-1)}(r);t-=1,r=void 0===r?2*t:r;var e,n,o,i,a=f.getModuleCount()*t+2*r,u=r,c=a-r,g=Array(t+1).join("██"),l=Array(t+1).join("  "),h="",s="";for(e=0;e<a;e+=1){for(o=Math.floor((e-u)/t),s="",n=0;n<a;n+=1)i=1,u<=n&&n<c&&u<=e&&e<c&&f.isDark(o,Math.floor((n-u)/t))&&(i=0),s+=i?g:l;for(o=0;o<t;o+=1)h+=s+"\n"}return h.substring(0,h.length-1)},f.renderTo2dContext=function(t,r){r=r||2;for(var e=f.getModuleCount(),n=0;n<e;n++)for(var o=0;o<e;o++)t.fillStyle=f.isDark(n,o)?"black":"white",t.fillRect(o*r,n*r,r,r)},f};t.stringToBytes=(t.stringToBytesFuncs={default:function(t){for(var r=[],e=0;e<t.length;e+=1){var n=t.charCodeAt(e);r.push(255&n)}return r}}).default,t.createStringToBytes=function(t,r){var e=function(){for(var e=S(t),n=function(){var t=e.read();if(-1==t)throw"eof";return t},o=0,i={};;){var a=e.read();if(-1==a)break;var u=n(),f=n()<<8|n();i[String.fromCharCode(a<<8|u)]=f,o+=1}if(o!=r)throw o+" != "+r;return i}(),n="?".charCodeAt(0);return function(t){for(var r=[],o=0;o<t.length;o+=1){var i=t.charCodeAt(o);if(i<128)r.push(i);else{var a=e[t.charAt(o)];"number"==typeof a?(255&a)==a?r.push(a):(r.push(a>>>8),r.push(255&a)):r.push(n)}}return r}};var r,e,n,o,i,a=1,u=2,f=4,c=8,g={L:1,M:0,Q:3,H:2},l=0,h=1,s=2,v=3,d=4,w=5,p=6,y=7,B=(r=[[],[6,18],[6,22],[6,26],[6,30],[6,34],[6,22,38],[6,24,42],[6,26,46],[6,28,50],[6,30,54],[6,32,58],[6,34,62],[6,26,46,66],[6,26,48,70],[6,26,50,74],[6,30,54,78],[6,30,56,82],[6,30,58,86],[6,34,62,90],[6,28,50,72,94],[6,26,50,74,98],[6,30,54,78,102],[6,28,54,80,106],[6,32,58,84,110],[6,30,58,86,114],[6,34,62,90,118],[6,26,50,74,98,122],[6,30,54,78,102,126],[6,26,52,78,104,130],[6,30,56,82,108,134],[6,34,60,86,112,138],[6,30,58,86,114,142],[6,34,62,90,118,146],[6,30,54,78,102,126,150],[6,24,50,76,102,128,154],[6,28,54,80,106,132,158],[6,32,58,84,110,136,162],[6,26,54,82,110,138,166],[6,30,58,86,114,142,170]],e=1335,n=7973,i=function(t){for(var r=0;0!=t;)r+=1,t>>>=1;return r},(o={}).getBCHTypeInfo=function(t){for(var r=t<<10;i(r)-i(e)>=0;)r^=e<<i(r)-i(e);return 21522^(t<<10|r)},o.getBCHTypeNumber=function(t){for(var r=t<<12;i(r)-i(n)>=0;)r^=n<<i(r)-i(n);return t<<12|r},o.getPatternPosition=function(t){return r[t-1]},o.getMaskFunction=function(t){switch(t){case l:return function(t,r){return(t+r)%2==0};case h:return function(t,r){return t%2==0};case s:return function(t,r){return r%3==0};case v:return function(t,r){return(t+r)%3==0};case d:return function(t,r){return(Math.floor(t/2)+Math.floor(r/3))%2==0};case w:return function(t,r){return t*r%2+t*r%3==0};case p:return function(t,r){return(t*r%2+t*r%3)%2==0};case y:return function(t,r){return(t*r%3+(t+r)%2)%2==0};default:throw"bad maskPattern:"+t}},o.getErrorCorrectPolynomial=function(t){for(var r=k([1],0),e=0;e<t;e+=1)r=r.multiply(k([1,C.gexp(e)],0));return r},o.getLengthInBits=function(t,r){if(1<=r&&r<10)switch(t){case a:return 10;case u:return 9;case f:case c:return 8;default:throw"mode:"+t}else if(r<27)switch(t){case a:return 12;case u:return 11;case f:return 16;case c:return 10;default:throw"mode:"+t}else{if(!(r<41))throw"type:"+r;switch(t){case a:return 14;case u:return 13;case f:return 16;case c:return 12;default:throw"mode:"+t}}},o.getLostPoint=function(t){for(var r=t.getModuleCount(),e=0,n=0;n<r;n+=1)for(var o=0;o<r;o+=1){for(var i=0,a=t.isDark(n,o),u=-1;u<=1;u+=1)if(!(n+u<0||r<=n+u))for(var f=-1;f<=1;f+=1)o+f<0||r<=o+f||0==u&&0==f||a==t.isDark(n+u,o+f)&&(i+=1);i>5&&(e+=3+i-5)}for(n=0;n<r-1;n+=1)for(o=0;o<r-1;o+=1){var c=0;t.isDark(n,o)&&(c+=1),t.isDark(n+1,o)&&(c+=1),t.isDark(n,o+1)&&(c+=1),t.isDark(n+1,o+1)&&(c+=1),0!=c&&4!=c||(e+=3)}for(n=0;n<r;n+=1)for(o=0;o<r-6;o+=1)t.isDark(n,o)&&!t.isDark(n,o+1)&&t.isDark(n,o+2)&&t.isDark(n,o+3)&&t.isDark(n,o+4)&&!t.isDark(n,o+5)&&t.isDark(n,o+6)&&(e+=40);for(o=0;o<r;o+=1)for(n=0;n<r-6;n+=1)t.isDark(n,o)&&!t.isDark(n+1,o)&&t.isDark(n+2,o)&&t.isDark(n+3,o)&&t.isDark(n+4,o)&&!t.isDark(n+5,o)&&t.isDark(n+6,o)&&(e+=40);var g=0;for(o=0;o<r;o+=1)for(n=0;n<r;n+=1)t.isDark(n,o)&&(g+=1);return e+=Math.abs(100*g/r/r-50)/5*10},o),C=function(){for(var t=new Array(256),r=new Array(256),e=0;e<8;e+=1)t[e]=1<<e;for(e=8;e<256;e+=1)t[e]=t[e-4]^t[e-5]^t[e-6]^t[e-8];for(e=0;e<255;e+=1)r[t[e]]=e;var n={glog:function(t){if(t<1)throw"glog("+t+")";return r[t]},gexp:function(r){for(;r<0;)r+=255;for(;r>=256;)r-=255;return t[r]}};return n}();function k(t,r){if(void 0===t.length)throw t.length+"/"+r;var e=function(){for(var e=0;e<t.length&&0==t[e];)e+=1;for(var n=new Array(t.length-e+r),o=0;o<t.length-e;o+=1)n[o]=t[o+e];return n}(),n={getAt:function(t){return e[t]},getLength:function(){return e.length},multiply:function(t){for(var r=new Array(n.getLength()+t.getLength()-1),e=0;e<n.getLength();e+=1)for(var o=0;o<t.getLength();o+=1)r[e+o]^=C.gexp(C.glog(n.getAt(e))+C.glog(t.getAt(o)));return k(r,0)},mod:function(t){if(n.getLength()-t.getLength()<0)return n;for(var r=C.glog(n.getAt(0))-C.glog(t.getAt(0)),e=new Array(n.getLength()),o=0;o<n.getLength();o+=1)e[o]=n.getAt(o);for(o=0;o<t.getLength();o+=1)e[o]^=C.gexp(C.glog(t.getAt(o))+r);return k(e,0).mod(t)}};return n}var A=function(){var t=[[1,26,19],[1,26,16],[1,26,13],[1,26,9],[1,44,34],[1,44,28],[1,44,22],[1,44,16],[1,70,55],[1,70,44],[2,35,17],[2,35,13],[1,100,80],[2,50,32],[2,50,24],[4,25,9],[1,134,108],[2,67,43],[2,33,15,2,34,16],[2,33,11,2,34,12],[2,86,68],[4,43,27],[4,43,19],[4,43,15],[2,98,78],[4,49,31],[2,32,14,4,33,15],[4,39,13,1,40,14],[2,121,97],[2,60,38,2,61,39],[4,40,18,2,41,19],[4,40,14,2,41,15],[2,146,116],[3,58,36,2,59,37],[4,36,16,4,37,17],[4,36,12,4,37,13],[2,86,68,2,87,69],[4,69,43,1,70,44],[6,43,19,2,44,20],[6,43,15,2,44,16],[4,101,81],[1,80,50,4,81,51],[4,50,22,4,51,23],[3,36,12,8,37,13],[2,116,92,2,117,93],[6,58,36,2,59,37],[4,46,20,6,47,21],[7,42,14,4,43,15],[4,133,107],[8,59,37,1,60,38],[8,44,20,4,45,21],[12,33,11,4,34,12],[3,145,115,1,146,116],[4,64,40,5,65,41],[11,36,16,5,37,17],[11,36,12,5,37,13],[5,109,87,1,110,88],[5,65,41,5,66,42],[5,54,24,7,55,25],[11,36,12,7,37,13],[5,122,98,1,123,99],[7,73,45,3,74,46],[15,43,19,2,44,20],[3,45,15,13,46,16],[1,135,107,5,136,108],[10,74,46,1,75,47],[1,50,22,15,51,23],[2,42,14,17,43,15],[5,150,120,1,151,121],[9,69,43,4,70,44],[17,50,22,1,51,23],[2,42,14,19,43,15],[3,141,113,4,142,114],[3,70,44,11,71,45],[17,47,21,4,48,22],[9,39,13,16,40,14],[3,135,107,5,136,108],[3,67,41,13,68,42],[15,54,24,5,55,25],[15,43,15,10,44,16],[4,144,116,4,145,117],[17,68,42],[17,50,22,6,51,23],[19,46,16,6,47,17],[2,139,111,7,140,112],[17,74,46],[7,54,24,16,55,25],[34,37,13],[4,151,121,5,152,122],[4,75,47,14,76,48],[11,54,24,14,55,25],[16,45,15,14,46,16],[6,147,117,4,148,118],[6,73,45,14,74,46],[11,54,24,16,55,25],[30,46,16,2,47,17],[8,132,106,4,133,107],[8,75,47,13,76,48],[7,54,24,22,55,25],[22,45,15,13,46,16],[10,142,114,2,143,115],[19,74,46,4,75,47],[28,50,22,6,51,23],[33,46,16,4,47,17],[8,152,122,4,153,123],[22,73,45,3,74,46],[8,53,23,26,54,24],[12,45,15,28,46,16],[3,147,117,10,148,118],[3,73,45,23,74,46],[4,54,24,31,55,25],[11,45,15,31,46,16],[7,146,116,7,147,117],[21,73,45,7,74,46],[1,53,23,37,54,24],[19,45,15,26,46,16],[5,145,115,10,146,116],[19,75,47,10,76,48],[15,54,24,25,55,25],[23,45,15,25,46,16],[13,145,115,3,146,116],[2,74,46,29,75,47],[42,54,24,1,55,25],[23,45,15,28,46,16],[17,145,115],[10,74,46,23,75,47],[10,54,24,35,55,25],[19,45,15,35,46,16],[17,145,115,1,146,116],[14,74,46,21,75,47],[29,54,24,19,55,25],[11,45,15,46,46,16],[13,145,115,6,146,116],[14,74,46,23,75,47],[44,54,24,7,55,25],[59,46,16,1,47,17],[12,151,121,7,152,122],[12,75,47,26,76,48],[39,54,24,14,55,25],[22,45,15,41,46,16],[6,151,121,14,152,122],[6,75,47,34,76,48],[46,54,24,10,55,25],[2,45,15,64,46,16],[17,152,122,4,153,123],[29,74,46,14,75,47],[49,54,24,10,55,25],[24,45,15,46,46,16],[4,152,122,18,153,123],[13,74,46,32,75,47],[48,54,24,14,55,25],[42,45,15,32,46,16],[20,147,117,4,148,118],[40,75,47,7,76,48],[43,54,24,22,55,25],[10,45,15,67,46,16],[19,148,118,6,149,119],[18,75,47,31,76,48],[34,54,24,34,55,25],[20,45,15,61,46,16]],r=function(t,r){var e={};return e.totalCount=t,e.dataCount=r,e},e={};return e.getRSBlocks=function(e,n){var o=function(r,e){switch(e){case g.L:return t[4*(r-1)+0];case g.M:return t[4*(r-1)+1];case g.Q:return t[4*(r-1)+2];case g.H:return t[4*(r-1)+3];default:return}}(e,n);if(void 0===o)throw"bad rs block @ typeNumber:"+e+"/errorCorrectionLevel:"+n;for(var i=o.length/3,a=[],u=0;u<i;u+=1)for(var f=o[3*u+0],c=o[3*u+1],l=o[3*u+2],h=0;h<f;h+=1)a.push(r(c,l));return a},e}(),b=function(){var t=[],r=0,e={getBuffer:function(){return t},getAt:function(r){var e=Math.floor(r/8);return 1==(t[e]>>>7-r%8&1)},put:function(t,r){for(var n=0;n<r;n+=1)e.putBit(1==(t>>>r-n-1&1))},getLengthInBits:function(){return r},putBit:function(e){var n=Math.floor(r/8);t.length<=n&&t.push(0),e&&(t[n]|=128>>>r%8),r+=1}};return e},M=function(t){var r=a,e=t,n={getMode:function(){return r},getLength:function(t){return e.length},write:function(t){for(var r=e,n=0;n+2<r.length;)t.put(o(r.substring(n,n+3)),10),n+=3;n<r.length&&(r.length-n==1?t.put(o(r.substring(n,n+1)),4):r.length-n==2&&t.put(o(r.substring(n,n+2)),7))}},o=function(t){for(var r=0,e=0;e<t.length;e+=1)r=10*r+i(t.charAt(e));return r},i=function(t){if("0"<=t&&t<="9")return t.charCodeAt(0)-"0".charCodeAt(0);throw"illegal char :"+t};return n},x=function(t){var r=u,e=t,n={getMode:function(){return r},getLength:function(t){return e.length},write:function(t){for(var r=e,n=0;n+1<r.length;)t.put(45*o(r.charAt(n))+o(r.charAt(n+1)),11),n+=2;n<r.length&&t.put(o(r.charAt(n)),6)}},o=function(t){if("0"<=t&&t<="9")return t.charCodeAt(0)-"0".charCodeAt(0);if("A"<=t&&t<="Z")return t.charCodeAt(0)-"A".charCodeAt(0)+10;switch(t){case" ":return 36;case"$":return 37;case"%":return 38;case"*":return 39;case"+":return 40;case"-":return 41;case".":return 42;case"/":return 43;case":":return 44;default:throw"illegal char :"+t}};return n},m=function(r){var e=f,n=t.stringToBytes(r),o={getMode:function(){return e},getLength:function(t){return n.length},write:function(t){for(var r=0;r<n.length;r+=1)t.put(n[r],8)}};return o},L=function(r){var e=c,n=t.stringToBytesFuncs.SJIS;if(!n)throw"sjis not supported.";!function(){var t=n("友");if(2!=t.length||38726!=(t[0]<<8|t[1]))throw"sjis not supported."}();var o=n(r),i={getMode:function(){return e},getLength:function(t){return~~(o.length/2)},write:function(t){for(var r=o,e=0;e+1<r.length;){var n=(255&r[e])<<8|255&r[e+1];if(33088<=n&&n<=40956)n-=33088;else{if(!(57408<=n&&n<=60351))throw"illegal char at "+(e+1)+"/"+n;n-=49472}n=192*(n>>>8&255)+(255&n),t.put(n,13),e+=2}if(e<r.length)throw"illegal char at "+(e+1)}};return i},D=function(){var t=[],r={writeByte:function(r){t.push(255&r)},writeShort:function(t){r.writeByte(t),r.writeByte(t>>>8)},writeBytes:function(t,e,n){e=e||0,n=n||t.length;for(var o=0;o<n;o+=1)r.writeByte(t[o+e])},writeString:function(t){for(var e=0;e<t.length;e+=1)r.writeByte(t.charCodeAt(e))},toByteArray:function(){return t},toString:function(){var r="";r+="[";for(var e=0;e<t.length;e+=1)e>0&&(r+=","),r+=t[e];return r+="]"}};return r},S=function(t){var r=t,e=0,n=0,o=0,i={read:function(){for(;o<8;){if(e>=r.length){if(0==o)return-1;throw"unexpected end of file./"+o}var t=r.charAt(e);if(e+=1,"="==t)return o=0,-1;t.match(/^\s$/)||(n=n<<6|a(t.charCodeAt(0)),o+=6)}var i=n>>>o-8&255;return o-=8,i}},a=function(t){if(65<=t&&t<=90)return t-65;if(97<=t&&t<=122)return t-97+26;if(48<=t&&t<=57)return t-48+52;if(43==t)return 62;if(47==t)return 63;throw"c:"+t};return i},I=function(t,r,e){for(var n=function(t,r){var e=t,n=r,o=new Array(t*r),i={setPixel:function(t,r,n){o[r*e+t]=n},write:function(t){t.writeString("GIF87a"),t.writeShort(e),t.writeShort(n),t.writeByte(128),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(0),t.writeByte(255),t.writeByte(255),t.writeByte(255),t.writeString(","),t.writeShort(0),t.writeShort(0),t.writeShort(e),t.writeShort(n),t.writeByte(0);var r=a(2);t.writeByte(2);for(var o=0;r.length-o>255;)t.writeByte(255),t.writeBytes(r,o,255),o+=255;t.writeByte(r.length-o),t.writeBytes(r,o,r.length-o),t.writeByte(0),t.writeString(";")}},a=function(t){for(var r=1<<t,e=1+(1<<t),n=t+1,i=u(),a=0;a<r;a+=1)i.add(String.fromCharCode(a));i.add(String.fromCharCode(r)),i.add(String.fromCharCode(e));var f,c,g,l=D(),h=(f=l,c=0,g=0,{write:function(t,r){if(t>>>r!=0)throw"length over";for(;c+r>=8;)f.writeByte(255&(t<<c|g)),r-=8-c,t>>>=8-c,g=0,c=0;g|=t<<c,c+=r},flush:function(){c>0&&f.writeByte(g)}});h.write(r,n);var s=0,v=String.fromCharCode(o[s]);for(s+=1;s<o.length;){var d=String.fromCharCode(o[s]);s+=1,i.contains(v+d)?v+=d:(h.write(i.indexOf(v),n),i.size()<4095&&(i.size()==1<<n&&(n+=1),i.add(v+d)),v=d)}return h.write(i.indexOf(v),n),h.write(e,n),h.flush(),l.toByteArray()},u=function(){var t={},r=0,e={add:function(n){if(e.contains(n))throw"dup key:"+n;t[n]=r,r+=1},size:function(){return r},indexOf:function(r){return t[r]},contains:function(r){return void 0!==t[r]}};return e};return i}(t,r),o=0;o<r;o+=1)for(var i=0;i<t;i+=1)n.setPixel(i,o,e(i,o));var a=D();n.write(a);for(var u=function(){var t=0,r=0,e=0,n="",o={},i=function(t){n+=String.fromCharCode(a(63&t))},a=function(t){if(t<0);else{if(t<26)return 65+t;if(t<52)return t-26+97;if(t<62)return t-52+48;if(62==t)return 43;if(63==t)return 47}throw"n:"+t};return o.writeByte=function(n){for(t=t<<8|255&n,r+=8,e+=1;r>=6;)i(t>>>r-6),r-=6},o.flush=function(){if(r>0&&(i(t<<6-r),t=0,r=0),e%3!=0)for(var o=3-e%3,a=0;a<o;a+=1)n+="="},o.toString=function(){return n},o}(),f=a.toByteArray(),c=0;c<f.length;c+=1)u.writeByte(f[c]);return u.flush(),"data:image/gif;base64,"+u};return t}();qrcode.stringToBytesFuncs["UTF-8"]=function(t){return function(t){for(var r=[],e=0;e<t.length;e++){var n=t.charCodeAt(e);n<128?r.push(n):n<2048?r.push(192|n>>6,128|63&n):n<55296||n>=57344?r.push(224|n>>12,128|n>>6&63,128|63&n):(e++,n=65536+((1023&n)<<10|1023&t.charCodeAt(e)),r.push(240|n>>18,128|n>>12&63,128|n>>6&63,128|63&n))}return r}(t)},function(t){"function"==typeof define&&define.amd?define([],t):"object"==typeof exports&&(module.exports=t())}(function(){return qrcode});
+</script>
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.4';
+const CONFIGURATOR_VERSION = '2.5';
+// Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
+// Leave empty to keep the feature fully disabled and hidden.
+const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.5', date:'Jul 2 2026', items:[
+    'QR codes now generated locally in your browser — manifest URLs (with your UUID and password) are no longer sent to an external QR service',
+    'Test buttons on API keys — verify TorBox / Real-Debrid / AllDebrid / Premiumize / Debrid-Link keys before generating',
+    'Light theme completed — result boxes, highlights, formatter cards, and warnings now readable in light mode',
+    'Device step ? buttons — plain-English explanations of DV-Only Kill, AV1, VC-1, eARC and other jargon',
+    'Resume banner shows what changed since your last downloaded template',
+    'Import URL result notes that paste.rs links can expire — keep the JSON as backup',
+  ]},
   { v:'2.4', date:'Jul 2 2026', items:[
     'Readability pass — larger text on every button (nav, download, install, pills, chips, links)',
     'Important info now highlighted: credential warnings in amber, key steps and privacy notes bolded',
@@ -701,7 +762,7 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
-const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed' };
+const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', telemetryOk: false };
 
 const FORMATTERS = [
   {
@@ -768,15 +829,15 @@ const DEFS = [
   },
   { id:'device', title:'Your Device', desc:'Sets audio format limits, codec exclusions, and HDR/DV handling.', key:'device', cols:'c1', layout:'svc-list', noHero:true,
     opts:[
-      { v:'generic',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="13" width="38" height="22" rx="3" stroke="#a78bfa" stroke-width="2"/><rect x="7" y="16" width="30" height="15" fill="#1a0a3a"/><line x1="15" y1="35" x2="12" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="29" y1="35" x2="32" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="10" y1="42" x2="34" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="16" y1="13" x2="12" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/><line x1="28" y1="13" x2="32" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/></svg>', name:'Standard TV',          desc:'Broadest compatibility · no restrictions' },
-      { v:'samsung',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="9" width="40" height="24" rx="2" stroke="#3d72e8" stroke-width="2"/><rect x="4" y="11" width="36" height="20" fill="#040e22"/><rect x="19" y="33" width="6" height="3" fill="#3d72e8"/><path d="M12 41 Q22 37 32 41" stroke="#3d72e8" stroke-width="2" stroke-linecap="round" fill="none"/><line x1="8" y1="21" x2="36" y2="21" stroke="#3d72e8" stroke-width="0.5" opacity="0.5"/></svg>', name:'Samsung TV',           desc:'DV-Only Kill · AV1/VC-1 excluded · HDR10+' },
-      { v:'appletv-old',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="14" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#888" stroke-width="1.5"/><path d="M19 22.5 C19 19.5 21 18 22.5 18 C23 18 23.5 18.3 24 18.5 24.5 18.3 25 18 25.5 18 C27 18 29 19.5 29 22.5 C29 25.5 27.5 27 25.5 27 C25 27 24.5 26.7 24 26.5 23.5 26.7 23 27 22.5 27 C21 27 19 25.5 19 22.5Z" fill="#888"/><line x1="23.5" y1="16" x2="25" y2="14" stroke="#888" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#f59e0b"/><text x="22" y="12" text-anchor="middle" fill="#666" font-size="6" font-family="system-ui,sans-serif">GEN 1 · 2</text></svg>', name:'Apple TV 4K Gen 1–2', desc:'DV · TrueHD · Atmos · no AV1 · 7.1' },
-      { v:'appletv-new',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="13" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#a0a0a8" stroke-width="1.5"/><path d="M19 21.5 C19 18.5 21 17 22.5 17 C23 17 23.5 17.3 24 17.5 24.5 17.3 25 17 25.5 17 C27 17 29 18.5 29 21.5 C29 24.5 27.5 26 25.5 26 C25 26 24.5 25.7 24 25.5 23.5 25.7 23 26 22.5 26 C21 26 19 24.5 19 21.5Z" fill="#a0a0a8"/><line x1="23.5" y1="15" x2="25" y2="13" stroke="#a0a0a8" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#fff" opacity="0.8"/><text x="22" y="11" text-anchor="middle" fill="#7ab4ff" font-size="6" font-family="system-ui,sans-serif">A15 · AV1</text></svg>', name:'Apple TV 4K Gen 3',   desc:'DV · TrueHD · Atmos · AV1 · 7.1' },
-      { v:'lgtv',            icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="7" width="40" height="27" rx="2" stroke="#c00000" stroke-width="2"/><rect x="4" y="9" width="36" height="23" fill="#080000"/><circle cx="12" cy="21" r="3.5" fill="#cc0000" opacity="0.7"/><circle cx="22" cy="21" r="3.5" fill="#00bb44" opacity="0.7"/><circle cx="32" cy="21" r="3.5" fill="#0044cc" opacity="0.7"/><rect x="17" y="34" width="10" height="4" rx="1" fill="#c00000"/><line x1="12" y1="42" x2="32" y2="42" stroke="#c00000" stroke-width="2" stroke-linecap="round"/></svg>', name:'LG TV webOS',          desc:'DV · AV1 · eARC · TrueHD · 7.1' },
-      { v:'windows',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="6" width="38" height="26" rx="3" stroke="#0078d4" stroke-width="2"/><rect x="7" y="9" width="30" height="20" fill="#001428"/><rect x="10" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="10" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="18" y="32" width="8" height="4" rx="1" fill="#0078d4"/><line x1="12" y1="40" x2="32" y2="40" stroke="#0078d4" stroke-width="2" stroke-linecap="round"/></svg>', name:'Windows PC',           desc:'Full lossless · AV1 · HDR-first · 7.1' },
-      { v:'firestick-hd',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff6b00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff6b00"/><path d="M16 20 C16 16 14 13 16 10 C16 10 17.5 12 19 11 C19 8 21.5 5 23 3 C23 3 23 7.5 26 10 C27.5 11 27 13.5 25 15.5 C25 15.5 25 13 23 14 C23 17 21 20 16 20Z" fill="#ff6b00"/><text x="19" y="29" text-anchor="middle" fill="#ff6b00" font-size="7.5" font-weight="800" font-family="system-ui,sans-serif">HD</text></svg>', name:'Fire Stick HD',        desc:'DV-Only Kill · no AV1/lossless · HDR10/HLG' },
-      { v:'firestick-4kmax', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff8c00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff8c00"/><path d="M15 20 C15 15 13 11 16 8 C16 8 18 11 20 10 C20 6 23 2 24 1 C24 1 24 6 28 9 C30 11 29.5 14 27 17 C27 17 27 14 24 15 C24 18 22 20 15 20Z" fill="#ff8c00"/><text x="19" y="29" text-anchor="middle" fill="#ff8c00" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">4K MAX</text></svg>', name:'Fire Stick 4K Max',   desc:'DV · AV1 · VC-1 excluded · no lossless' },
-      { v:'shield', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="4" y="21" width="29" height="11" rx="3" fill="#0d1a0a" stroke="#76b900" stroke-width="1.5"/><rect x="34" y="23" width="7" height="7" rx="2" fill="#76b900"/><path d="M22 6 L30 10 L30 19 Q30 22 22 25 Q14 22 14 19 L14 10 Z" fill="none" stroke="#76b900" stroke-width="1.5" stroke-linejoin="round"/><path d="M22 8 L28 11.5 L28 19 Q28 21 22 23.5" stroke="#76b900" stroke-width="0.5" stroke-linejoin="round" fill="#76b900" opacity="0.2"/></svg>', name:'Streaming Box', desc:'No AV1 · no HLG · Nvidia Shield / Android TV' },
+      { v:'generic',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="13" width="38" height="22" rx="3" stroke="#a78bfa" stroke-width="2"/><rect x="7" y="16" width="30" height="15" fill="#1a0a3a"/><line x1="15" y1="35" x2="12" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="29" y1="35" x2="32" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="10" y1="42" x2="34" y2="42" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><line x1="16" y1="13" x2="12" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/><line x1="28" y1="13" x2="32" y2="5" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/></svg>', name:'Standard TV',          desc:'Broadest compatibility · no restrictions', help:'No format restrictions — every stream type is allowed. Pick this if you are unsure of your TV specs; everything will play, though rare formats may need transcoding.' },
+      { v:'samsung',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="9" width="40" height="24" rx="2" stroke="#3d72e8" stroke-width="2"/><rect x="4" y="11" width="36" height="20" fill="#040e22"/><rect x="19" y="33" width="6" height="3" fill="#3d72e8"/><path d="M12 41 Q22 37 32 41" stroke="#3d72e8" stroke-width="2" stroke-linecap="round" fill="none"/><line x1="8" y1="21" x2="36" y2="21" stroke="#3d72e8" stroke-width="0.5" opacity="0.5"/></svg>', name:'Samsung TV',           desc:'DV-Only Kill · AV1/VC-1 excluded · HDR10+', help:'<b>DV-Only Kill</b>: Samsung TVs have no Dolby Vision support — DV streams without an HDR10 fallback show a purple/green tint, so they are removed. <b>AV1 / VC-1 excluded</b>: 2018–2022 Samsung models lack these video decoders. <b>HDR10+</b> is Samsung&#39;s own HDR format and is prioritised.' },
+      { v:'appletv-old',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="14" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#888" stroke-width="1.5"/><path d="M19 22.5 C19 19.5 21 18 22.5 18 C23 18 23.5 18.3 24 18.5 24.5 18.3 25 18 25.5 18 C27 18 29 19.5 29 22.5 C29 25.5 27.5 27 25.5 27 C25 27 24.5 26.7 24 26.5 23.5 26.7 23 27 22.5 27 C21 27 19 25.5 19 22.5Z" fill="#888"/><line x1="23.5" y1="16" x2="25" y2="14" stroke="#888" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#f59e0b"/><text x="22" y="12" text-anchor="middle" fill="#666" font-size="6" font-family="system-ui,sans-serif">GEN 1 · 2</text></svg>', name:'Apple TV 4K Gen 1–2', desc:'DV · TrueHD · Atmos · no AV1 · 7.1', help:'<b>DV</b>: Dolby Vision fully supported. <b>TrueHD / Atmos</b>: lossless audio passes through. <b>No AV1</b>: Gen 1–2 have no AV1 hardware decoder, so those streams are excluded. <b>7.1</b>: full surround channels ranked first.' },
+      { v:'appletv-new',     icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="8" y="13" width="28" height="18" rx="7" fill="#1c1c1e" stroke="#a0a0a8" stroke-width="1.5"/><path d="M19 21.5 C19 18.5 21 17 22.5 17 C23 17 23.5 17.3 24 17.5 24.5 17.3 25 17 25.5 17 C27 17 29 18.5 29 21.5 C29 24.5 27.5 26 25.5 26 C25 26 24.5 25.7 24 25.5 23.5 25.7 23 26 22.5 26 C21 26 19 24.5 19 21.5Z" fill="#a0a0a8"/><line x1="23.5" y1="15" x2="25" y2="13" stroke="#a0a0a8" stroke-width="1.5" stroke-linecap="round"/><circle cx="22" cy="34" r="2" fill="#fff" opacity="0.8"/><text x="22" y="11" text-anchor="middle" fill="#7ab4ff" font-size="6" font-family="system-ui,sans-serif">A15 · AV1</text></svg>', name:'Apple TV 4K Gen 3',   desc:'DV · TrueHD · Atmos · AV1 · 7.1', help:'Same profile as Gen 1–2 plus <b>AV1</b>: the A15 chip decodes AV1 in hardware, so those smaller, more efficient streams are allowed and ranked.' },
+      { v:'lgtv',            icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="2" y="7" width="40" height="27" rx="2" stroke="#c00000" stroke-width="2"/><rect x="4" y="9" width="36" height="23" fill="#080000"/><circle cx="12" cy="21" r="3.5" fill="#cc0000" opacity="0.7"/><circle cx="22" cy="21" r="3.5" fill="#00bb44" opacity="0.7"/><circle cx="32" cy="21" r="3.5" fill="#0044cc" opacity="0.7"/><rect x="17" y="34" width="10" height="4" rx="1" fill="#c00000"/><line x1="12" y1="42" x2="32" y2="42" stroke="#c00000" stroke-width="2" stroke-linecap="round"/></svg>', name:'LG TV webOS',          desc:'DV · AV1 · eARC · TrueHD · 7.1', help:'<b>eARC</b>: passes lossless audio (TrueHD, DTS-HD MA) to a soundbar or receiver over HDMI. LG OLED/QNED supports Dolby Vision and AV1 — nothing is excluded on this profile.' },
+      { v:'windows',         icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="3" y="6" width="38" height="26" rx="3" stroke="#0078d4" stroke-width="2"/><rect x="7" y="9" width="30" height="20" fill="#001428"/><rect x="10" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="12" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="10" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="17" y="18" width="6" height="5" rx="0.5" fill="#0078d4"/><rect x="18" y="32" width="8" height="4" rx="1" fill="#0078d4"/><line x1="12" y1="40" x2="32" y2="40" stroke="#0078d4" stroke-width="2" stroke-linecap="round"/></svg>', name:'Windows PC',           desc:'Full lossless · AV1 · HDR-first · 7.1', help:'PCs can decode anything in software if needed, so nothing is excluded. <b>HDR-first</b>: HDR streams ranked above SDR. Full lossless audio ranked for external DACs and receivers.' },
+      { v:'firestick-hd',    icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff6b00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff6b00"/><path d="M16 20 C16 16 14 13 16 10 C16 10 17.5 12 19 11 C19 8 21.5 5 23 3 C23 3 23 7.5 26 10 C27.5 11 27 13.5 25 15.5 C25 15.5 25 13 23 14 C23 17 21 20 16 20Z" fill="#ff6b00"/><text x="19" y="29" text-anchor="middle" fill="#ff6b00" font-size="7.5" font-weight="800" font-family="system-ui,sans-serif">HD</text></svg>', name:'Fire Stick HD',        desc:'DV-Only Kill · no AV1/lossless · HDR10/HLG', help:'The HD stick has no Dolby Vision, no AV1 decoder, and no lossless audio passthrough — those streams are removed or down-ranked so everything actually plays. <b>HDR10 / HLG</b> still work.' },
+      { v:'firestick-4kmax', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="5" y="20" width="28" height="11" rx="3" fill="#1a0800" stroke="#ff8c00" stroke-width="1.5"/><rect x="33" y="22" width="7" height="7" rx="2" fill="#ff8c00"/><path d="M15 20 C15 15 13 11 16 8 C16 8 18 11 20 10 C20 6 23 2 24 1 C24 1 24 6 28 9 C30 11 29.5 14 27 17 C27 17 27 14 24 15 C24 18 22 20 15 20Z" fill="#ff8c00"/><text x="19" y="29" text-anchor="middle" fill="#ff8c00" font-size="6.5" font-weight="800" font-family="system-ui,sans-serif">4K MAX</text></svg>', name:'Fire Stick 4K Max',   desc:'DV · AV1 · VC-1 excluded · no lossless', help:'<b>DV + AV1</b> are supported on the 4K Max. <b>VC-1 excluded</b>: an old Blu-ray codec the stick struggles with. <b>No lossless</b>: Fire OS does not bitstream TrueHD or DTS-HD MA, so DD+/Atmos is the ceiling.' },
+      { v:'shield', icon:'<svg width="44" height="44" viewBox="0 0 44 44" fill="none"><rect x="4" y="21" width="29" height="11" rx="3" fill="#0d1a0a" stroke="#76b900" stroke-width="1.5"/><rect x="34" y="23" width="7" height="7" rx="2" fill="#76b900"/><path d="M22 6 L30 10 L30 19 Q30 22 22 25 Q14 22 14 19 L14 10 Z" fill="none" stroke="#76b900" stroke-width="1.5" stroke-linejoin="round"/><path d="M22 8 L28 11.5 L28 19 Q28 21 22 23.5" stroke="#76b900" stroke-width="0.5" stroke-linejoin="round" fill="#76b900" opacity="0.2"/></svg>', name:'Streaming Box', desc:'No AV1 · no HLG · Nvidia Shield / Android TV', help:'<b>No AV1</b>: the Nvidia Shield (2019) has no AV1 decoder. <b>No HLG</b>: a broadcast HDR format with known Shield playback issues. Everything else, including Dolby Vision and lossless audio, works.' },
     ]
   },
   { id:'resolution', title:'Resolution', desc:'Primary resolution target for this template.', key:'resolution', cols:'c1', layout:'svc-list', noHero:true,
@@ -835,6 +896,27 @@ function sanitizeSharedConfig(d) {
   if (Array.isArray(d.langs)) { const l = d.langs.filter(v => LANG_OPTS.some(o => o.v === v)); if (l.length) out.langs = l; }
   if (typeof d.name === 'string') out.name = d.name.replace(/[<>"'&`]/g, '').slice(0, 60);
   return out;
+}
+
+function saveLastGen() {
+  try { const snap = {}; SHARE_KEYS.forEach(k => { snap[k] = S[k]; }); localStorage.setItem('coreBuildLastGen', JSON.stringify(snap)); } catch(e) {}
+}
+function lastGenDiff() {
+  try {
+    const last = JSON.parse(localStorage.getItem('coreBuildLastGen') || 'null');
+    if (!last) return [];
+    const NICE = { sizeLimit: v => v === 'unlimited' ? 'Unlimited' : v + 'GB', cacheMode: v => ({ mixed:'Mixed', cached:'Cached Only', uncached:'Uncached' })[v] || v };
+    const KEYS = [['device','Device'],['resolution','Resolution'],['audio','Audio'],['content','Content'],['formatter','Formatter'],['sizeLimit','Size limit'],['cacheMode','Cache']];
+    const out = [];
+    KEYS.forEach(([k, lbl]) => {
+      const a = last[k], b = S[k];
+      if (a == null || b == null || a === b) return;
+      const fmt = v => NICE[k] ? NICE[k](v) : (label(k, v) || v);
+      out.push(lbl + ': ' + fmt(a) + ' → ' + fmt(b));
+    });
+    if (Array.isArray(last.multiServices) && JSON.stringify([...last.multiServices].sort()) !== JSON.stringify([...(S.multiServices||[])].sort())) out.push('Services changed');
+    return out;
+  } catch(e) { return []; }
 }
 
 function loadState() {
@@ -903,19 +985,19 @@ function renderOpts(def) {
   if (def.layout === 'formatter-picker') return '<div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.65)':'rgba(255,255,255,.13)'};border-radius:12px;background:${on?'rgba(0,212,255,.1)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;overflow:hidden;${on?'box-shadow:0 0 0 1px rgba(0,212,255,.22),0 4px 22px rgba(0,180,220,.2);':''}">
+      return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}">
         <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
           <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0;box-shadow:0 0 8px ${f.bc}88"></div>
           <div style="flex:1;min-width:0">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
-              <span class="fmt-lbl" style="font-weight:700;font-size:.9rem;color:${on?'#00d4ff':'#e6edf3'}">${f.label}</span>
+              <span class="fmt-lbl" style="font-weight:700;font-size:.9rem">${f.label}</span>
               <span style="font-size:.62rem;font-weight:700;padding:2px 7px;border-radius:5px;background:${f.bc}22;color:${f.bc}">${f.badge}</span>
             </div>
             <div style="color:#6b7280;font-size:.72rem">${f.desc}</div>
           </div>
-          ${on ? '<span style="color:#00d4ff;font-size:.9rem;flex-shrink:0">✓</span>' : '<span style="color:#374151;font-size:.9rem;flex-shrink:0">›</span>'}
+          <span class="fmt-arr"></span>
         </div>
-        <div class="fmt-preview-wrap" style="padding:0 13px 11px;${on?'':'display:none'}">${fmtPreviewHtml(f.id)}</div>
+        <div class="fmt-preview-wrap">${fmtPreviewHtml(f.id)}</div>
       </div>`;
     }).join('') +
   '</div>';
@@ -926,8 +1008,9 @@ function renderOpts(def) {
       const rows = def.opts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
         <div class="opt-icon">${o.icon}</div>
         <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc.replace(/<[^>]*>/g,'')}</div></div>
+        ${o.help ? `<button type="button" class="help-btn" data-action="toggle-device-help" data-v="${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>` : ''}
         <span class="svc-list-arr">›</span>
-      </label></div>`).join('');
+      </label>${o.help ? `<div class="device-help" id="help_${o.v}">${o.help}</div>` : ''}</div>`).join('');
       if (def.id === 'resolution') {
         const AUDIO_OPTS = [
           { v:'lossless', icon:'<svg width="28" height="28" viewBox="0 0 44 44" fill="none"><path d="M7 17 L7 27 L13 27 L21 33 L21 11 L13 17 Z" stroke="#10b981" stroke-width="1.5" stroke-linejoin="round" fill="#0a1f16"/><path d="M26 14 Q32 22 26 30" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M30 9 Q39 22 30 35" stroke="#10b981" stroke-width="2" stroke-linecap="round"/><path d="M34 5 Q44 22 34 39" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/></svg>', name:'Full Lossless', desc:'TrueHD · Atmos · DTS-HD MA · FLAC · eARC required' },
@@ -1139,17 +1222,17 @@ function renderAdvancedPanel() {
 
   const fmtCards = FORMATTERS.map(f => {
     const on = S.formatter === f.id;
-    return `<div data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border:1.5px solid ${on?'rgba(0,212,255,.4)':'rgba(255,255,255,.1)'};border-radius:12px;background:${on?'rgba(0,212,255,.07)':'rgba(8,12,18,.9)'};cursor:pointer;transition:border-color .15s,background .15s;overflow:hidden">
+    return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}">
       <div style="display:flex;align-items:center;gap:14px;padding:13px 16px">
         <div style="width:10px;height:10px;border-radius:50%;background:${f.bc};flex-shrink:0"></div>
         <div style="flex:1;min-width:0">
-          <span class="fmt-lbl" style="font-weight:700;font-size:.9rem;color:${on?'#00d4ff':'#e6edf3'}">${f.label}</span>
+          <span class="fmt-lbl" style="font-weight:700;font-size:.9rem">${f.label}</span>
           <span style="margin-left:6px;background:rgba(255,255,255,.06);border-radius:4px;padding:2px 6px;font-size:.65rem;color:#6b7280">${f.badge}</span>
           <div style="color:#6b7280;font-size:.72rem;margin-top:2px">${f.desc}</div>
         </div>
-        ${on ? '<span style="color:#00d4ff;font-size:.85rem;flex-shrink:0">✓</span>' : '<span style="color:#374151;font-size:.85rem;flex-shrink:0">›</span>'}
+        <span class="fmt-arr"></span>
       </div>
-      <div class="fmt-preview-wrap" style="padding:0 13px 11px;${on?'':'display:none'}">${fmtPreviewHtml(f.id)}</div>
+      <div class="fmt-preview-wrap">${fmtPreviewHtml(f.id)}</div>
     </div>`;
   }).join('');
 
@@ -1298,6 +1381,7 @@ function splashHtml() {
       <div style="flex:1;min-width:0">
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
         <div style="font-size:.67rem;color:#6b7280;margin-top:1px">Step ${_savedStep} of 6${S.service ? ' · ' + label('service', S.service) : ''}</div>
+        ${(() => { const d = lastGenDiff(); return d.length ? `<div style="font-size:.66rem;color:#f59e0b;margin-top:3px;line-height:1.4">Changed since last download — ${d.slice(0,2).join(' · ')}${d.length > 2 ? ` +${d.length - 2} more` : ''}</div>` : ''; })()}
       </div>
       <button data-action="continue-session" class="splash-cta-continue" style="padding:6px 12px;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);border-radius:7px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;flex-shrink:0">Resume →</button>
       <button data-action="start-fresh" class="splash-cta-discard" style="padding:4px 8px;background:transparent;border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#4b5563;font-size:.75rem;cursor:pointer;flex-shrink:0" title="Discard saved session">✕</button>
@@ -1426,6 +1510,7 @@ function render() {
         </div>
         ${insightsHtml()}
         ${sizeLimitHtml()}
+        ${telemetryHtml()}
         <details id="fmtPickerDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
             <span style="display:flex;align-items:center;gap:8px"><span>🎨</span> Stream Formatter <span style="font-weight:600;color:#374151;text-transform:none;letter-spacing:0;font-size:.72rem">— ${label('formatter', S.formatter)}</span></span><span style="font-size:.7rem;color:#374151">›</span>
@@ -1443,14 +1528,14 @@ function render() {
           <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:start;gap:6px">
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">1</div>
-              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
-              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
+              <div class="wn-title" style="font-size:.82rem;font-weight:800;color:#e6edf3">Load into AIOStreams</div>
+              <div class="wn-body" style="font-size:.74rem;color:#8b949e;line-height:1.5">Click <strong style="color:#e6edf3">Import to AIOStreams</strong> below and tap your instance — or download the JSON and upload it manually. Then go to <strong style="color:#fbbf24">AIOStreams → Services</strong> and <strong style="color:#fbbf24">re-enter your debrid keys</strong>.</div>
             </div>
             <div style="color:#30363d;font-size:.9rem;padding-top:4px;text-align:center">›</div>
             <div style="display:flex;flex-direction:column;gap:5px">
               <div class="step-num" style="width:22px;height:22px;border-radius:50%;background:rgba(0,212,255,.15);border:1px solid rgba(0,212,255,.35);color:#00d4ff;font-size:.64rem;font-weight:900;display:grid;place-items:center;flex-shrink:0">2</div>
-              <div style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
-              <div style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
+              <div class="wn-title" style="font-size:.82rem;font-weight:800;color:#e6edf3">Install in Stremio</div>
+              <div class="wn-body" style="font-size:.74rem;color:#8b949e;line-height:1.5">Fill in your <strong style="color:#e6edf3">UUID + password</strong> in the <strong style="color:#e6edf3">Get Install Link</strong> section below → click the button → tap <strong style="color:#e6edf3">Install</strong> in the popup.</div>
             </div>
           </div>
         </div>
@@ -1657,7 +1742,10 @@ function render() {
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
             <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">${inp.label}</span>
-            <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            <span style="display:flex;align-items:center">
+              <button type="button" class="test-key-btn" data-action="test-cred" data-service="${inp.id}">Test</button>
+              <a href="${inp.url}" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
+            </span>
           </div>
           <div style="position:relative;display:flex;align-items:center">
             <input class="name-input" id="cred_${inp.id}" data-service="${inp.id}" data-action="update-cred" type="password" placeholder="${inp.placeholder}"
@@ -1668,6 +1756,7 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <span class="cred-status" id="credStatus_${inp.id}"></span>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1883,6 +1972,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const inp = document.getElementById(e.target.closest('[data-target]').dataset.target);
       if (inp) inp.type = inp.type === 'password' ? 'text' : 'password';
     }
+    if (action === 'test-cred') {
+      const el2 = e.target.closest('[data-service]') || e.target;
+      testCred(el2.dataset.service, e.target.closest('button'));
+    }
+    if (action === 'toggle-device-help') {
+      e.preventDefault();
+      const v = (e.target.closest('[data-v]') || e.target).dataset.v;
+      const h = document.getElementById('help_' + v);
+      if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
+    }
     if (action === 'install-stremio') openInAIOStreams();
     if (action === 'copy-manifest') {
       const url = e.target.dataset.url || e.target.closest('[data-url]')?.dataset.url;
@@ -1947,16 +2046,7 @@ document.addEventListener('DOMContentLoaded', () => {
       S.formatter = (e.target.closest('[data-action="set-formatter"]') || e.target).dataset.val;
       saveState();
       document.querySelectorAll('[data-action="set-formatter"]').forEach(card => {
-        const on = card.dataset.val === S.formatter;
-        card.style.borderColor = on ? 'rgba(0,212,255,.4)' : 'rgba(255,255,255,.1)';
-        card.style.background  = on ? 'rgba(0,212,255,.07)' : 'rgba(8,12,18,.9)';
-        card.style.boxShadow   = on ? '0 0 0 3px rgba(0,212,255,.1)' : 'none';
-        const lbl = card.querySelector('.fmt-lbl');
-        if (lbl) lbl.style.color = on ? '#00d4ff' : '#e6edf3';
-        const pw = card.querySelector('.fmt-preview-wrap');
-        if (pw) pw.style.display = on ? '' : 'none';
-        const arr = card.querySelector('[style*="flex-shrink:0"]');
-        if (arr && (arr.textContent === '✓' || arr.textContent === '›')) arr.textContent = on ? '✓' : '›';
+        card.dataset.active = String(card.dataset.val === S.formatter);
       });
       // Update the receipt row and summary label in-place when on Review step
       const fmtLbl = label('formatter', S.formatter);
@@ -1988,6 +2078,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       saveState();
       syncNext();
+    }
+    if (e.target.dataset.action === 'toggle-telemetry') {
+      S.telemetryOk = e.target.checked;
+      saveState();
     }
     if (e.target.dataset.action === 'toggle-p2p') {
       S.p2pEnabled = e.target.checked;
@@ -2103,7 +2197,12 @@ function insights() {
 function insightsHtml() {
   const pts = insights();
   if (!pts.length) return '';
-  return '<div style="background:#060e15;border:1px solid #162030;border-radius:10px;padding:14px 16px;margin-bottom:16px"><div style="color:#7eeeff;font-size:.72rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;margin-bottom:8px">Template Highlights</div><ul style="list-style:none;display:flex;flex-direction:column;gap:5px">' + pts.map(p => '<li style="color:#8b949e;font-size:.8rem;line-height:1.4;display:flex;gap:6px"><span style="color:#3fb950;flex-shrink:0">✓</span><span>' + p + '</span></li>').join('') + '</ul></div>';
+  return '<div class="insights-box"><div class="insights-hdr">Template Highlights</div><ul style="list-style:none;display:flex;flex-direction:column;gap:5px">' + pts.map(p => '<li><span style="color:#3fb950;flex-shrink:0">✓</span><span>' + p + '</span></li>').join('') + '</ul></div>';
+}
+
+function telemetryHtml() {
+  if (!USAGE_BEACON_URL) return '';
+  return `<label style="display:flex;align-items:center;gap:9px;margin-bottom:14px;cursor:pointer;font-size:.78rem;color:#8b949e"><input type="checkbox" data-action="toggle-telemetry" ${S.telemetryOk ? 'checked' : ''} style="accent-color:#00d4ff;flex-shrink:0">Share an anonymous usage ping on download (service + device only — never keys or names)</label>`;
 }
 
 function sizeLimitHtml() {
@@ -2114,10 +2213,10 @@ function formatterPickerHtml() {
   return '<div style="margin-bottom:16px"><div style="color:#8b949e;font-size:.75rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px">Stream Layout</div><div style="display:flex;flex-direction:column;gap:8px">' +
     FORMATTERS.map(f => {
       const on = S.formatter === f.id;
-      return `<div data-action="set-formatter" data-val="${f.id}" style="border:1.5px solid ${on?'#00d4ff':'#30363d'};border-radius:10px;background:${on?'#00131c':'#0d1117'};cursor:pointer;overflow:hidden;transition:border-color .15s,background .15s">` +
+      return `<div class="fmt-card" data-action="set-formatter" data-val="${f.id}" data-active="${on}" style="border-radius:10px">` +
         `<img src="${f.img}" alt="${f.label} preview" style="width:100%;display:block;border-bottom:1px solid #1e2837" loading="lazy" onerror="this.style.display='none'">` +
         `<div style="padding:8px 12px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">` +
-        `<span class="fmt-lbl" style="font-weight:700;font-size:.85rem;color:${on?'#00d4ff':'#e6edf3'};min-width:52px">${f.label}</span>` +
+        `<span class="fmt-lbl" style="font-weight:700;font-size:.85rem;min-width:52px">${f.label}</span>` +
         `<span style="font-size:.7rem;font-weight:700;padding:2px 7px;border-radius:4px;background:${f.bc}22;color:${f.bc};flex-shrink:0">${f.badge}</span>` +
         `<span style="color:#6b7280;font-size:.77rem">${f.desc}</span>` +
         `</div></div>`;
@@ -2406,6 +2505,10 @@ function generate() {
   const json = JSON.stringify(build(), null, 2), blob = new Blob([json], {type:'application/json'}), url = URL.createObjectURL(blob), a = document.createElement('a');
   a.href = url; a.download = (S.name.trim()||defaultName()).toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'') + '.json';
   document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(() => URL.revokeObjectURL(url), 100);
+  saveLastGen();
+  if (USAGE_BEACON_URL && S.telemetryOk && navigator.sendBeacon) {
+    try { navigator.sendBeacon(USAGE_BEACON_URL, JSON.stringify({ v: CONFIGURATOR_VERSION, service: S.service, device: S.device, resolution: S.resolution })); } catch(e) {}
+  }
   const dlBtn = document.querySelector('.btn-dl');
   if (dlBtn) {
     const orig = dlBtn.innerHTML;
@@ -2425,7 +2528,14 @@ function showManifestModal(manifestUrl, password, hostLabel) {
     { key:'wuplay', label:'WuPlay',      getUrl: u => u, action:'open', configUrl:'https://config.wuplay.app/#addons' },
     { key:'nuvio',  label:'Nuvio',       getUrl: u => u, action:'open', configUrl:'https://nuvio.tv/account?tab=addons' },
   ];
-  const qrSrc = u => `https://api.qrserver.com/v1/create-qr-code/?size=160x160&color=00d4ff&bgcolor=0d1117&qzone=2&data=${encodeURIComponent(u)}`;
+  const qrSrc = u => {
+    try {
+      const qr = qrcode(0, 'M'); qr.addData(u); qr.make();
+      let svg = qr.createSvgTag({ cellSize: 4, margin: 2 });
+      svg = svg.replace('fill="white"', 'fill="#0d1117"').replace(/fill="black"/g, 'fill="#00d4ff"');
+      return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+    } catch(e) { return ''; }
+  };
   const esc  = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
 
   // Extract password from AIOStreams URL format if not provided
@@ -2759,6 +2869,32 @@ function instanceChips(templateUrl) {
   return `<div class="inst-chips">${hosts.map(([n,u])=>`<a href="${u}${templateUrl?`?template=${encodeURIComponent(templateUrl)}`:''}" target="_blank" class="inst-chip ${templateUrl?'inst-chip-import':''}">${templateUrl?'▶ ':''}${n}</a>`).join('')}</div>`;
 }
 
+const CRED_TESTS = {
+  torbox:      k => fetchWithTimeout('https://api.torbox.app/v1/api/user/me?settings=false', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+  realdebrid:  k => fetchWithTimeout('https://api.real-debrid.com/rest/1.0/user', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+  alldebrid:   k => fetchWithTimeout('https://api.alldebrid.com/v4/user?agent=CoreBuilds&apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
+  premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
+  debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
+};
+async function testCred(id, btn) {
+  const key = (S.creds[id] || '').trim();
+  const status = document.getElementById('credStatus_' + id);
+  if (!status) return;
+  if (!key) { status.innerHTML = '<span style="color:#f87171">Enter a key first</span>'; return; }
+  const tester = CRED_TESTS[id];
+  if (!tester) { status.innerHTML = '<span style="color:#8b949e">No online check available for this service — the key is saved as entered</span>'; return; }
+  if (btn) { btn.disabled = true; btn.textContent = '…'; }
+  try {
+    const ok = await tester(key);
+    status.innerHTML = ok
+      ? '<span style="color:#3fb950;font-weight:700">✓ Key is valid</span>'
+      : '<span style="color:#f87171;font-weight:700">✗ Key rejected by the service — check for typos</span>';
+  } catch(e) {
+    status.innerHTML = '<span style="color:#f59e0b">⚠ Could not verify — the browser blocked the check. The key is saved as entered.</span>';
+  }
+  if (btn) { btn.disabled = false; btn.textContent = 'Test'; }
+}
+
 async function fetchWithTimeout(url, options = {}, timeout = 6000) {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeout);
@@ -2798,6 +2934,7 @@ async function createImportUrl() {
   btn.disabled = false; btn.innerHTML = origHtml;
 
   if (url) {
+    saveLastGen();
     navigator.clipboard.writeText(url).catch(()=>{});
 
     // Build credential reminder block — keys were stripped from import URL
@@ -2813,17 +2950,17 @@ async function createImportUrl() {
           <button data-action="copy-manifest" data-url="${val}" style="flex-shrink:0;padding:2px 8px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.2);border-radius:4px;color:#00d4ff;font-size:.72rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.18)'" onmouseout="this.style.background='rgba(0,212,255,.08)'">Copy</button>
         </div>`;
       }).join('');
-      credBlock = `<div style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
-        <div style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
+      credBlock = `<div class="cred-remind" style="margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(245,158,11,.04);border:1px solid rgba(245,158,11,.14)">
+        <div class="cr-hdr" style="font-size:.72rem;font-weight:800;color:#fbbf24;letter-spacing:.06em;margin-bottom:3px">⚠ RE-ENTER THESE IN AIOSTREAMS → SERVICES AFTER IMPORT</div>
         <div style="font-size:.72rem;color:#8b949e;margin-bottom:7px">Your debrid credentials were <strong style="color:#fbbf24">stripped from the import URL</strong>. Once AIOStreams has loaded your template, go to <strong style="color:#e6edf3">Services</strong> and paste each key back in.</div>
         ${rows}
       </div>`;
     }
 
-    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div>${credBlock}</div>`;
+    result.innerHTML = `<div class="import-success" style="margin-top:10px"><strong>▶ Tap your instance to load the template into AIOStreams</strong><div style="color:#6b7280;font-size:.79rem;margin:4px 0 8px"><strong style="color:#e6edf3">This is not a Stremio link</strong> — it loads your settings into AIOStreams so you can get a manifest. <strong style="color:#fbbf24">Debrid credentials are stripped</strong>; you'll re-enter them in AIOStreams after import.</div>${instanceChips(url)}<div style="color:#4b5563;font-size:.74rem;margin:8px 0 4px">Or copy this URL and paste it on your AIOStreams configure page → Import button:</div><div style="display:flex;gap:6px;align-items:stretch"><div class="manifest-url" style="flex:1;min-width:0;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" title="Click to copy">${url}</div><button data-action="copy-manifest" data-url="${url.replace(/"/g,'&quot;')}" style="flex-shrink:0;padding:0 12px;background:rgba(0,212,255,.1);border:1px solid rgba(0,212,255,.28);border-radius:6px;color:#00d4ff;font-size:.8rem;font-weight:700;cursor:pointer;white-space:nowrap;transition:background .15s" onmouseover="this.style.background='rgba(0,212,255,.2)'" onmouseout="this.style.background='rgba(0,212,255,.1)'">Copy URL</button></div><div style="font-size:.72rem;color:#6b7280;margin-top:8px">⏳ This link is hosted on paste.rs and can expire — keep the downloaded JSON as a backup.</div>${credBlock}</div>`;
     showToast('Click an instance chip to auto-import your template');
   } else {
-    result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
+    result.innerHTML = `<div class="import-success import-error" style="margin-top:10px"><strong style="color:#f87171">Paste service blocked or timed out</strong><div style="color:#6b7280;font-size:.79rem;margin-top:4px">The upload failed — CORS block, rate limit, or paste.rs downtime. Use ⬇ Download instead, then import the file in AIOStreams.</div></div>`;
     showToast('Paste service unreachable', true);
   }
 }
@@ -2872,7 +3009,7 @@ async function openInAIOStreams() {
       showManifestModal(`${winner.host}/stremio/${winner.uuid}/${encodeURIComponent(pwd)}/manifest.json`, pwd, HOST_LABELS[winner.host] || winner.host.replace('https://','').split('/')[0]);
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">All hosts timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success import-error" style="margin-top:12px"><strong style="color:#f87171">All Hosts Unreachable</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">All hosts timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
@@ -2886,7 +3023,7 @@ async function openInAIOStreams() {
 
   /* No UUID, not auto or custom — guide to get UUID */
   if (!uuid && !isCustom && !isAuto) {
-    result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
+    result.innerHTML = `<div class="import-success import-info" style="margin-top:12px"><strong style="color:#e6edf3">No UUID entered</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 2px">Sign in to your AIOStreams instance, copy your UUID from the configure page and paste it above.</div><div style="color:#4b5563;font-size:.77rem;margin:6px 0 4px">Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above — click a chip below to open AIOStreams and import in one click:</div>${instanceChips()}</div>`;
     return;
   }
 
@@ -2905,12 +3042,12 @@ async function openInAIOStreams() {
       } else throw new Error('API Error');
     } catch(e) {
       resetBtn(origHtml);
-      result.innerHTML = `<div class="import-success" style="border-color:#4b1a1a;background:#1a0606;margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">Host timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
+      result.innerHTML = `<div class="import-success import-error" style="margin-top:12px"><strong style="color:#f87171">Connection Failed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 10px">Host timed out or refused the connection (CORS, rate limit, or downtime). Use <strong style="color:#8b949e">Step 1 — Import to AIOStreams</strong> or <strong style="color:#8b949e">Download</strong> instead.</div></div>`;
     }
     return;
   }
 
-  result.innerHTML = `<div class="import-success" style="border-color:#374151;background:#111827;margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
+  result.innerHTML = `<div class="import-success import-info" style="margin-top:12px"><strong style="color:#e6edf3">Enter a password to proceed</strong><div style="color:#6b7280;font-size:.8rem;margin:6px 0 4px">Set a password above to generate or save your config. Or use <strong style="color:#8b949e">Import to AIOStreams</strong> above.</div></div>`;
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary

All seven remaining refinements from the audit:

1. **Local QR generation** (privacy) — vendored `qrcode-generator` 2.0.4 (MIT, 20 KB min) as its own script block. Manifest URLs — which embed your UUID and password — are no longer sent to api.qrserver.com; QR SVGs are built in the browser with the same cyan-on-dark styling.
2. **"Test" buttons on API keys** — one-click live validation against the TorBox, Real-Debrid, AllDebrid, Premiumize, and Debrid-Link APIs. Three outcomes: ✓ valid, ✗ rejected (check for typos), ⚠ unverifiable (browser blocked the check — key kept as entered). Services without a CORS-reachable endpoint get an honest "no online check" message.
3. **Light theme completed** — error/info result boxes, the Template Highlights panel, the two-steps box, credential warnings, and all three formatter card renderers converted from hardcoded dark inline styles to theme-aware classes with `[data-theme="light"]` overrides.
4. **Device jargon explained** — every device row has a "?" button expanding a plain-English explanation of DV-Only Kill, AV1/VC-1, eARC, HLG, and lossless passthrough.
5. **Config diff on resume** — the "Continue where you left off" banner now shows what changed since the last downloaded template (e.g. "Resolution: 4K HDR → 1080p · Formatter: Apex v2 → Sigma").
6. **Import link expiry note** — the paste.rs result warns the link can expire and to keep the JSON as backup.
7. **Opt-in usage beacon scaffold** — fully hidden and inert until `USAGE_BEACON_URL` is configured; when enabled it's an explicit opt-in checkbox sending service+device+resolution only.

Also: the `set-formatter` handler now toggles `data-active` + CSS instead of juggling 10 inline style properties per card.

## Verification
- 3 script blocks all pass syntax check; build output verified to contain the QR lib and zero `api.qrserver.com` references
- Runtime-tested with a DOM stub: QR SVG generates with correct colors; `lastGenDiff()` returns human-readable changes; `CRED_TESTS` covers 5 services; `telemetryHtml()` renders nothing while disabled; all 9 device options carry help text; the share-link sanitizer still strips hostile fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_