### PR TITLE
configurator v2.8: Quick Start presets repurposed as Easy Setup accelerators

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -580,7 +580,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .receipt-row[data-action]:hover{background:rgba(0,212,255,.05)}
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>
-<script>function _0x1b11(_0x3cacca,_0x47f63d){_0x3cacca=_0x3cacca-(-0x1385+-0x229+0x1622);var _0x5dc080=_0x1661();var _0xcd7ce0=_0x5dc080[_0x3cacca];if(_0x1b11['OEfsdP']===undefined){var _0x15be0d=function(_0x55fcd5){var _0x46c4cf='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x14c40e='',_0x4356db='';for(var _0x14b8d1=-0x1bf4+0x1*0x24f1+-0x8fd,_0x4ec526,_0xbe3fd4,_0x41f7ee=-0x1f49*0x1+0x1285+0xcc4;_0xbe3fd4=_0x55fcd5['charAt'](_0x41f7ee++);~_0xbe3fd4&&(_0x4ec526=_0x14b8d1%(0x4c1*0x5+-0x21*0xb+-0x1656)?_0x4ec526*(0x527*-0x1+0x156f+0x156*-0xc)+_0xbe3fd4:_0xbe3fd4,_0x14b8d1++%(0x25a6+0x1*0x117a+0x2*-0x1b8e))?_0x14c40e+=String['fromCharCode'](0x1713+-0x1a50+0x43c&_0x4ec526>>(-(0x1a4d+0x1*-0x21ea+0x79f)*_0x14b8d1&0x3*0xa5+-0x1*-0x20b9+-0x22a2)):0x7*0x42d+0x190a+-0x3645){_0xbe3fd4=_0x46c4cf['indexOf'](_0xbe3fd4);}for(var _0x1465c1=-0x3f*0x2d+0x79*0xa+-0x41*-0x19,_0x844510=_0x14c40e['length'];_0x1465c1<_0x844510;_0x1465c1++){_0x4356db+='%'+('00'+_0x14c40e['charCodeAt'](_0x1465c1)['toString'](-0x1*-0x100d+0xf22+-0x1f1f))['slice'](-(0x1a0c+-0x43a+-0x10*0x15d));}return decodeURIComponent(_0x4356db);};_0x1b11['mPetqK']=_0x15be0d,_0x1b11['jGufhx']={},_0x1b11['OEfsdP']=!![];}var _0x2cbbe9=_0x5dc080[-0x1*-0x21d9+0x1ad+0x2*-0x11c3],_0x9ddcf2=_0x3cacca+_0x2cbbe9,_0xe929be=_0x1b11['jGufhx'][_0x9ddcf2];return!_0xe929be?(_0xcd7ce0=_0x1b11['mPetqK'](_0xcd7ce0),_0x1b11['jGufhx'][_0x9ddcf2]=_0xcd7ce0):_0xcd7ce0=_0xe929be,_0xcd7ce0;}function _0x1661(){var _0x47ae3a=['zg9JDw1LBNrfBgvTzw50','mJK2mdHcB0jwrKu','mJa2mdzeuKLqAxq','otb4Eg9hB1C','mteZmZmWmg1wu1HSsW','C2v0qxr0CMLIDxrL','mJe4ouHowMDSEq','khbYzwzLCNmTy29SB3iTC2nOzw1LoMrHCMSP','mtG0ntKYs0r0C21s','mtC5nZG1u1rAtgvm','mta3nZbcwNvXvKO','mtqWsNLWvffw','Bwf0y2HnzwrPyq','BgLNAhq','mtK0mtG3nKLXChnevW','zgf0ys10AgvTzq','nZvPyvjKD1y','Bwf0y2HLCW','zgfYAW'];_0x1661=function(){return _0x47ae3a;};return _0x1661();}var _0x4f5a89=_0x1b11;(function(_0x571860,_0x3c21c0){var _0x2411fc={_0x3965e2:0x77,_0x3630ff:0x7b,_0x11318a:0x75,_0x563829:0x82,_0x3f3cdc:0x7d,_0x17c1cc:0x84},_0x36bed8=_0x1b11,_0x5ed26c=_0x571860();while(!![]){try{var _0x288816=parseInt(_0x36bed8(0x83))/(0x1*-0x1efd+-0x1b22+-0xba*-0x50)+parseInt(_0x36bed8(0x7c))/(-0x8a*0x41+-0x1d54+0x4060)*(parseInt(_0x36bed8(_0x2411fc._0x3965e2))/(0x1*-0x25e+-0x51*-0x79+-0x23e8))+-parseInt(_0x36bed8(_0x2411fc._0x3630ff))/(-0x1*0x1f2b+0x5dd*-0x1+0x2*0x1286)*(parseInt(_0x36bed8(0x85))/(-0x137e+-0x1*0x107f+0x2402))+-parseInt(_0x36bed8(_0x2411fc._0x11318a))/(0x2*0x2fd+0xc40+0x4*-0x48d)+-parseInt(_0x36bed8(0x7e))/(0x29b*-0xc+0x8b8+0x1693*0x1)+parseInt(_0x36bed8(_0x2411fc._0x563829))/(-0x1d22+-0x14d4+-0xed*-0x36)*(parseInt(_0x36bed8(_0x2411fc._0x3f3cdc))/(-0x89d+-0x12*0x40+0xd26))+-parseInt(_0x36bed8(_0x2411fc._0x17c1cc))/(-0xbb4+0x53b*-0x7+0x305b)*(-parseInt(_0x36bed8(0x80))/(-0x50e+0x1*0x9e3+0x4ca*-0x1));if(_0x288816===_0x3c21c0)break;else _0x5ed26c['push'](_0x5ed26c['shift']());}catch(_0x3fb620){_0x5ed26c['push'](_0x5ed26c['shift']());}}}(_0x1661,0x30491*0x1+-0x17cc3+-0x125d*-0x13));try{document[_0x4f5a89(0x7a)][_0x4f5a89(0x7f)](_0x4f5a89(0x76),localStorage['getItem']('cbTheme')||(window[_0x4f5a89(0x86)](_0x4f5a89(0x81))[_0x4f5a89(0x78)]?_0x4f5a89(0x79):_0x4f5a89(0x74)));}catch(_0x14eff0){}</script>
+<script>function _0x262d(){var _0x1ef712=['mJrPywLszwq','nJK5mZa3Be5brwrO','mtaXmtuWnhjPA1nhBq','mZGYnde3ogjJuff0wq','y2juAgvTzq','C2v0qxr0CMLIDxrL','ndq1mti2nwL5Bfrxvq','z2v0sxrLBq','Bwf0y2HLCW','mtu3nJq4nJbItw5XzLy','ntKZnty1tLL0qM5X','zgf0ys10AgvTzq','mZe1ndG0CMjWuM9Q','mZzXtKnKv08','nLPpqNHbqG','Bwf0y2HnzwrPyq'];_0x262d=function(){return _0x1ef712;};return _0x262d();}var _0x28bf66=_0x32e3;(function(_0x4db39e,_0x2cd648){var _0x38f6ce={_0xa20555:0x1ca,_0xaeb4e6:0x1d5,_0x5da1c9:0x1d3,_0x2534b4:0x1cf,_0x3b785c:0x1cb,_0x45e800:0x1d6},_0x3a0f6f=_0x32e3,_0x3cbfce=_0x4db39e();while(!![]){try{var _0x4026f4=-parseInt(_0x3a0f6f(_0x38f6ce._0xa20555))/(-0x447*-0x9+0x1cc0+-0x433e)+-parseInt(_0x3a0f6f(_0x38f6ce._0xaeb4e6))/(0x383+-0x62d+-0x4*-0xab)*(parseInt(_0x3a0f6f(0x1d7))/(-0x8*-0x47b+0xeab*-0x1+0x3*-0x70e))+-parseInt(_0x3a0f6f(0x1d9))/(-0x2eb+-0x2*0x799+0x1221)*(parseInt(_0x3a0f6f(_0x38f6ce._0x5da1c9))/(0x1383+-0xdbb+-0x5*0x127))+parseInt(_0x3a0f6f(0x1cc))/(-0x1*0x2047+0x45c+0x1bf1)+-parseInt(_0x3a0f6f(_0x38f6ce._0x2534b4))/(-0x1*-0x1f73+0x78b+-0x26f7)+-parseInt(_0x3a0f6f(_0x38f6ce._0x3b785c))/(0x1d42+0x17*-0x18a+0x62c)*(-parseInt(_0x3a0f6f(_0x38f6ce._0x45e800))/(0x5fc+-0x128c*-0x2+0x1*-0x2b0b))+parseInt(_0x3a0f6f(0x1d2))/(0x2021+0x191b+0x1*-0x3932);if(_0x4026f4===_0x2cd648)break;else _0x3cbfce['push'](_0x3cbfce['shift']());}catch(_0x3fad85){_0x3cbfce['push'](_0x3cbfce['shift']());}}}(_0x262d,-0x8*-0x101f5+-0x489bd+0x2*0xf599));function _0x32e3(_0x9db41e,_0x571506){_0x9db41e=_0x9db41e-(-0x4dc+-0x11c3*-0x1+-0xb1d);var _0x5eacde=_0x262d();var _0x52c6f7=_0x5eacde[_0x9db41e];if(_0x32e3['odMRSU']===undefined){var _0x5ca98f=function(_0x33f908){var _0x282607='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x25fc68='',_0xd9499f='';for(var _0x38d191=-0x2536+0x2487+-0x7*-0x19,_0x259ead,_0x5b6fb5,_0x1dc99d=-0x264d+-0x1147*0x1+-0x3794*-0x1;_0x5b6fb5=_0x33f908['charAt'](_0x1dc99d++);~_0x5b6fb5&&(_0x259ead=_0x38d191%(-0x2*-0x21f+-0x22fe+0x1ec4)?_0x259ead*(0x1e67+-0x22a2+0x1*0x47b)+_0x5b6fb5:_0x5b6fb5,_0x38d191++%(0x782+-0x21eb+0x1a6d))?_0x25fc68+=String['fromCharCode'](-0x1068+0x1ae4+0x15b*-0x7&_0x259ead>>(-(0x1*0x26a+-0x420+0x1b8)*_0x38d191&-0x1acf+0x1ab8+0x1d*0x1)):-0xa3f+0x28a+0x7b5){_0x5b6fb5=_0x282607['indexOf'](_0x5b6fb5);}for(var _0x5d4c34=-0x1*0x239b+-0x106*-0x17+0xc11,_0x24d010=_0x25fc68['length'];_0x5d4c34<_0x24d010;_0x5d4c34++){_0xd9499f+='%'+('00'+_0x25fc68['charCodeAt'](_0x5d4c34)['toString'](0x206*-0xb+0x1d59+-0x707))['slice'](-(-0x52*0x48+0x1c69+0x1*-0x557));}return decodeURIComponent(_0xd9499f);};_0x32e3['wpLCbV']=_0x5ca98f,_0x32e3['SMTCXD']={},_0x32e3['odMRSU']=!![];}var _0x90ad5b=_0x5eacde[-0x227a*0x1+-0x4c*-0x74+0xa],_0x1a4178=_0x9db41e+_0x90ad5b,_0x1f8004=_0x32e3['SMTCXD'][_0x1a4178];return!_0x1f8004?(_0x52c6f7=_0x32e3['wpLCbV'](_0x52c6f7),_0x32e3['SMTCXD'][_0x1a4178]=_0x52c6f7):_0x52c6f7=_0x1f8004,_0x52c6f7;}try{document['documentElement'][_0x28bf66(0x1ce)](_0x28bf66(0x1d4),localStorage[_0x28bf66(0x1d0)](_0x28bf66(0x1cd))||(window[_0x28bf66(0x1d8)]('(prefers-color-scheme:dark)')[_0x28bf66(0x1d1)]?'dark':'light'));}catch(_0x477a34){}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -634,11 +634,16 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.7.1';
+const CONFIGURATOR_VERSION = '2.8';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.8', date:'Jul 2 2026', items:[
+    'Quick Start presets return as Easy Setup accelerators — 4K · Lossless and 1080p · DD+ pre-answer the resolution question',
+    'Presets now ask for your device (the old presets skipped it, which broke Samsung and Fire Stick playback profiles) and end on the one-click install',
+    'Device choice still auto-corrects audio — pick Samsung after the 4K preset and the profile drops to DD+ with a toast explaining why',
+  ]},
   { v:'2.7.1', date:'Jul 2 2026', items:[
     'TMDB fields renamed to match AIOStreams exactly — "TMDB Read Access Token" and "TMDB API Key" (version suffixes dropped)',
     'Helper text under each TMDB field mirrors AIOStreams: the long eyJ… token vs the 32-character key',
@@ -1418,6 +1423,12 @@ function splashHtml() {
     </div>
     <button class="splash-cta" data-action="easy-start">⚡ Easy Setup<br><span style="font-size:.74rem;font-weight:600;opacity:.85">3 quick questions — we handle the rest</span></button>
     <button data-action="custom-start" style="width:100%;max-width:310px;margin-top:8px;padding:11px 24px;font-size:.86rem;font-weight:700;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(255,255,255,.03);color:#8b949e;cursor:pointer;transition:all .2s" onmouseover="this.style.background='rgba(255,255,255,.07)'" onmouseout="this.style.background='rgba(255,255,255,.03)'">Custom Setup — full control</button>
+    <div style="width:100%;max-width:310px;margin-top:12px;font-size:.63rem;font-weight:700;color:#4b5563;letter-spacing:.08em;text-transform:uppercase;text-align:center">Or start from a preset</div>
+    <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:8px">
+      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(124,58,237,.06);border:1.5px solid rgba(124,58,237,.25);border-radius:12px;color:#a78bfa;font-size:.84rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(124,58,237,.13)'" onmouseout="this.style.background='rgba(124,58,237,.06)'">⚡ 4K Preset<br><span style="font-size:.68rem;opacity:.8;font-weight:600">Lossless audio · big screen</span></button>
+      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.22);border-radius:12px;color:#60a5fa;font-size:.84rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.13)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ 1080p Preset<br><span style="font-size:.68rem;opacity:.8;font-weight:600">DD+ · everyday streaming</span></button>
+    </div>
+    <div style="width:100%;max-width:310px;margin-top:6px;font-size:.66rem;color:#4b5563;text-align:center;line-height:1.4">Presets pre-answer the resolution question — you still pick your service and device, then one-click install.</div>
     ${hadSavedState && _savedStep > 0 ? `<div class="continue-banner" style="width:100%;max-width:310px;margin-top:10px;padding:11px 14px;background:rgba(0,212,255,.06);border:1px solid rgba(0,212,255,.18);border-radius:10px;display:flex;align-items:center;gap:10px">
       <div style="flex:1;min-width:0">
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
@@ -1897,7 +1908,7 @@ function syncNext() {
   let ok = !def.key || !!S[def.key];
   if (step === 1) ok = S.multiServices.length > 0;
   btn.disabled = !ok;
-  const nextDef = step < STEPS ? DEFS[(S.simpleMode && step === 3) ? 4 : step] : null;
+  const nextDef = step < STEPS ? DEFS[((S.quickStart && step === 2) || (S.simpleMode && step === 3)) ? 4 : step] : null;
   const nextLabel = nextDef ? nextDef.title : null;
   if (step === STEPS) {
     btn.innerHTML = `<span style="flex:1">Review &amp; Generate</span><span class="cta-arr">→</span>`;
@@ -1984,7 +1995,7 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         document.getElementById('main').classList.remove('nav-back');
-        step = (step === 1 && S.quickStart) ? 5 : ((S.simpleMode && step === 3) ? 5 : step + 1);
+        step = (S.quickStart && step === 2) ? 5 : ((S.simpleMode && step === 3) ? 5 : step + 1);
         if (S.simpleMode && !S.content) S.content = 'all';
         pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
@@ -1992,20 +2003,20 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'nav-back') {
       if (step > 0) {
         document.getElementById('main').classList.add('nav-back');
-        step = (step === 5 && S.quickStart) ? 1 : ((S.simpleMode && step === 5) ? 3 : step - 1);
+        step = (step === 5 && S.quickStart) ? 2 : ((S.simpleMode && step === 5) ? 3 : step - 1);
         pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'skip-device') {
       S.device = 'generic';
       document.getElementById('main').classList.remove('nav-back');
-      step = (step === 1 && S.quickStart) ? 5 : step + 1;
+      step = S.quickStart ? 5 : step + 1;
       pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'skip-content') {
       S.content = 'all';
       document.getElementById('main').classList.remove('nav-back');
-      step = (step === 1 && S.quickStart) ? 5 : step + 1;
+      step = S.quickStart ? 5 : step + 1;
       pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
@@ -2015,8 +2026,8 @@ document.addEventListener('DOMContentLoaded', () => {
         saveState(); document.getElementById('main').classList.remove('nav-back');
         step = 5; pushStep(); render(); window.scrollTo(0,0);
       } else {
-        if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
-        else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
+        if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true, simpleMode:true });
+        else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true, simpleMode:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
         step = 1; pushStep(); render(); window.scrollTo(0,0);
       }

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -634,11 +634,16 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.7.1';
+const CONFIGURATOR_VERSION = '2.8';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.8', date:'Jul 2 2026', items:[
+    'Quick Start presets return as Easy Setup accelerators — 4K · Lossless and 1080p · DD+ pre-answer the resolution question',
+    'Presets now ask for your device (the old presets skipped it, which broke Samsung and Fire Stick playback profiles) and end on the one-click install',
+    'Device choice still auto-corrects audio — pick Samsung after the 4K preset and the profile drops to DD+ with a toast explaining why',
+  ]},
   { v:'2.7.1', date:'Jul 2 2026', items:[
     'TMDB fields renamed to match AIOStreams exactly — "TMDB Read Access Token" and "TMDB API Key" (version suffixes dropped)',
     'Helper text under each TMDB field mirrors AIOStreams: the long eyJ… token vs the 32-character key',
@@ -1418,6 +1423,12 @@ function splashHtml() {
     </div>
     <button class="splash-cta" data-action="easy-start">⚡ Easy Setup<br><span style="font-size:.74rem;font-weight:600;opacity:.85">3 quick questions — we handle the rest</span></button>
     <button data-action="custom-start" style="width:100%;max-width:310px;margin-top:8px;padding:11px 24px;font-size:.86rem;font-weight:700;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(255,255,255,.03);color:#8b949e;cursor:pointer;transition:all .2s" onmouseover="this.style.background='rgba(255,255,255,.07)'" onmouseout="this.style.background='rgba(255,255,255,.03)'">Custom Setup — full control</button>
+    <div style="width:100%;max-width:310px;margin-top:12px;font-size:.63rem;font-weight:700;color:#4b5563;letter-spacing:.08em;text-transform:uppercase;text-align:center">Or start from a preset</div>
+    <div style="display:flex;gap:8px;width:100%;max-width:310px;margin-top:8px">
+      <button data-action="quick-start" data-preset="4k" style="flex:1;padding:12px 10px;background:rgba(124,58,237,.06);border:1.5px solid rgba(124,58,237,.25);border-radius:12px;color:#a78bfa;font-size:.84rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(124,58,237,.13)'" onmouseout="this.style.background='rgba(124,58,237,.06)'">⚡ 4K Preset<br><span style="font-size:.68rem;opacity:.8;font-weight:600">Lossless audio · big screen</span></button>
+      <button data-action="quick-start" data-preset="1080p" style="flex:1;padding:12px 10px;background:rgba(59,130,246,.06);border:1.5px solid rgba(59,130,246,.22);border-radius:12px;color:#60a5fa;font-size:.84rem;font-weight:700;cursor:pointer;transition:all .2s;line-height:1.35" onmouseover="this.style.background='rgba(59,130,246,.13)'" onmouseout="this.style.background='rgba(59,130,246,.06)'">⚡ 1080p Preset<br><span style="font-size:.68rem;opacity:.8;font-weight:600">DD+ · everyday streaming</span></button>
+    </div>
+    <div style="width:100%;max-width:310px;margin-top:6px;font-size:.66rem;color:#4b5563;text-align:center;line-height:1.4">Presets pre-answer the resolution question — you still pick your service and device, then one-click install.</div>
     ${hadSavedState && _savedStep > 0 ? `<div class="continue-banner" style="width:100%;max-width:310px;margin-top:10px;padding:11px 14px;background:rgba(0,212,255,.06);border:1px solid rgba(0,212,255,.18);border-radius:10px;display:flex;align-items:center;gap:10px">
       <div style="flex:1;min-width:0">
         <div style="font-size:.72rem;font-weight:700;color:#00d4ff">Continue where you left off</div>
@@ -1897,7 +1908,7 @@ function syncNext() {
   let ok = !def.key || !!S[def.key];
   if (step === 1) ok = S.multiServices.length > 0;
   btn.disabled = !ok;
-  const nextDef = step < STEPS ? DEFS[(S.simpleMode && step === 3) ? 4 : step] : null;
+  const nextDef = step < STEPS ? DEFS[((S.quickStart && step === 2) || (S.simpleMode && step === 3)) ? 4 : step] : null;
   const nextLabel = nextDef ? nextDef.title : null;
   if (step === STEPS) {
     btn.innerHTML = `<span style="flex:1">Review &amp; Generate</span><span class="cta-arr">→</span>`;
@@ -1984,7 +1995,7 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         document.getElementById('main').classList.remove('nav-back');
-        step = (step === 1 && S.quickStart) ? 5 : ((S.simpleMode && step === 3) ? 5 : step + 1);
+        step = (S.quickStart && step === 2) ? 5 : ((S.simpleMode && step === 3) ? 5 : step + 1);
         if (S.simpleMode && !S.content) S.content = 'all';
         pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
@@ -1992,20 +2003,20 @@ document.addEventListener('DOMContentLoaded', () => {
     if (action === 'nav-back') {
       if (step > 0) {
         document.getElementById('main').classList.add('nav-back');
-        step = (step === 5 && S.quickStart) ? 1 : ((S.simpleMode && step === 5) ? 3 : step - 1);
+        step = (step === 5 && S.quickStart) ? 2 : ((S.simpleMode && step === 5) ? 3 : step - 1);
         pushStep(); saveState(); render(); window.scrollTo(0,0);
       }
     }
     if (action === 'skip-device') {
       S.device = 'generic';
       document.getElementById('main').classList.remove('nav-back');
-      step = (step === 1 && S.quickStart) ? 5 : step + 1;
+      step = S.quickStart ? 5 : step + 1;
       pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'skip-content') {
       S.content = 'all';
       document.getElementById('main').classList.remove('nav-back');
-      step = (step === 1 && S.quickStart) ? 5 : step + 1;
+      step = S.quickStart ? 5 : step + 1;
       pushStep(); saveState(); render(); window.scrollTo(0,0);
     }
     if (action === 'quick-start') {
@@ -2015,8 +2026,8 @@ document.addEventListener('DOMContentLoaded', () => {
         saveState(); document.getElementById('main').classList.remove('nav-back');
         step = 5; pushStep(); render(); window.scrollTo(0,0);
       } else {
-        if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
-        else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true });
+        if (preset === '1080p') Object.assign(S, { resolution:'1080p', audio:'standard', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true, simpleMode:true });
+        else Object.assign(S, { resolution:'4k', audio:'lossless', content:'all', formatter:'apex-v2', matchMode:'balanced', p2pEnabled:false, quickStart:true, simpleMode:true });
         saveState(); document.getElementById('main').classList.remove('nav-back');
         step = 1; pushStep(); render(); window.scrollTo(0,0);
       }


### PR DESCRIPTION
## Summary

The 4K · Lossless and 1080p · DD+ Quick Start cards return to the splash — but rebuilt on top of Easy Setup instead of the old flow:

- **Placement:** under "Or start from a preset", below the Easy/Custom buttons, with a one-line note: *"Presets pre-answer the resolution question — you still pick your service and device, then one-click install."*
- **What a preset does now:** sets resolution + audio + safe defaults, then runs service → device → keys → **Create & Install**. Two taps fewer than plain Easy Setup.
- **What's fixed vs the old Quick Start:** the old cards skipped the device step entirely, so Samsung/Fire Stick users got no DV-Only Kill or codec exclusions (purple-tint DV streams, unplayable AV1) — and they ended on the confusing full Review. Both problems are gone: device is asked, finish is one click.
- **Audio still self-corrects:** pick Samsung after the 4K preset and the Lossless audio pre-selection drops to DD+ with the explanatory toast, since the device profile wins.

Flow rules verified for all three modes:
- Preset: 1 → 2 → 5, Back 5 → 2 → 1
- Easy: 1 → 2 → 3 → 5, Back 5 → 3
- Custom: unchanged (1…6 with Back mirroring)

The Next button correctly shows "API Keys" from the device step for preset users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_