### PR TITLE
filtering: add apex-flagship.json expression bundle

### DIFF
--- a/Filtering/expressions/README.md
+++ b/Filtering/expressions/README.md
@@ -2,7 +2,7 @@
 
 Individual expression files split by category — use only the ones you need.
 
-> These are the same expressions from the combined files (`core-builds-eses.json`, `core-builds-ises.json`, `core-builds-pses.json`) split into standalone modules. No duplicates between files.
+> These are the same expressions from the combined files (`core-builds-eses.json`, `core-builds-ises.json`, `core-builds-pses.json`) split into standalone modules. No duplicates between category files. The flagship file (`apex-flagship.json`) intentionally overlaps with category files — it collects all Apex-specific expressions into one import.
 
 ---
 
@@ -36,6 +36,14 @@ Individual expression files split by category — use only the ones you need.
 | `device-pses.json` | 13 | Samsung, Ultrawide, Apple TV device PSEs |
 | `labs-pses.json` | 23 | Experimental: S+ tier, pattern-verified, perGroup |
 
+## Flagship Bundle
+
+| File | ESEs | PSEs | Use Case |
+|---|---|---|---|
+| `apex-flagship.json` | 4 | 16 | All Apex-specific expressions in one file: Score IQR Guard, perGroup dedup, IQR Tukey fence bitrate PSEs, APEX static tiers, elite group pins |
+
+> `apex-flagship.json` is a structured JSON with `eses` and `pses` keys. It overlaps with `advanced-eses.json`, `iqr-pses.json`, `cb-static-pses.json`, and `pins-pses.json` by design — use it *instead of* those files for an Apex-only setup.
+
 ---
 
 ## Recommended Combinations
@@ -43,7 +51,10 @@ Individual expression files split by category — use only the ones you need.
 **Basic setup (any debrid):**
 `core-eses.json` + `core-ises.json` + `cb-static-pses.json` + `universal-pses.json`
 
-**4K flagship:**
+**4K Apex (flagship bundle):**
+`core-eses.json` + `advanced-eses.json` + `core-ises.json` + `apex-flagship.json` + `universal-pses.json`
+
+**4K flagship (by category):**
 `core-eses.json` + `advanced-eses.json` + `core-ises.json` + `iqr-pses.json` + `universal-pses.json` + `pins-pses.json`
 
 **Anime:**

