### PR TITLE
configurator v2.7.1: TMDB field naming aligned with AIOStreams + swap detection

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -580,7 +580,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .receipt-row[data-action]:hover{background:rgba(0,212,255,.05)}
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>
-<script>var _0x1656ad=_0x4b67;function _0x1a09(){var _0x2387ac=['nJbjwKfHAeq','C2v0qxr0CMLIDxrL','mtKYndi0mLj2Afjftq','mtiYnteWn1bfs3ndqW','ntiWmtmWELrKsezy','otyYnhvyrwH1CW','zg9JDw1LBNrfBgvTzw50','y2juAgvTzq','mty0otvftwntDwi','zgf0ys10AgvTzq','Bwf0y2HnzwrPyq','mtuWmdq2ngrxBgLZEG','nJe5ntjxv2fTCMO','Bwf0y2HLCW'];_0x1a09=function(){return _0x2387ac;};return _0x1a09();}(function(_0x3ab186,_0x5df515){var _0x2330a1={_0x38f741:0x7d,_0x1ab7ef:0x75,_0x21bf0a:0x79,_0x267242:0x73,_0x4fe14a:0x7c},_0x5caed8=_0x4b67,_0x53de99=_0x3ab186();while(!![]){try{var _0x16653e=parseInt(_0x5caed8(_0x2330a1._0x38f741))/(-0x2689*0x1+-0x74f+-0x42b*-0xb)+parseInt(_0x5caed8(_0x2330a1._0x1ab7ef))/(0x2408+0x1b56*0x1+-0x3f5c)+parseInt(_0x5caed8(0x74))/(-0x6d*-0x3e+0x1aea+0xaa9*-0x5)+-parseInt(_0x5caed8(0x7f))/(0x1c4c+0xb*-0x2fb+0x481)*(-parseInt(_0x5caed8(_0x2330a1._0x21bf0a))/(-0x11f2*0x1+0x19*-0xfb+0x2a7a))+-parseInt(_0x5caed8(_0x2330a1._0x267242))/(-0x2*-0x905+-0x11cf+-0x35)+-parseInt(_0x5caed8(_0x2330a1._0x4fe14a))/(-0x3d5*-0x5+-0x2*0x1021+-0x10*-0xd2)+-parseInt(_0x5caed8(0x76))/(0x1595+-0x1990+0x1*0x403);if(_0x16653e===_0x5df515)break;else _0x53de99['push'](_0x53de99['shift']());}catch(_0x30ea88){_0x53de99['push'](_0x53de99['shift']());}}}(_0x1a09,0x1*0x20d7f+0x2*0x22e05+-0x2b1f0));function _0x4b67(_0x1ffcff,_0x44f2cb){_0x1ffcff=_0x1ffcff-(0x10fa+0x1a*0xc1+0x1211*-0x2);var _0x4e916b=_0x1a09();var _0x523979=_0x4e916b[_0x1ffcff];if(_0x4b67['rrKlow']===undefined){var _0x7ac1eb=function(_0x2e827e){var _0x19c94e='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x11c5b7='',_0x52370f='';for(var _0x7920c8=0x6df*-0x4+0x1f80+0x101*-0x4,_0x47649a,_0x423e67,_0x2a4783=0x20be+0x3f8+-0x24b6;_0x423e67=_0x2e827e['charAt'](_0x2a4783++);~_0x423e67&&(_0x47649a=_0x7920c8%(-0x1*0x1db3+-0x1d62+0x3b19)?_0x47649a*(-0xec2*0x1+0x2194+-0x1292)+_0x423e67:_0x423e67,_0x7920c8++%(-0x1982*0x1+0x1*-0x14e+0x65*0x44))?_0x11c5b7+=String['fromCharCode'](0x655+0x1*0x1023+0x1579*-0x1&_0x47649a>>(-(0xca+0x5*-0x7a9+-0x2585*-0x1)*_0x7920c8&0x1bcd+-0x1*0x8f3+-0x12d4)):-0x19c5*-0x1+-0xdf*-0x7+-0x1fde){_0x423e67=_0x19c94e['indexOf'](_0x423e67);}for(var _0x45b527=-0xaef+0x3*-0x40+0xbaf,_0x19f404=_0x11c5b7['length'];_0x45b527<_0x19f404;_0x45b527++){_0x52370f+='%'+('00'+_0x11c5b7['charCodeAt'](_0x45b527)['toString'](-0x8af+-0xa89+-0x9a4*-0x2))['slice'](-(-0x1449+0x17b3*0x1+-0x368));}return decodeURIComponent(_0x52370f);};_0x4b67['SnrRGJ']=_0x7ac1eb,_0x4b67['nVvbKh']={},_0x4b67['rrKlow']=!![];}var _0x12f793=_0x4e916b[0x25c1+0x766*0x5+-0xd7*0x59],_0x585f3e=_0x1ffcff+_0x12f793,_0x3dd74d=_0x4b67['nVvbKh'][_0x585f3e];return!_0x3dd74d?(_0x523979=_0x4b67['SnrRGJ'](_0x523979),_0x4b67['nVvbKh'][_0x585f3e]=_0x523979):_0x523979=_0x3dd74d,_0x523979;}try{document[_0x1656ad(0x77)][_0x1656ad(0x72)](_0x1656ad(0x7a),localStorage['getItem'](_0x1656ad(0x78))||(window[_0x1656ad(0x7b)]('(prefers-color-scheme:dark)')[_0x1656ad(0x7e)]?'dark':'light'));}catch(_0x4ceda2){}</script>
+<script>function _0x1b11(_0x3cacca,_0x47f63d){_0x3cacca=_0x3cacca-(-0x1385+-0x229+0x1622);var _0x5dc080=_0x1661();var _0xcd7ce0=_0x5dc080[_0x3cacca];if(_0x1b11['OEfsdP']===undefined){var _0x15be0d=function(_0x55fcd5){var _0x46c4cf='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x14c40e='',_0x4356db='';for(var _0x14b8d1=-0x1bf4+0x1*0x24f1+-0x8fd,_0x4ec526,_0xbe3fd4,_0x41f7ee=-0x1f49*0x1+0x1285+0xcc4;_0xbe3fd4=_0x55fcd5['charAt'](_0x41f7ee++);~_0xbe3fd4&&(_0x4ec526=_0x14b8d1%(0x4c1*0x5+-0x21*0xb+-0x1656)?_0x4ec526*(0x527*-0x1+0x156f+0x156*-0xc)+_0xbe3fd4:_0xbe3fd4,_0x14b8d1++%(0x25a6+0x1*0x117a+0x2*-0x1b8e))?_0x14c40e+=String['fromCharCode'](0x1713+-0x1a50+0x43c&_0x4ec526>>(-(0x1a4d+0x1*-0x21ea+0x79f)*_0x14b8d1&0x3*0xa5+-0x1*-0x20b9+-0x22a2)):0x7*0x42d+0x190a+-0x3645){_0xbe3fd4=_0x46c4cf['indexOf'](_0xbe3fd4);}for(var _0x1465c1=-0x3f*0x2d+0x79*0xa+-0x41*-0x19,_0x844510=_0x14c40e['length'];_0x1465c1<_0x844510;_0x1465c1++){_0x4356db+='%'+('00'+_0x14c40e['charCodeAt'](_0x1465c1)['toString'](-0x1*-0x100d+0xf22+-0x1f1f))['slice'](-(0x1a0c+-0x43a+-0x10*0x15d));}return decodeURIComponent(_0x4356db);};_0x1b11['mPetqK']=_0x15be0d,_0x1b11['jGufhx']={},_0x1b11['OEfsdP']=!![];}var _0x2cbbe9=_0x5dc080[-0x1*-0x21d9+0x1ad+0x2*-0x11c3],_0x9ddcf2=_0x3cacca+_0x2cbbe9,_0xe929be=_0x1b11['jGufhx'][_0x9ddcf2];return!_0xe929be?(_0xcd7ce0=_0x1b11['mPetqK'](_0xcd7ce0),_0x1b11['jGufhx'][_0x9ddcf2]=_0xcd7ce0):_0xcd7ce0=_0xe929be,_0xcd7ce0;}function _0x1661(){var _0x47ae3a=['zg9JDw1LBNrfBgvTzw50','mJK2mdHcB0jwrKu','mJa2mdzeuKLqAxq','otb4Eg9hB1C','mteZmZmWmg1wu1HSsW','C2v0qxr0CMLIDxrL','mJe4ouHowMDSEq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mtG0ntKYs0r0C21s','mtC5nZG1u1rAtgvm','mta3nZbcwNvXvKO','mtqWsNLWvffw','Bwf0y2HnzwrPyq','BgLNAhq','mtK0mtG3nKLXChnevW','zgf0ys10AgvTzq','nZvPyvjKD1y','Bwf0y2HLCW','zgfYAW'];_0x1661=function(){return _0x47ae3a;};return _0x1661();}var _0x4f5a89=_0x1b11;(function(_0x571860,_0x3c21c0){var _0x2411fc={_0x3965e2:0x77,_0x3630ff:0x7b,_0x11318a:0x75,_0x563829:0x82,_0x3f3cdc:0x7d,_0x17c1cc:0x84},_0x36bed8=_0x1b11,_0x5ed26c=_0x571860();while(!![]){try{var _0x288816=parseInt(_0x36bed8(0x83))/(0x1*-0x1efd+-0x1b22+-0xba*-0x50)+parseInt(_0x36bed8(0x7c))/(-0x8a*0x41+-0x1d54+0x4060)*(parseInt(_0x36bed8(_0x2411fc._0x3965e2))/(0x1*-0x25e+-0x51*-0x79+-0x23e8))+-parseInt(_0x36bed8(_0x2411fc._0x3630ff))/(-0x1*0x1f2b+0x5dd*-0x1+0x2*0x1286)*(parseInt(_0x36bed8(0x85))/(-0x137e+-0x1*0x107f+0x2402))+-parseInt(_0x36bed8(_0x2411fc._0x11318a))/(0x2*0x2fd+0xc40+0x4*-0x48d)+-parseInt(_0x36bed8(0x7e))/(0x29b*-0xc+0x8b8+0x1693*0x1)+parseInt(_0x36bed8(_0x2411fc._0x563829))/(-0x1d22+-0x14d4+-0xed*-0x36)*(parseInt(_0x36bed8(_0x2411fc._0x3f3cdc))/(-0x89d+-0x12*0x40+0xd26))+-parseInt(_0x36bed8(_0x2411fc._0x17c1cc))/(-0xbb4+0x53b*-0x7+0x305b)*(-parseInt(_0x36bed8(0x80))/(-0x50e+0x1*0x9e3+0x4ca*-0x1));if(_0x288816===_0x3c21c0)break;else _0x5ed26c['push'](_0x5ed26c['shift']());}catch(_0x3fb620){_0x5ed26c['push'](_0x5ed26c['shift']());}}}(_0x1661,0x30491*0x1+-0x17cc3+-0x125d*-0x13));try{document[_0x4f5a89(0x7a)][_0x4f5a89(0x7f)](_0x4f5a89(0x76),localStorage['getItem']('cbTheme')||(window[_0x4f5a89(0x86)](_0x4f5a89(0x81))[_0x4f5a89(0x78)]?_0x4f5a89(0x79):_0x4f5a89(0x74)));}catch(_0x14eff0){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -634,11 +634,16 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.7';
+const CONFIGURATOR_VERSION = '2.7.1';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.7.1', date:'Jul 2 2026', items:[
+    'TMDB fields renamed to match AIOStreams exactly — "TMDB Read Access Token" and "TMDB API Key" (version suffixes dropped)',
+    'Helper text under each TMDB field mirrors AIOStreams: the long eyJ… token vs the 32-character key',
+    'Swap detection — pasting the API Key into the Token field (or vice versa) shows an inline warning as you type',
+  ]},
   { v:'2.7', date:'Jul 2 2026', items:[
     'Easy Setup — the new default path: pick your service, device, and resolution (each advances automatically), add your key, then one Create &amp; Install button. No UUIDs, no import URLs, no manifest juggling',
     'One-click finish — your config is created on a public AIOStreams host with an auto-generated password and the Stremio install button appears immediately',
@@ -1809,7 +1814,7 @@ function render() {
         ` : ''}
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
-            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
+            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
@@ -1821,10 +1826,12 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <div style="font-size:.72rem;color:#6b7280;margin-top:5px;line-height:1.45">The <strong style="color:#8b949e">long</strong> token starting with <code style="color:#8b949e;font-family:monospace">eyJ</code> — not the 32-character API Key.</div>
+          <span class="cred-status" id="tmdbStatus" role="status" aria-live="polite"></span>
         </div>
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
-            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
+            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
@@ -1836,6 +1843,8 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <div style="font-size:.72rem;color:#6b7280;margin-top:5px;line-height:1.45">The <strong style="color:#8b949e">32-character</strong> key — not the Read Access Token.</div>
+          <span class="cred-status" id="tmdbKeyStatus" role="status" aria-live="polite"></span>
         </div>
       </div>`;
     nav.style.display = 'flex';
@@ -2236,8 +2245,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const st = document.getElementById('credStatus_' + e.target.dataset.service);
       if (st) st.innerHTML = credHint(e.target.dataset.service, e.target.value);
     }
-    else if (a === 'update-tmdb') S.tmdbToken = e.target.value;
-    else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
+    else if (a === 'update-tmdb') {
+      S.tmdbToken = e.target.value;
+      const st = document.getElementById('tmdbStatus');
+      if (st) st.innerHTML = tmdbHint('token', e.target.value);
+    }
+    else if (a === 'update-tmdb-key') {
+      S.tmdbApiKey = e.target.value;
+      const st = document.getElementById('tmdbKeyStatus');
+      if (st) st.innerHTML = tmdbHint('key', e.target.value);
+    }
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
     else if (a === 'update-pwd') S.instancePassword = e.target.value;
     else if (a === 'update-base-uuid') { S.baseUuid = e.target.value.trim(); e.target.style.borderColor = S.baseUuid ? 'rgba(168,85,247,.5)' : ''; }
@@ -3012,6 +3029,18 @@ const CRED_TESTS = {
   premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
   debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
 };
+function tmdbHint(field, val) {
+  const v = (val || '').trim();
+  if (!v) return '';
+  const looksToken = v.startsWith('eyJ');
+  const looksKey = /^[a-f0-9]{32}$/i.test(v);
+  if (field === 'token' && looksKey) return '<span style="color:#f59e0b">⚠ That is the 32-character API Key — this field wants the long Read Access Token (starts with eyJ).</span>';
+  if (field === 'token' && !looksToken && v.length >= 20) return '<span style="color:#f59e0b">⚠ Read Access Tokens start with eyJ — this does not look like one.</span>';
+  if (field === 'key' && looksToken) return '<span style="color:#f59e0b">⚠ That is the Read Access Token — this field wants the 32-character API Key.</span>';
+  if (field === 'key' && !looksKey && v.length >= 24) return '<span style="color:#f59e0b">⚠ API Keys are exactly 32 characters (letters and numbers) — this does not look like one.</span>';
+  return '';
+}
+
 function credHint(id, val) {
   const v = (val || '').trim();
   if (!v) return '';

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -634,11 +634,16 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.7';
+const CONFIGURATOR_VERSION = '2.7.1';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.7.1', date:'Jul 2 2026', items:[
+    'TMDB fields renamed to match AIOStreams exactly — "TMDB Read Access Token" and "TMDB API Key" (version suffixes dropped)',
+    'Helper text under each TMDB field mirrors AIOStreams: the long eyJ… token vs the 32-character key',
+    'Swap detection — pasting the API Key into the Token field (or vice versa) shows an inline warning as you type',
+  ]},
   { v:'2.7', date:'Jul 2 2026', items:[
     'Easy Setup — the new default path: pick your service, device, and resolution (each advances automatically), add your key, then one Create &amp; Install button. No UUIDs, no import URLs, no manifest juggling',
     'One-click finish — your config is created on a public AIOStreams host with an auto-generated password and the Stremio install button appears immediately',
@@ -1809,7 +1814,7 @@ function render() {
         ` : ''}
         <div class="name-row" style="margin-bottom:14px">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
-            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token (v4)</span>
+            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB Read Access Token</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
@@ -1821,10 +1826,12 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <div style="font-size:.72rem;color:#6b7280;margin-top:5px;line-height:1.45">The <strong style="color:#8b949e">long</strong> token starting with <code style="color:#8b949e;font-family:monospace">eyJ</code> — not the 32-character API Key.</div>
+          <span class="cred-status" id="tmdbStatus" role="status" aria-live="polite"></span>
         </div>
         <div class="name-row">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
-            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key (v3)</span>
+            <span style="color:#8b949e;font-size:.82rem;text-transform:uppercase;letter-spacing:.05em">TMDB API Key</span>
             <a href="https://www.themoviedb.org/settings/api" target="_blank" style="font-size:.83rem;color:#00d4ff;text-decoration:none;font-weight:700">Get key →</a>
           </div>
           <div style="position:relative;display:flex;align-items:center">
@@ -1836,6 +1843,8 @@ function render() {
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
           </div>
+          <div style="font-size:.72rem;color:#6b7280;margin-top:5px;line-height:1.45">The <strong style="color:#8b949e">32-character</strong> key — not the Read Access Token.</div>
+          <span class="cred-status" id="tmdbKeyStatus" role="status" aria-live="polite"></span>
         </div>
       </div>`;
     nav.style.display = 'flex';
@@ -2236,8 +2245,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const st = document.getElementById('credStatus_' + e.target.dataset.service);
       if (st) st.innerHTML = credHint(e.target.dataset.service, e.target.value);
     }
-    else if (a === 'update-tmdb') S.tmdbToken = e.target.value;
-    else if (a === 'update-tmdb-key') S.tmdbApiKey = e.target.value;
+    else if (a === 'update-tmdb') {
+      S.tmdbToken = e.target.value;
+      const st = document.getElementById('tmdbStatus');
+      if (st) st.innerHTML = tmdbHint('token', e.target.value);
+    }
+    else if (a === 'update-tmdb-key') {
+      S.tmdbApiKey = e.target.value;
+      const st = document.getElementById('tmdbKeyStatus');
+      if (st) st.innerHTML = tmdbHint('key', e.target.value);
+    }
     else if (a === 'update-url') S.instanceUrl = e.target.value.trim();
     else if (a === 'update-pwd') S.instancePassword = e.target.value;
     else if (a === 'update-base-uuid') { S.baseUuid = e.target.value.trim(); e.target.style.borderColor = S.baseUuid ? 'rgba(168,85,247,.5)' : ''; }
@@ -3012,6 +3029,18 @@ const CRED_TESTS = {
   premiumize:  k => fetchWithTimeout('https://www.premiumize.me/api/account/info?apikey=' + encodeURIComponent(k), {}, 6000).then(r => r.json()).then(d => !!d && d.status === 'success'),
   debridlink:  k => fetchWithTimeout('https://debrid-link.com/api/v2/account/infos', { headers: { Authorization: 'Bearer ' + k } }, 6000).then(r => r.ok),
 };
+function tmdbHint(field, val) {
+  const v = (val || '').trim();
+  if (!v) return '';
+  const looksToken = v.startsWith('eyJ');
+  const looksKey = /^[a-f0-9]{32}$/i.test(v);
+  if (field === 'token' && looksKey) return '<span style="color:#f59e0b">⚠ That is the 32-character API Key — this field wants the long Read Access Token (starts with eyJ).</span>';
+  if (field === 'token' && !looksToken && v.length >= 20) return '<span style="color:#f59e0b">⚠ Read Access Tokens start with eyJ — this does not look like one.</span>';
+  if (field === 'key' && looksToken) return '<span style="color:#f59e0b">⚠ That is the Read Access Token — this field wants the 32-character API Key.</span>';
+  if (field === 'key' && !looksKey && v.length >= 24) return '<span style="color:#f59e0b">⚠ API Keys are exactly 32 characters (letters and numbers) — this does not look like one.</span>';
+  return '';
+}
+
 function credHint(id, val) {
   const v = (val || '').trim();
   if (!v) return '';


### PR DESCRIPTION
## Summary

Aligns the configurator's TMDB fields with AIOStreams' own import screen so users see the same names in both places:

- **Labels renamed** — "TMDB Read Access Token (v4)" → **TMDB Read Access Token**, "TMDB API Key (v3)" → **TMDB API Key** (AIOStreams doesn't show version suffixes)
- **Helper text added** under each field, mirroring AIOStreams' guidance: the Token field wants the *long value starting with `eyJ`*, the Key field wants the *32-character key*
- **Swap detection as you type** — AIOStreams' "make sure to copy X and not Y" warning is now enforced automatically: pasting the 32-char key into the Token field (or the `eyJ…` token into the Key field) shows an inline warning, and values matching neither format get a gentle format hint. Short inputs don't nag.
- Status lines use `role="status"`/`aria-live` like the debrid key hints

## Verification
Runtime-tested all six hint paths: key-in-token-field flags, garbage-in-token-field flags, valid token silent, token-in-key-field flags, valid key silent, short inputs silent. Build contains zero occurrences of the old suffixed labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_