### PR TITLE
posts: v3.2 release announcement for r/CoreBuilds

### DIFF
--- a/posts/scheduled/2026-07-02-v320-release.md
+++ b/posts/scheduled/2026-07-02-v320-release.md
@@ -1,0 +1,57 @@
+---
+title: "v3.2 — ranked scoring restored (it had been silently dead), smarter season pack handling, and a big Labs drop"
+subreddit: CoreBuilds
+scheduled: 2026-07-02
+flair: Update
+---
+
+Big release today, and it starts with an honest confession.
+
+## The ranking bug nobody noticed — including us
+
+While researching Labs optimizations we found that the release-group scoring layer — the thing that ranks a FraMeSToR remux above a random encode with the same specs — has been **silently dead across every template** since the v2.8.x slimming.
+
+What happened: templates sync Vidhin05's regex list so patterns pass elfhosted's whitelist, but every entry in that list carries a score of zero. The scored copies that used to live inside each template were removed during slimming and never made it back. Result: the regex-score sort key has been sorting against nothing this whole time.
+
+**v3.2.0 restores it properly.** Every 4K template now carries 100 scored patterns (from +100 for Remux T1 down to −200 for junk), 1080p templates carry 96, and every single pattern string is verified byte-for-byte against Vidhin05's current file — so elfhosted and fortheweak imports both keep working. Anime templates are intentionally left out (SeaDex handles that job better).
+
+**You'll want to re-import your template to get this.** Every template took a version bump.
+
+## Season packs: hard kill, with a brain
+
+By popular request: on standard (non-anime) templates, asking for an episode now **never returns a season pack** when single episodes exist. No more 45 GB pack sitting above the 2 GB episode you actually wanted.
+
+v3.2.1 adds the important exception — the **Older-Show Pack Pass**. A show that ended 2+ years ago and only exists as packs (looking at you, everything pre-2015) keeps its packs instead of returning zero results. The rules:
+
+- Current/ongoing show with at least 1 single episode → packs gone
+- Any show with 3+ singles → packs gone
+- Ended show with fewer than 3 singles → packs stay
+
+Anime templates are fully exempt — batch releases are how good anime is distributed, and nothing changes there.
+
+## Labs got the biggest drop yet
+
+For nightly testers, five new systems (these graduate to stable if testing goes well):
+
+**1. Pattern-verified elite tiers.** The synced regex patterns now double as *named matchers* — a remux that matches Remux T1 or UHD Bluray T1 patterns gets its own tier **above** generic remuxes, and a pattern pin catches elite groups our hand-curated list misses. This is the replacement architecture for regex scoring: the signal lives in the expression layer where we can actually see it working.
+
+**2. Adaptive Seeder Guard.** Kills the bottom-quartile-seeded uncached torrents — but only on titles less than a year old with deep pools. Catalog titles are exempt, because a 2009 show with 4 seeders is normal, not suspicious. (Other SEL setups punish old content here; ours deliberately doesn't.)
+
+**3. p10–p90 fences.** When 8+ remuxes are available, the bitrate window tightens from the Tukey fence to the 10th–90th percentile — deeper pools earn stricter quality cuts.
+
+**4. Animation-aware bitrate floors.** Animation legitimately compresses ~50% smaller than live action at the same visual quality. The REMUX bitrate floors now recognize that instead of killing perfectly good animated releases.
+
+**5. Unknown-tag cleanup.** Streams with unrecognized resolution or quality get dropped — but only when 5+ properly-tagged alternatives exist. Thin results are never made thinner.
+
+## Also fixed
+
+The Samsung RU7100 template shipped with protection guards referencing regex names from a German SEL setup that don't exist in our sync — so its "don't kill good encodes" checks never matched and the kills fired unconditionally. If 4K BluRay results seemed thin on that template, that was why. Fixed.
+
+## TL;DR
+
+Re-import your template. Ranking is genuinely better now (it was quietly broken), episode requests stop drowning in season packs, old shows still work, and Labs testers get the most advanced expression stack we've shipped.
+
+Full changelog: https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md
+Templates: https://core-builds.mintlify.app/template-directory
+
+Questions below or on the [GitHub discussions](https://github.com/brevityA/Core-Builds/discussions).


### PR DESCRIPTION
## Summary

Reddit release post for v3.2.0 + v3.2.1, scheduled for **today's 18:00 UTC** auto-poster run (`posts/scheduled/2026-07-02-v320-release.md`, flair: Update).

Structure, in the established r/CoreBuilds voice:
- Opens with the honest story: the release-group scoring layer was silently dead fleet-wide since v2.8.x, and what v3.2.0 restores (100/96 scored patterns, verified against Vidhin05 for elfhosted/fortheweak compatibility)
- Season packs: hard kill explained in user terms ("no more 45 GB pack above the 2 GB episode"), plus the v3.2.1 Older-Show Pack Pass rules table and the anime exemption
- The five Labs systems in plain English (pattern-verified tiers, seeder guard with the catalog-title exemption, p10–p90 fences, animation-aware floors, Unknown cleanup)
- RU7100 fix note for anyone who saw thin 4K BluRay results there
- TL;DR with the re-import call to action + changelog/template links

Frontmatter validated against the poster script's parser (yaml loads, subreddit/flair/date all correct — merging before 18:00 UTC means it goes out tonight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_