### PR TITLE
4K Apex v0.7.4: Foreign Language Kill ESE (anime exempt)

### DIFF
--- a/Templates/Torbox/Single/core-nexus-4k-apex.json
+++ b/Templates/Torbox/Single/core-nexus-4k-apex.json
@@ -5,7 +5,7 @@
     "description": "Adaptive flagship build. Ranked-pool-relative bitrate PSEs using Tukey IQR outlier detection: \u22654 ranked streams \u2192 Q1\u22121.5\u00d7IQR to Q3+1.5\u00d7IQR window; 1\u20133 ranked \u2192 80%\u2013120% of min/max; 0 ranked \u2192 pow(0.95, daysSinceRelease) decay median cluster. HDR and SDR evaluated separately in the WEB-DL tier. Full ESE stack: REPACK passthrough, per-addon flood guard, Usenet propagation guard, codec efficiency booster, DV-Only Kill, audio pinnacle, and more.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -309,6 +309,10 @@
         "enabled": true
       },
       {
+        "expression": "/* CB | Foreign Language Kill (movies/series only \u2014 anime exempt) */ (queryType == 'movie' or queryType == 'series') ? negate(merge(library(streams), seadex(streams), language(streams, 'English', 'Original', 'Multi', 'Dual Audio', 'Dubbed', 'Unknown')), streams) : []",
+        "enabled": true
+      },
+      {
         "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
         "enabled": true
       },
@@ -435,10 +439,6 @@
       {
         "expression": "/*REPACK/PROPER Passthrough*/ count(keyword(negate(merge(library(streams),seadex(streams)),streams),'all','repack','proper'))>0?passthrough(keyword(negate(merge(library(streams),seadex(streams)),streams),'all','repack','proper'),'excluded','limit'):[]",
         "enabled": true
-      },
-      {
-        "enabled": true,
-        "expression": "/* Language Exclusive \u2014 English */ language(streams,'English','Original','Multi','Dual Audio','Dubbed','Unknown')"
       }
     ],
     "rankedStreamExpressions": [],


### PR DESCRIPTION
## Summary
- **Foreign Language Kill ESE** added to 4K Apex — excludes streams not tagged as English, Original, Multi, Dual Audio, Dubbed, or Unknown. Polish, Russian, French, etc. streams are killed.
- **Conditional on `queryType`** — only fires for `movie` and `series`. Anime queries (`anime.movie`, `anime.series`) are fully exempt so Japanese-only streams are preserved.
- **Replaces** the unconditional Language Exclusive ISE from v0.7.3, which would have also killed Japanese anime streams.
- Library and SeaDex matches are always preserved regardless of language.

## ESE expression
```
(queryType == 'movie' or queryType == 'series') ? negate(merge(library(streams), seadex(streams), language(streams, 'English', 'Original', 'Multi', 'Dual Audio', 'Dubbed', 'Unknown')), streams) : []
```

## Test plan
- [x] 70 template validation tests pass
- [ ] Manual: verify non-English streams excluded for movie queries
- [ ] Manual: verify anime queries still return Japanese-only streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_