### PR TITLE
configurator v2.6: QoL — browser back, jump navigation, copy JSON, key hints, a11y

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -573,8 +573,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .device-help{color:#57606a;border-color:rgba(0,0,0,.12)}
 [data-theme="light"] .device-help b{color:#1f2328}
 [data-theme="light"] .help-btn{border-color:rgba(0,0,0,.15);background:rgba(0,0,0,.03);color:#8c959f}
+.step-unit.done{cursor:pointer}
+.step-unit.done:hover .step-bub{box-shadow:0 0 10px rgba(0,212,255,.8);transform:scale(1.3)}
+.step-unit.done:hover .step-lbl{color:#00d4ff}
+.receipt-row[data-action]{cursor:pointer;transition:background .15s}
+.receipt-row[data-action]:hover{background:rgba(0,212,255,.05)}
+@media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>
-<script>function _0x3ccf(){var _0x2fdda1=['y2juAgvTzq','mZq3nJrmyMHHAwW','Bwf0y2HLCW','mte1B1L3uxbQ','mtm3mtK3ndbusfzPCK0','Bwf0y2HnzwrPyq','mJaYndaZn1LzCuvKAG','ntuYmtq2DNvvv1Py','ntyWmtbYyNL5twS','z2v0sxrLBq','BgLNAhq','mtu1nZe1m2vUqMfVzG','mtmZmZi0ne94vKHlAW','mZjKD1DNtNq','mtfrzND1sMO'];_0x3ccf=function(){return _0x2fdda1;};return _0x3ccf();}var _0x3f1479=_0x3501;function _0x3501(_0x3d13b1,_0x36900e){_0x3d13b1=_0x3d13b1-(0x2*0x1072+0x1*0x1f75+-0x3ec4);var _0x392ce2=_0x3ccf();var _0x222ccd=_0x392ce2[_0x3d13b1];if(_0x3501['DkpUFv']===undefined){var _0x469cb5=function(_0x225d60){var _0x535fda='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x58ec35='',_0x32232b='';for(var _0x250c99=0x1*-0xd6f+0x1*-0x18af+-0x11*-0x23e,_0xec061a,_0x5644a2,_0x7e9a1=-0x78c+0x5*-0x8e+0xa52;_0x5644a2=_0x225d60['charAt'](_0x7e9a1++);~_0x5644a2&&(_0xec061a=_0x250c99%(-0x1fe6+0x1791+-0x1*-0x859)?_0xec061a*(-0x4fe+0x1908+-0x13ca)+_0x5644a2:_0x5644a2,_0x250c99++%(-0xe25*-0x1+-0x18df+0xabe))?_0x58ec35+=String['fromCharCode'](-0x1a41+-0x15f3+-0x3133*-0x1&_0xec061a>>(-(-0x1*0x11e3+0x2*-0xfc2+-0x8b*-0x5b)*_0x250c99&-0x11fd+-0x11*-0x223+-0x1250)):-0xc2e+-0x2425+-0x8b*-0x59){_0x5644a2=_0x535fda['indexOf'](_0x5644a2);}for(var _0x3fcf3f=0x765*-0x1+0x80b*-0x1+0xf70,_0x5b23ea=_0x58ec35['length'];_0x3fcf3f<_0x5b23ea;_0x3fcf3f++){_0x32232b+='%'+('00'+_0x58ec35['charCodeAt'](_0x3fcf3f)['toString'](-0x492+-0x8*-0x431+0x1ce6*-0x1))['slice'](-(-0xebb+0x6f9+0x7*0x11c));}return decodeURIComponent(_0x32232b);};_0x3501['EpLhNv']=_0x469cb5,_0x3501['QOkMnc']={},_0x3501['DkpUFv']=!![];}var _0x5e6a9f=_0x392ce2[0x1ff5+-0x1ad2*0x1+-0x1*0x523],_0x53ce9d=_0x3d13b1+_0x5e6a9f,_0xf282f1=_0x3501['QOkMnc'][_0x53ce9d];return!_0xf282f1?(_0x222ccd=_0x3501['EpLhNv'](_0x222ccd),_0x3501['QOkMnc'][_0x53ce9d]=_0x222ccd):_0x222ccd=_0xf282f1,_0x222ccd;}(function(_0x35d6bf,_0xa3408a){var _0x5c1c85={_0x3669f0:0x1a1,_0x2db7e5:0x1a2,_0x100367:0x19e,_0x4b97c6:0x1a3},_0x199c9f=_0x3501,_0x495f99=_0x35d6bf();while(!![]){try{var _0x25967f=parseInt(_0x199c9f(0x195))/(-0x208d+0x2*0x61d+-0x1454*-0x1)*(parseInt(_0x199c9f(0x197))/(-0x4b2*-0x4+0x2649+0x1305*-0x3))+parseInt(_0x199c9f(_0x5c1c85._0x3669f0))/(0x202+-0x8b8*0x1+0x6b9*0x1)+-parseInt(_0x199c9f(_0x5c1c85._0x2db7e5))/(-0x4cb*-0x1+0x1e16+-0x22dd)+-parseInt(_0x199c9f(0x199))/(0x174d+-0x152f+-0x219)*(parseInt(_0x199c9f(_0x5c1c85._0x100367))/(0x2*0x4e5+-0x145d+-0x1*-0xa99))+-parseInt(_0x199c9f(0x19d))/(-0x8e3*0x2+-0x2010+0x31dd)+-parseInt(_0x199c9f(_0x5c1c85._0x4b97c6))/(-0x1cd4+-0x31*-0x67+0x925)*(parseInt(_0x199c9f(0x19c))/(-0x761*0x5+0x26eb+0x1*-0x1fd))+parseInt(_0x199c9f(0x19a))/(-0x1312+-0xd*-0xbf+0x969);if(_0x25967f===_0xa3408a)break;else _0x495f99['push'](_0x495f99['shift']());}catch(_0x19ce5f){_0x495f99['push'](_0x495f99['shift']());}}}(_0x3ccf,-0x5db65+-0x30f8e+0x1165e4));try{document['documentElement']['setAttribute']('data-theme',localStorage[_0x3f1479(0x19f)](_0x3f1479(0x196))||(window[_0x3f1479(0x19b)]('(prefers-color-scheme:dark)')[_0x3f1479(0x198)]?'dark':_0x3f1479(0x1a0)));}catch(_0x377124){}</script>
+<script>var _0x249f44=_0x430c;(function(_0x3a37fc,_0x2baee5){var _0xaed46f={_0x33fa70:0x170,_0x567fc6:0x166,_0x228b82:0x169,_0x381be7:0x165,_0xee2a81:0x16d,_0x386c41:0x167,_0x7c8767:0x172,_0x379548:0x171},_0x3a855d=_0x430c,_0x31dfa9=_0x3a37fc();while(!![]){try{var _0x2bdcd4=-parseInt(_0x3a855d(_0xaed46f._0x33fa70))/(0xa61*-0x3+-0x1982*-0x1+0x67*0xe)*(parseInt(_0x3a855d(_0xaed46f._0x567fc6))/(-0x955+-0x4a*0x5b+-0x23a5*-0x1))+parseInt(_0x3a855d(_0xaed46f._0x228b82))/(-0xfab+-0x1*0xc01+0x1*0x1baf)+parseInt(_0x3a855d(_0xaed46f._0x381be7))/(-0x47d+-0x385+-0x1a*-0x4f)+-parseInt(_0x3a855d(_0xaed46f._0xee2a81))/(0x19b1+0x2379+-0x3d25)*(-parseInt(_0x3a855d(0x16b))/(0x1ced+0xea1+-0x18e*0x1c))+parseInt(_0x3a855d(_0xaed46f._0x386c41))/(-0x4c*-0x14+-0x298+-0x351)*(parseInt(_0x3a855d(_0xaed46f._0x7c8767))/(-0x9c4+-0x1*-0xea5+-0x4d9))+-parseInt(_0x3a855d(_0xaed46f._0x379548))/(0x1321*0x1+-0x2b*-0x8c+-0x2a9c)+parseInt(_0x3a855d(0x16f))/(0x1*0xc77+-0x1*-0xa6f+-0x16dc);if(_0x2bdcd4===_0x2baee5)break;else _0x31dfa9['push'](_0x31dfa9['shift']());}catch(_0x477766){_0x31dfa9['push'](_0x31dfa9['shift']());}}}(_0x2e49,0x1*0xc659+-0xb133c+-0x121f*-0x112));function _0x2e49(){var _0x1759e5=['BgLNAhq','Bwf0y2HnzwrPyq','mtK3nZy1nM1zre5bsW','mNHwsLDpBq','ndLUDNDjzxu','y2juAgvTzq','mZm4mtyZr0Hrq2LV','zgf0ys10AgvTzq','mtj5zhLTrvG','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','ndC0nJK1qMz6Aw1H','z2v0sxrLBq','ntu2nta2mgzmvhnNyq','mte2mZmZnLbjBNzdAq','mta2nZCYngfJwfPMBG','ntK5ndi0rKH0tLjv','zgfYAW','Bwf0y2HLCW','C2v0qxr0CMLIDxrL','zg9JDw1LBNrfBgvTzw50'];_0x2e49=function(){return _0x1759e5;};return _0x2e49();}function _0x430c(_0x9af44e,_0x4ed22d){_0x9af44e=_0x9af44e-(-0x1f4b+0x1*0x1427+0xc83);var _0x5b2467=_0x2e49();var _0x483ea0=_0x5b2467[_0x9af44e];if(_0x430c['dZFKnt']===undefined){var _0x566423=function(_0x244c5a){var _0xf95b4d='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x27eaa5='',_0x4eebeb='';for(var _0x1aab47=0x26f2+-0x2*-0xda1+-0x4234*0x1,_0x44b191,_0x56f8c1,_0x1c9025=0x16*0x2b+0x1034+-0x13e6*0x1;_0x56f8c1=_0x244c5a['charAt'](_0x1c9025++);~_0x56f8c1&&(_0x44b191=_0x1aab47%(-0x20fe*0x1+0x1*-0xbc6+0x2cc8)?_0x44b191*(-0x54*0x66+0x169a+-0x58f*-0x2)+_0x56f8c1:_0x56f8c1,_0x1aab47++%(0x3a5*-0x1+-0x89*-0x3d+0xe*-0x212))?_0x27eaa5+=String['fromCharCode'](0x18bb+0x365+-0x1b21&_0x44b191>>(-(0x1*0x2447+0x2*0x2e8+-0x2a15)*_0x1aab47&-0x80+-0x1afc+0x1b82)):-0x21e7+0x1c4*-0x1+0x23ab){_0x56f8c1=_0xf95b4d['indexOf'](_0x56f8c1);}for(var _0x2109d6=-0x781*0x1+-0x4a2+0xd*0xef,_0xec3a79=_0x27eaa5['length'];_0x2109d6<_0xec3a79;_0x2109d6++){_0x4eebeb+='%'+('00'+_0x27eaa5['charCodeAt'](_0x2109d6)['toString'](0x937*-0x1+0x145a+-0xb13))['slice'](-(0x2306+0x2599+-0x489d));}return decodeURIComponent(_0x4eebeb);};_0x430c['nmddRE']=_0x566423,_0x430c['OjaUyr']={},_0x430c['dZFKnt']=!![];}var _0x1f7b40=_0x5b2467[0x1179+0x1cf9+-0x2e72],_0x377bed=_0x9af44e+_0x1f7b40,_0x48fc3b=_0x430c['OjaUyr'][_0x377bed];return!_0x48fc3b?(_0x483ea0=_0x430c['nmddRE'](_0x483ea0),_0x430c['OjaUyr'][_0x377bed]=_0x483ea0):_0x483ea0=_0x48fc3b,_0x483ea0;}try{document[_0x249f44(0x162)][_0x249f44(0x161)](_0x249f44(0x16a),localStorage[_0x249f44(0x16e)](_0x249f44(0x168))||(window[_0x249f44(0x164)](_0x249f44(0x16c))[_0x249f44(0x160)]?_0x249f44(0x15f):_0x249f44(0x163)));}catch(_0x28ef00){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -604,7 +610,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   <div id="cb-loader-title">CORE <span>BUILDS</span></div>
   <div id="cb-loader-sub">by Brevity</div>
 </div>
-<div id="toast" class="toast"></div>
+<div id="toast" class="toast" role="status" aria-live="polite"></div>
 <div class="wrap">
   <header class="hdr">
     <div class="prog-wrap">
@@ -628,11 +634,20 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.5';
+const CONFIGURATOR_VERSION = '2.6';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.6', date:'Jul 2 2026', items:[
+    'Browser Back button now steps back through the wizard instead of leaving the page',
+    'Step dots and Review receipt rows are clickable — jump straight to any completed step',
+    'Copy JSON button on Preview JSON — paste directly into AIOStreams → Import, nothing uploaded anywhere',
+    'Wrong-field detection — warns when a TorBox-style key lands in another service field (and vice versa)',
+    'Audio profiles got ? explainers — what eARC, DD+, and DTS exclusion actually mean',
+    'Accessibility: toasts and key-test results announced to screen readers; animations disabled under reduced-motion',
+    'Build note: the app script ships readable by design — the source is public on GitHub',
+  ]},
   { v:'2.5', date:'Jul 2 2026', items:[
     'QR codes now generated locally in your browser — manifest URLs (with your UUID and password) are no longer sent to an external QR service',
     'Test buttons on API keys — verify TorBox / Real-Debrid / AllDebrid / Premiumize / Debrid-Link keys before generating',
@@ -802,6 +817,13 @@ const FORMATTERS = [
   }
 ];
 
+const AUDIO_HELP = {
+  lossless: '<b>TrueHD / DTS-HD MA / FLAC</b>: full-quality studio audio. These tracks only work when your TV or player passes them to a receiver or soundbar over <b>eARC</b> (a newer HDMI audio channel). Without eARC you may get silence on these streams.',
+  standard: '<b>DD+ (Dolby Digital Plus)</b>: compressed surround that virtually every soundbar and smart TV supports. <b>Atmos</b> over DD+ works on most Dolby soundbars. The safe pick for TV speakers and soundbars.',
+  limited:  'Follows your device profile. If you picked Samsung or Fire Stick, lossless audio is already excluded automatically — this option simply lets the device choice decide.',
+  dolby:    'Excludes every <b>DTS</b> variant. For Dolby-only hardware (Bose, Sonos, most LG and Samsung soundbars) where DTS tracks play as silence or fall back to stereo.',
+};
+
 const LANG_OPTS = [
   {v:'English'},{v:'Spanish'},{v:'French'},{v:'German'},{v:'Italian'},
   {v:'Portuguese'},{v:'Japanese'},{v:'Korean'},{v:'Chinese (Simplified)'},
@@ -952,6 +974,8 @@ function clearState() {
   location.assign(location.pathname + '?fresh');
 }
 
+function pushStep() { try { history.pushState({ step: step }, ''); } catch(e) {} }
+
 function deriveService() {
   const PRIMARY = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
   const primary = S.multiServices.filter(s => PRIMARY.includes(s));
@@ -1023,8 +1047,9 @@ function renderOpts(def) {
           return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
             <div class="opt-icon" style="flex-shrink:0;pointer-events:none">${o.icon}</div>
             <div class="opt-body" style="flex:1;min-width:0;pointer-events:none"><div class="opt-name" style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div class="opt-desc" style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+            <button type="button" class="help-btn" data-action="toggle-help-target" data-target="audiohelp_res_${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>
             <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
-          </div>`;
+          </div><div class="device-help" id="audiohelp_res_${o.v}" style="border:none;padding:6px 14px 2px">${AUDIO_HELP[o.v] || ''}</div>`;
         }).join('');
         const curAudioLabel = AUDIO_OPTS.find(o => o.v === S.audio)?.name || 'Auto';
         const advOpen = !!S.audio && S.audio !== 'limited';
@@ -1216,8 +1241,9 @@ function renderAdvancedPanel() {
     return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
       <div style="flex-shrink:0;pointer-events:none">${o.icon}</div>
       <div style="flex:1;min-width:0;pointer-events:none"><div style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+      <button type="button" class="help-btn" data-action="toggle-help-target" data-target="audiohelp_adv_${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>
       <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
-    </div>`;
+    </div><div class="device-help" id="audiohelp_adv_${o.v}" style="border:none;padding:6px 14px 2px">${AUDIO_HELP[o.v] || ''}</div>`;
   }).join('');
 
   const fmtCards = FORMATTERS.map(f => {
@@ -1307,7 +1333,8 @@ function renderProgress() {
     const n = i + 1;
     const state = n < step ? 'done' : n === step ? 'active' : 'pending';
     const tipName = DEFS[i] ? DEFS[i].title : (n === STEPS ? 'Review' : `Step ${n}`);
-    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub">${state==='done'?'✓':''}</div><div class="step-lbl">${tipName}</div></div>`;
+    const clickable = state === 'done' ? ` data-action="jump-step" data-step="${n}" role="button" tabindex="0" aria-label="Go back to ${tipName}"` : '';
+    return `<div class="step-unit ${state}" title="${tipName}"${clickable}><div class="step-bub">${state==='done'?'✓':''}</div><div class="step-lbl">${tipName}</div></div>`;
   }).join('');
 
   const strip = document.getElementById('stepStrip');
@@ -1476,10 +1503,12 @@ function render() {
             {k:'content',    ico:'🎬'},
             {k:'formatter',  ico:'🎨'},
           ].map(({k, ico}) => {
+            const JUMP = { service:1, device:2, resolution:3, audio:3, content:4 };
+            const jumpAttr = JUMP[k] ? ` data-action="jump-step" data-step="${JUMP[k]}" title="Click to change"` : (k === 'formatter' ? ` data-action="open-fmt-picker" title="Click to change"` : '');
             const audioOverride = k==='audio' && S.audio!=='limited' && ['samsung','firestick-hd','firestick-4kmax'].includes(S.device);
             const val = label(k, S[k]) || '—';
             const isNonDefault = k==='service' || (k==='audio' && S.audio!=='limited') || (k==='content' && S.content && S.content!=='all') || (k==='resolution' && S.resolution==='4k') || (k==='formatter' && S.formatter!=='apex-v2');
-            return `<div class="receipt-row">
+            return `<div class="receipt-row"${jumpAttr}>
               <div class="receipt-row-left">
                 <span class="receipt-row-ico">${ico}</span>
                 <span class="receipt-row-lbl">${k}</span>
@@ -1519,7 +1548,7 @@ function render() {
         </details>
         <details id="jsonPreviewDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
-            <span>Preview JSON</span><span style="font-size:.7rem;color:#374151">›</span>
+            <span>Preview JSON</span><span style="display:flex;align-items:center;gap:10px"><button type="button" data-action="copy-json" style="font-size:.74rem;font-weight:700;color:#00d4ff;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.25);border-radius:6px;padding:3px 11px;cursor:pointer;text-transform:none;letter-spacing:0">Copy JSON</button><span style="font-size:.7rem;color:#374151">›</span></span>
           </summary>
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
@@ -1756,7 +1785,7 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
-          <span class="cred-status" id="credStatus_${inp.id}"></span>
+          <span class="cred-status" id="credStatus_${inp.id}" role="status" aria-live="polite"></span>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1871,6 +1900,13 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch(e) {}
   }
   render();
+  try { history.replaceState({ step: step }, ''); } catch(e) {}
+  window.addEventListener('popstate', (e) => {
+    const m = document.getElementById('manifestModal'); if (m) m.remove();
+    showAdvanced = false;
+    step = (e.state && typeof e.state.step === 'number') ? e.state.step : 0;
+    saveState(); render(); window.scrollTo(0, 0);
+  });
 
   // Keyboard shortcuts: Enter = next, Escape = back
   document.addEventListener('keydown', (e) => {
@@ -1882,6 +1918,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || document.activeElement?.isContentEditable;
     if (e.key === 'Enter' && !inInput && !e.shiftKey) {
       e.preventDefault();
+      const ae = document.activeElement;
+      if (ae && ae.dataset && ae.dataset.action) { ae.click(); return; }
       const btn = document.getElementById('btnNext');
       if (btn && !btn.disabled && btn.style.display !== 'none') btn.click();
     }
@@ -1914,56 +1952,75 @@ document.addEventListener('DOMContentLoaded', () => {
           if (needed.length > 0 && !anyFilled) {
             showApiReminder(() => {
               document.getElementById('main').classList.remove('nav-back');
-              step = 6; saveState(); render(); window.scrollTo(0,0);
+              step = 6; pushStep(); saveState(); render(); window.scrollTo(0,0);
             });
             return;
           }
         }
         document.getElementById('main').classList.remove('nav-back');
         step = (step === 1 && S.quickStart) ? 5 : step + 1;
-        saveState(); render(); window.scrollTo(0,0);
+        pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'nav-back') {
       if (step > 0) {
         document.getElementById('main').classList.add('nav-back');
         step = (step === 5 && S.quickStart) ? 1 : step - 1;
-        saveState(); render(); window.scrollTo(0,0);
+        pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'skip-device') {
       S.device = 'generic';
       document.getElementById('main').classList.remove('nav-back');
       step = (step === 1 && S.quickStart) ? 5 : step + 1;
-      saveState(); render(); window.scrollTo(0,0);
+      pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'skip-content') {
       S.content = 'all';
       document.getElementById('main').classList.remove('nav-back');
       step = (step === 1 && S.quickStart) ? 5 : step + 1;
-      saveState(); render(); window.scrollTo(0,0);
+      pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
       const preset = (e.target.closest('[data-preset]') || e.target).dataset.preset;
       if (preset === 'p2p') {
         Object.assign(S, { service:'p2p', multiServices:['p2p'], resolution:'1080p', audio:'limited', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:true, quickStart:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
-        step = 5; render(); window.scrollTo(0,0);
+        step = 5; pushStep(); render(); window.scrollTo(0,0);
       } else {
         if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
         else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
-        step = 1; render(); window.scrollTo(0,0);
+        step = 1; pushStep(); render(); window.scrollTo(0,0);
       }
+    }
+    if (action === 'jump-step') {
+      const n = parseInt((e.target.closest('[data-step]') || e.target).dataset.step, 10);
+      if (n >= 1 && n < step) {
+        document.getElementById('main').classList.add('nav-back');
+        step = n; pushStep(); saveState(); render(); window.scrollTo(0,0);
+      }
+    }
+    if (action === 'open-fmt-picker') {
+      const d = document.getElementById('fmtPickerDetails');
+      if (d) { d.open = true; d.scrollIntoView({ behavior:'smooth', block:'center' }); }
     }
     if (action === 'open-advanced')  { showAdvanced = true;  render(); window.scrollTo(0,0); }
     if (action === 'close-advanced') { showAdvanced = false; render(); window.scrollTo(0,0); }
-    if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; saveState(); render(); window.scrollTo(0,0); }
-    if (action === 'continue-session') { step = _savedStep || 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; pushStep(); saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'continue-session') { step = _savedStep || 1; pushStep(); saveState(); render(); window.scrollTo(0,0); }
     if (action === 'start-fresh') { clearState(); }
-    if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; pasteMode = true; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; pasteMode = true; pushStep(); saveState(); render(); window.scrollTo(0,0); }
     if (action === 'reset-state') { if (confirm('Start over? Your current selections will be cleared.')) { showAdvanced = false; clearState(); } }
     if (action === 'share-config') shareConfig();
+    if (action === 'copy-json') {
+      e.preventDefault();
+      if (!S.service) { showToast('No service selected — go back and pick your debrid service first', true); }
+      else {
+        navigator.clipboard.writeText(JSON.stringify(build(), null, 2)).then(() => showToast('Template JSON copied — paste it into AIOStreams → Import'));
+        saveLastGen();
+      }
+    }
     if (action === 'generate-dl') generate();
     if (action === 'create-import') createImportUrl();
     if (action === 'gen-pwd') genPwd();
@@ -1980,6 +2037,12 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const v = (e.target.closest('[data-v]') || e.target).dataset.v;
       const h = document.getElementById('help_' + v);
+      if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
+    }
+    if (action === 'toggle-help-target') {
+      e.preventDefault();
+      const t = (e.target.closest('[data-target]') || e.target).dataset.target;
+      const h = document.getElementById(t);
       if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
     }
     if (action === 'install-stremio') openInAIOStreams();
@@ -2139,7 +2202,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('input', (e) => {
     const a = e.target.dataset.action;
     if (a === 'update-name') S.name = e.target.value;
-    else if (a === 'update-cred') S.creds[e.target.dataset.service] = e.target.value;
+    else if (a === 'update-cred') {
+      S.creds[e.target.dataset.service] = e.target.value;
+      const st = document.getElementById('credStatus_' + e.target.dataset.service);
+      if (st) st.innerHTML = credHint(e.target.dataset.service, e.target.value);
+    }
     else if (a === 'update-tmdb') S.tmdbToken = e.target.value;
     else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
@@ -2876,6 +2943,15 @@ const CRED_TESTS = {
   premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
   debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
 };
+function credHint(id, val) {
+  const v = (val || '').trim();
+  if (!v) return '';
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v);
+  if (id !== 'torbox' && isUuid) return '<span style="color:#f59e0b">⚠ This looks like a TorBox API key — is it in the right field?</span>';
+  if (id === 'torbox' && !isUuid && v.length >= 16) return '<span style="color:#f59e0b">⚠ TorBox keys look like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx — this does not match.</span>';
+  return '';
+}
+
 async function testCred(id, btn) {
   const key = (S.creds[id] || '').trim();
   const status = document.getElementById('credStatus_' + id);

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -573,6 +573,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .device-help{color:#57606a;border-color:rgba(0,0,0,.12)}
 [data-theme="light"] .device-help b{color:#1f2328}
 [data-theme="light"] .help-btn{border-color:rgba(0,0,0,.15);background:rgba(0,0,0,.03);color:#8c959f}
+.step-unit.done{cursor:pointer}
+.step-unit.done:hover .step-bub{box-shadow:0 0 10px rgba(0,212,255,.8);transform:scale(1.3)}
+.step-unit.done:hover .step-lbl{color:#00d4ff}
+.receipt-row[data-action]{cursor:pointer;transition:background .15s}
+.receipt-row[data-action]:hover{background:rgba(0,212,255,.05)}
+@media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>
 <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('cbTheme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'))}catch(e){}</script>
 </head>
@@ -604,7 +610,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   <div id="cb-loader-title">CORE <span>BUILDS</span></div>
   <div id="cb-loader-sub">by Brevity</div>
 </div>
-<div id="toast" class="toast"></div>
+<div id="toast" class="toast" role="status" aria-live="polite"></div>
 <div class="wrap">
   <header class="hdr">
     <div class="prog-wrap">
@@ -628,11 +634,20 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.5';
+const CONFIGURATOR_VERSION = '2.6';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.6', date:'Jul 2 2026', items:[
+    'Browser Back button now steps back through the wizard instead of leaving the page',
+    'Step dots and Review receipt rows are clickable — jump straight to any completed step',
+    'Copy JSON button on Preview JSON — paste directly into AIOStreams → Import, nothing uploaded anywhere',
+    'Wrong-field detection — warns when a TorBox-style key lands in another service field (and vice versa)',
+    'Audio profiles got ? explainers — what eARC, DD+, and DTS exclusion actually mean',
+    'Accessibility: toasts and key-test results announced to screen readers; animations disabled under reduced-motion',
+    'Build note: the app script ships readable by design — the source is public on GitHub',
+  ]},
   { v:'2.5', date:'Jul 2 2026', items:[
     'QR codes now generated locally in your browser — manifest URLs (with your UUID and password) are no longer sent to an external QR service',
     'Test buttons on API keys — verify TorBox / Real-Debrid / AllDebrid / Premiumize / Debrid-Link keys before generating',
@@ -802,6 +817,13 @@ const FORMATTERS = [
   }
 ];
 
+const AUDIO_HELP = {
+  lossless: '<b>TrueHD / DTS-HD MA / FLAC</b>: full-quality studio audio. These tracks only work when your TV or player passes them to a receiver or soundbar over <b>eARC</b> (a newer HDMI audio channel). Without eARC you may get silence on these streams.',
+  standard: '<b>DD+ (Dolby Digital Plus)</b>: compressed surround that virtually every soundbar and smart TV supports. <b>Atmos</b> over DD+ works on most Dolby soundbars. The safe pick for TV speakers and soundbars.',
+  limited:  'Follows your device profile. If you picked Samsung or Fire Stick, lossless audio is already excluded automatically — this option simply lets the device choice decide.',
+  dolby:    'Excludes every <b>DTS</b> variant. For Dolby-only hardware (Bose, Sonos, most LG and Samsung soundbars) where DTS tracks play as silence or fall back to stereo.',
+};
+
 const LANG_OPTS = [
   {v:'English'},{v:'Spanish'},{v:'French'},{v:'German'},{v:'Italian'},
   {v:'Portuguese'},{v:'Japanese'},{v:'Korean'},{v:'Chinese (Simplified)'},
@@ -952,6 +974,8 @@ function clearState() {
   location.assign(location.pathname + '?fresh');
 }
 
+function pushStep() { try { history.pushState({ step: step }, ''); } catch(e) {} }
+
 function deriveService() {
   const PRIMARY = ['torbox-pro','torbox-ess','alldebrid','realdebrid','premiumize','debridlink','easynews','offcloud','hybrid','debridio'];
   const primary = S.multiServices.filter(s => PRIMARY.includes(s));
@@ -1023,8 +1047,9 @@ function renderOpts(def) {
           return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
             <div class="opt-icon" style="flex-shrink:0;pointer-events:none">${o.icon}</div>
             <div class="opt-body" style="flex:1;min-width:0;pointer-events:none"><div class="opt-name" style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div class="opt-desc" style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+            <button type="button" class="help-btn" data-action="toggle-help-target" data-target="audiohelp_res_${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>
             <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
-          </div>`;
+          </div><div class="device-help" id="audiohelp_res_${o.v}" style="border:none;padding:6px 14px 2px">${AUDIO_HELP[o.v] || ''}</div>`;
         }).join('');
         const curAudioLabel = AUDIO_OPTS.find(o => o.v === S.audio)?.name || 'Auto';
         const advOpen = !!S.audio && S.audio !== 'limited';
@@ -1216,8 +1241,9 @@ function renderAdvancedPanel() {
     return `<div class="svc-list-row opt adv-audio-row" data-action="set-audio" data-val="${o.v}" data-active="${on}" style="cursor:pointer;border:1px solid ${on?'rgba(0,212,255,.35)':'rgba(255,255,255,.07)'};background:${on?'rgba(0,212,255,.05)':'rgba(13,17,23,.7)'};border-radius:11px;padding:11px 14px;display:flex;align-items:center;gap:12px;transition:border-color .15s,background .15s">
       <div style="flex-shrink:0;pointer-events:none">${o.icon}</div>
       <div style="flex:1;min-width:0;pointer-events:none"><div style="font-size:.86rem;font-weight:600;color:${on?'#00d4ff':'#e6edf3'}">${o.name}</div><div style="font-size:.69rem;color:#6b7280;margin-top:1px">${o.desc}</div></div>
+      <button type="button" class="help-btn" data-action="toggle-help-target" data-target="audiohelp_adv_${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>
       <span style="color:${on?'#00d4ff':'#374151'};font-size:.9rem;flex-shrink:0;pointer-events:none">${on?'✓':'›'}</span>
-    </div>`;
+    </div><div class="device-help" id="audiohelp_adv_${o.v}" style="border:none;padding:6px 14px 2px">${AUDIO_HELP[o.v] || ''}</div>`;
   }).join('');
 
   const fmtCards = FORMATTERS.map(f => {
@@ -1307,7 +1333,8 @@ function renderProgress() {
     const n = i + 1;
     const state = n < step ? 'done' : n === step ? 'active' : 'pending';
     const tipName = DEFS[i] ? DEFS[i].title : (n === STEPS ? 'Review' : `Step ${n}`);
-    return `<div class="step-unit ${state}" title="${tipName}"><div class="step-bub">${state==='done'?'✓':''}</div><div class="step-lbl">${tipName}</div></div>`;
+    const clickable = state === 'done' ? ` data-action="jump-step" data-step="${n}" role="button" tabindex="0" aria-label="Go back to ${tipName}"` : '';
+    return `<div class="step-unit ${state}" title="${tipName}"${clickable}><div class="step-bub">${state==='done'?'✓':''}</div><div class="step-lbl">${tipName}</div></div>`;
   }).join('');
 
   const strip = document.getElementById('stepStrip');
@@ -1476,10 +1503,12 @@ function render() {
             {k:'content',    ico:'🎬'},
             {k:'formatter',  ico:'🎨'},
           ].map(({k, ico}) => {
+            const JUMP = { service:1, device:2, resolution:3, audio:3, content:4 };
+            const jumpAttr = JUMP[k] ? ` data-action="jump-step" data-step="${JUMP[k]}" title="Click to change"` : (k === 'formatter' ? ` data-action="open-fmt-picker" title="Click to change"` : '');
             const audioOverride = k==='audio' && S.audio!=='limited' && ['samsung','firestick-hd','firestick-4kmax'].includes(S.device);
             const val = label(k, S[k]) || '—';
             const isNonDefault = k==='service' || (k==='audio' && S.audio!=='limited') || (k==='content' && S.content && S.content!=='all') || (k==='resolution' && S.resolution==='4k') || (k==='formatter' && S.formatter!=='apex-v2');
-            return `<div class="receipt-row">
+            return `<div class="receipt-row"${jumpAttr}>
               <div class="receipt-row-left">
                 <span class="receipt-row-ico">${ico}</span>
                 <span class="receipt-row-lbl">${k}</span>
@@ -1519,7 +1548,7 @@ function render() {
         </details>
         <details id="jsonPreviewDetails" style="margin-bottom:12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;overflow:hidden">
           <summary style="list-style:none;display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:11px 16px;background:rgba(255,255,255,.03);font-size:.76rem;font-weight:700;color:#4b5563;letter-spacing:.04em;text-transform:uppercase;user-select:none">
-            <span>Preview JSON</span><span style="font-size:.7rem;color:#374151">›</span>
+            <span>Preview JSON</span><span style="display:flex;align-items:center;gap:10px"><button type="button" data-action="copy-json" style="font-size:.74rem;font-weight:700;color:#00d4ff;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.25);border-radius:6px;padding:3px 11px;cursor:pointer;text-transform:none;letter-spacing:0">Copy JSON</button><span style="font-size:.7rem;color:#374151">›</span></span>
           </summary>
           <pre id="jsonPreview" style="margin:0;padding:12px 16px;background:#0d1117;overflow-x:auto;font-size:.68rem;color:#8b949e;font-family:monospace;line-height:1.5;max-height:260px;overflow-y:auto"></pre>
         </details>
@@ -1756,7 +1785,7 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
-          <span class="cred-status" id="credStatus_${inp.id}"></span>
+          <span class="cred-status" id="credStatus_${inp.id}" role="status" aria-live="polite"></span>
         </div>`).join('')}
         <div style="border-top:1px solid #21262d;margin:18px 0 14px"></div>
         <div style="color:#8b949e;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px">Metadata &amp; Posters</div>
@@ -1871,6 +1900,13 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch(e) {}
   }
   render();
+  try { history.replaceState({ step: step }, ''); } catch(e) {}
+  window.addEventListener('popstate', (e) => {
+    const m = document.getElementById('manifestModal'); if (m) m.remove();
+    showAdvanced = false;
+    step = (e.state && typeof e.state.step === 'number') ? e.state.step : 0;
+    saveState(); render(); window.scrollTo(0, 0);
+  });
 
   // Keyboard shortcuts: Enter = next, Escape = back
   document.addEventListener('keydown', (e) => {
@@ -1882,6 +1918,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || document.activeElement?.isContentEditable;
     if (e.key === 'Enter' && !inInput && !e.shiftKey) {
       e.preventDefault();
+      const ae = document.activeElement;
+      if (ae && ae.dataset && ae.dataset.action) { ae.click(); return; }
       const btn = document.getElementById('btnNext');
       if (btn && !btn.disabled && btn.style.display !== 'none') btn.click();
     }
@@ -1914,56 +1952,75 @@ document.addEventListener('DOMContentLoaded', () => {
           if (needed.length > 0 && !anyFilled) {
             showApiReminder(() => {
               document.getElementById('main').classList.remove('nav-back');
-              step = 6; saveState(); render(); window.scrollTo(0,0);
+              step = 6; pushStep(); saveState(); render(); window.scrollTo(0,0);
             });
             return;
           }
         }
         document.getElementById('main').classList.remove('nav-back');
         step = (step === 1 && S.quickStart) ? 5 : step + 1;
-        saveState(); render(); window.scrollTo(0,0);
+        pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'nav-back') {
       if (step > 0) {
         document.getElementById('main').classList.add('nav-back');
         step = (step === 5 && S.quickStart) ? 1 : step - 1;
-        saveState(); render(); window.scrollTo(0,0);
+        pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'skip-device') {
       S.device = 'generic';
       document.getElementById('main').classList.remove('nav-back');
       step = (step === 1 && S.quickStart) ? 5 : step + 1;
-      saveState(); render(); window.scrollTo(0,0);
+      pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'skip-content') {
       S.content = 'all';
       document.getElementById('main').classList.remove('nav-back');
       step = (step === 1 && S.quickStart) ? 5 : step + 1;
-      saveState(); render(); window.scrollTo(0,0);
+      pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
       const preset = (e.target.closest('[data-preset]') || e.target).dataset.preset;
       if (preset === 'p2p') {
         Object.assign(S, { service:'p2p', multiServices:['p2p'], resolution:'1080p', audio:'limited', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:true, quickStart:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
-        step = 5; render(); window.scrollTo(0,0);
+        step = 5; pushStep(); render(); window.scrollTo(0,0);
       } else {
         if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
         else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
-        step = 1; render(); window.scrollTo(0,0);
+        step = 1; pushStep(); render(); window.scrollTo(0,0);
       }
+    }
+    if (action === 'jump-step') {
+      const n = parseInt((e.target.closest('[data-step]') || e.target).dataset.step, 10);
+      if (n >= 1 && n < step) {
+        document.getElementById('main').classList.add('nav-back');
+        step = n; pushStep(); saveState(); render(); window.scrollTo(0,0);
+      }
+    }
+    if (action === 'open-fmt-picker') {
+      const d = document.getElementById('fmtPickerDetails');
+      if (d) { d.open = true; d.scrollIntoView({ behavior:'smooth', block:'center' }); }
     }
     if (action === 'open-advanced')  { showAdvanced = true;  render(); window.scrollTo(0,0); }
     if (action === 'close-advanced') { showAdvanced = false; render(); window.scrollTo(0,0); }
-    if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; saveState(); render(); window.scrollTo(0,0); }
-    if (action === 'continue-session') { step = _savedStep || 1; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'start-setup') { S.quickStart = false; document.getElementById('main').classList.remove('nav-back'); step = 1; pushStep(); saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'continue-session') { step = _savedStep || 1; pushStep(); saveState(); render(); window.scrollTo(0,0); }
     if (action === 'start-fresh') { clearState(); }
-    if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; pasteMode = true; saveState(); render(); window.scrollTo(0,0); }
+    if (action === 'paste-manifest-splash') { document.getElementById('main').classList.remove('nav-back'); step = STEPS; pasteMode = true; pushStep(); saveState(); render(); window.scrollTo(0,0); }
     if (action === 'reset-state') { if (confirm('Start over? Your current selections will be cleared.')) { showAdvanced = false; clearState(); } }
     if (action === 'share-config') shareConfig();
+    if (action === 'copy-json') {
+      e.preventDefault();
+      if (!S.service) { showToast('No service selected — go back and pick your debrid service first', true); }
+      else {
+        navigator.clipboard.writeText(JSON.stringify(build(), null, 2)).then(() => showToast('Template JSON copied — paste it into AIOStreams → Import'));
+        saveLastGen();
+      }
+    }
     if (action === 'generate-dl') generate();
     if (action === 'create-import') createImportUrl();
     if (action === 'gen-pwd') genPwd();
@@ -1980,6 +2037,12 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const v = (e.target.closest('[data-v]') || e.target).dataset.v;
       const h = document.getElementById('help_' + v);
+      if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
+    }
+    if (action === 'toggle-help-target') {
+      e.preventDefault();
+      const t = (e.target.closest('[data-target]') || e.target).dataset.target;
+      const h = document.getElementById(t);
       if (h) h.style.display = h.style.display === 'block' ? 'none' : 'block';
     }
     if (action === 'install-stremio') openInAIOStreams();
@@ -2139,7 +2202,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('input', (e) => {
     const a = e.target.dataset.action;
     if (a === 'update-name') S.name = e.target.value;
-    else if (a === 'update-cred') S.creds[e.target.dataset.service] = e.target.value;
+    else if (a === 'update-cred') {
+      S.creds[e.target.dataset.service] = e.target.value;
+      const st = document.getElementById('credStatus_' + e.target.dataset.service);
+      if (st) st.innerHTML = credHint(e.target.dataset.service, e.target.value);
+    }
     else if (a === 'update-tmdb') S.tmdbToken = e.target.value;
     else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
@@ -2876,6 +2943,15 @@ const CRED_TESTS = {
   premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
   debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
 };
+function credHint(id, val) {
+  const v = (val || '').trim();
+  if (!v) return '';
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v);
+  if (id !== 'torbox' && isUuid) return '<span style="color:#f59e0b">⚠ This looks like a TorBox API key — is it in the right field?</span>';
+  if (id === 'torbox' && !isUuid && v.length >= 16) return '<span style="color:#f59e0b">⚠ TorBox keys look like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx — this does not match.</span>';
+  return '';
+}
+
 async function testCred(id, btn) {
   const key = (S.creds[id] || '').trim();
   const status = document.getElementById('credStatus_' + id);


### PR DESCRIPTION
## Summary

The final QoL batch:

1. **Browser Back button works** — every step transition pushes a history entry and a `popstate` handler restores the step, so the phone/browser Back gesture steps back through the wizard instead of dumping users on the splash. An open manifest modal is closed on pop.
2. **Jump navigation** — completed step dots are clickable (with `role="button"` + keyboard activation), and Review receipt rows jump straight to their step (service → 1, device → 2, resolution/audio → 3, content → 4). The formatter row opens the inline formatter picker instead.
3. **Copy JSON** — button on the Preview JSON section copies the full template for direct paste into AIOStreams → Import. Fastest and most private path (no paste.rs involved). Guarded by the same no-service check as Generate.
4. **Wrong-field key detection** — typing/pasting a UUID-shaped key into a non-TorBox field warns "this looks like a TorBox API key"; a non-UUID value in the TorBox field warns it doesn't match the expected format. Short values don't nag.
5. **Audio profile "?" explainers** — eARC, DD+/Atmos, and DTS-exclusion jargon explained in both the resolution-step accordion and the Advanced panel, same pattern as the device step.
6. **Accessibility** — toast and key-test status get `role="status"`/`aria-live="polite"`; all pulsing animations disabled under `prefers-reduced-motion`; Enter now activates the focused interactive element instead of always advancing the wizard.
7. **Honesty note** — changelog states the app script ships readable by design (the v1.4 "obfuscated" claim never applied to the main script; source is public anyway).

## Verification
- All 3 script blocks pass syntax check; rebuild verified (306 KB) with all new hooks present
- Runtime stub tests: `credHint` correctly flags TorBox-key-in-RD-field and malformed TorBox keys, stays silent for valid/short values; `AUDIO_HELP` covers all 4 profiles; `pushStep` defined; version reads 2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_