--- a/Filtering/expressions/apex-flagship.json
+++ b/Filtering/expressions/apex-flagship.json
@@ -1,0 +1,203 @@
+{
+  "eses": [
+    {
+      "expression": "/* Score IQR Guard */ count(negate(merge(library(streams), seadex(streams)), merge(cached(streams), type(streams, 'p2p', 'http')))) >= 8 ? streamExpressionScore(negate(merge(library(streams), seadex(streams)), streams), -1000000, q1(values(negate(merge(library(streams), seadex(streams)), streams), 'seScore')) - 1.5 * iqr(values(negate(merge(library(streams), seadex(streams)), streams), 'seScore'))) : []",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* Extra Cached HQ */ negate(perGroup(negate(merge(library(streams), uncached(streams)), quality(streams, 'Bluray REMUX', 'Bluray', 'WEB-DL', 'WEBRip')), 'resolution', 3), negate(merge(library(streams), uncached(streams)), quality(streams, 'Bluray REMUX', 'Bluray', 'WEB-DL', 'WEBRip')))",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* Extra Cached LQ */ negate(perGroup(negate(merge(library(streams), uncached(streams)), quality(streams, 'HDTV', 'HDRip', 'DVDRip', 'HC HD-Rip', 'CAM', 'TS', 'TC', 'SCR', 'Unknown')), 'resolution', 3), negate(merge(library(streams), uncached(streams)), quality(streams, 'HDTV', 'HDRip', 'DVDRip', 'HC HD-Rip', 'CAM', 'TS', 'TC', 'SCR', 'Unknown')))",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* Extra Uncached */ negate(perGroup(uncached(streams), 'resolution', 3), uncached(streams))",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    }
+  ],
+  "pses": [
+    {
+      "expression": "/* Elite 4K Remux pin */ pin(releaseGroup(quality(resolution(streams, 'BluRay REMUX'), '2160p'), 'FraMeSToR', 'DON', 'FLUX', 'HIFI', 'playBD', 'BMF', 'QxR', 'EPSiLON', 'BLURANiUM', 'PmP'), 'top')",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* Elite 1080p Remux pin */ pin(releaseGroup(quality(resolution(streams, 'BluRay REMUX'), '1080p'), 'NTb', 'FLUX', 'KiNGS', 'NTG', 'BHDStudio', 'FraMeSToR', 'SiC', '126811'), 'top')",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* LQ group pin bottom */ pin(releaseGroup(streams, 'YIFY', 'RARBG', 'EVO', 'YTS', 'PSA', 'MeGusta', 'Tigole'), 'bottom')",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/* IMAX pin */ count(visualTag(streams, 'IMAX')) > 0 ? pin(visualTag(streams, 'IMAX'), 'top') : []",
+      "enabled": true,
+      "templates": [
+        "4K AllDebrid",
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Essential",
+        "4K Hybrid"
+      ]
+    },
+    {
+      "expression": "/*APEX S-Tier 4K Remux \u2014 IQR Tukey fence (\u22654 ranked) \u00b7 min/max fallback (1\u20133) \u00b7 size floor 15GB*/ count(resolution(quality(streams,'BluRay REMUX'),'2160p'))>=4?size(bitrate(resolution(quality(streams,'BluRay REMUX'),'2160p'),q1(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate')),q3(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate'))+1.5*iqr(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate'))), '15GB'):count(resolution(quality(streams,'BluRay REMUX'),'2160p'))>0?size(bitrate(resolution(quality(streams,'BluRay REMUX'),'2160p'),min(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate'))*0.80,max(values(resolution(quality(streams,'BluRay REMUX'),'2160p'),'bitrate'))*1.20), '15GB'):[]",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/*APEX A-Tier 4K WEB-DL HDR \u2014 IQR Tukey fence (\u22654) \u00b7 min/max fallback (1\u20133) \u00b7 age-decay median window (pow 0.95/d)*/ count(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'))>=4?bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),q1(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate')),q3(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))+1.5*iqr(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))):count(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'))>0?bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),min(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))*0.80,max(values(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))*1.20):((count(bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),median(values(bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease)),median(values(bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1+0.4*pow(0.95,daysSinceRelease))))>=1?bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),median(values(bitrate(resolution(visualTag(quality(streams,'WEB-DL'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease))):[]))",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex Labs"
+      ]
+    },
+    {
+      "expression": "/*APEX B-Tier 4K WEB-DL SDR \u2014 IQR Tukey fence (\u22654) \u00b7 min/max fallback (1\u20133) \u00b7 age-decay median window (pow 0.95/d)*/ count(resolution(quality(streams,'WEB-DL'),'2160p'))>=4?bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),q1(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate')),q3(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate'))+1.5*iqr(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate'))):count(resolution(quality(streams,'WEB-DL'),'2160p'))>0?bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),min(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate'))*0.80,max(values(resolution(quality(streams,'WEB-DL'),'2160p'),'bitrate'))*1.20):((count(bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease)),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),'5Mbps'),'bitrate'))*(1+0.4*pow(0.95,daysSinceRelease))))>=1?bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease))):[]))",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/*APEX C-Tier 4K WEBRip HDR \u2014 IQR Tukey fence (\u22654) \u00b7 min/max fallback (1\u20133) \u00b7 age-decay median window (pow 0.95/d)*/ count(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'))>=4?bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),q1(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate')),q3(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))+1.5*iqr(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))):count(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'))>0?bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),min(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))*0.80,max(values(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'bitrate'))*1.20):((count(bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),median(values(bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease)),median(values(bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1+0.4*pow(0.95,daysSinceRelease))))>=1?bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),median(values(bitrate(resolution(visualTag(quality(streams,'WEBRip'),'HDR+DV','DV','HDR10+','HDR10','HDR'),'2160p'),'5Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease))):[]))",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex Labs"
+      ]
+    },
+    {
+      "expression": "/*APEX D-Tier 4K WEBRip SDR \u2014 IQR Tukey fence (\u22654) \u00b7 min/max fallback (1\u20133)*/ count(resolution(quality(streams,'WEBRip'),'2160p'))>=4?bitrate(resolution(quality(streams,'WEBRip'),'2160p'),q1(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate')),q3(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate'))+1.5*iqr(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate'))):count(resolution(quality(streams,'WEBRip'),'2160p'))>0?bitrate(resolution(quality(streams,'WEBRip'),'2160p'),min(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate'))*0.80,max(values(resolution(quality(streams,'WEBRip'),'2160p'),'bitrate'))*1.20):[]",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/* APEX E-Tier 4K | Any 2160p fallback */ resolution(streams,'2160p')",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/*APEX S-Tier 1080p Remux \u2014 IQR Tukey fence (\u22654 ranked) \u00b7 min/max fallback (1\u20133) \u00b7 size floor 8GB*/ count(resolution(quality(streams,'BluRay REMUX'),'1080p'))>=4?size(bitrate(resolution(quality(streams,'BluRay REMUX'),'1080p'),q1(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate')),q3(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate'))+1.5*iqr(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate'))), '8GB'):count(resolution(quality(streams,'BluRay REMUX'),'1080p'))>0?size(bitrate(resolution(quality(streams,'BluRay REMUX'),'1080p'),min(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate'))*0.80,max(values(resolution(quality(streams,'BluRay REMUX'),'1080p'),'bitrate'))*1.20), '8GB'):[]",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/*APEX A-Tier 1080p WEB-DL \u2014 IQR Tukey fence (\u22654) \u00b7 min/max fallback (1\u20133) \u00b7 age-decay median window (pow 0.95/d)*/ count(resolution(quality(streams,'WEB-DL'),'1080p'))>=4?bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),q1(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate')),q3(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate'))+1.5*iqr(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate'))):count(resolution(quality(streams,'WEB-DL'),'1080p'))>0?bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),min(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate'))*0.80,max(values(resolution(quality(streams,'WEB-DL'),'1080p'),'bitrate'))*1.20):((count(bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),'1Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease)),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),'1Mbps'),'bitrate'))*(1+0.4*pow(0.95,daysSinceRelease))))>=1?bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),median(values(bitrate(resolution(quality(streams,'WEB-DL'),'1080p'),'1Mbps'),'bitrate'))*(1-0.4*pow(0.95,daysSinceRelease))):[]))",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/* APEX B-Tier 1080p | WEBRip or BluRay */ resolution(quality(streams,'WEBRip','BluRay'),'1080p')",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/* APEX C-Tier 1080p | Any 1080p */ resolution(streams,'1080p')",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/* APEX 720p | WEB-DL or WEBRip */ resolution(quality(streams,'WEB-DL','WEBRip'),'720p')",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    },
+    {
+      "expression": "/* APEX 720p | Any */ resolution(streams,'720p')",
+      "enabled": true,
+      "templates": [
+        "4K Apex",
+        "4K Apex (TorBox)",
+        "4K Apex Labs",
+        "Samsung RU7100 4K"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- New `Filtering/expressions/apex-flagship.json` — single-file bundle of all 20 Apex-specific expressions (4 ESEs + 16 PSEs)
- Structured as `{ "eses": [...], "pses": [...] }` for easy import
- Contains: Score IQR Guard, perGroup dedup (HQ/LQ/Uncached), 7 IQR Tukey fence bitrate PSEs, 5 APEX static tiers, 4 elite group pins
- README updated with Apex flagship combination and overlap note

## Test plan

- [x] All 20 expressions match the actual 4K Apex template
- [x] JSON valid and parseable
- [x] README reflects new file and recommended combination

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqqHGvBDtxq4EUt2nNPBnj)_