### PR TITLE
Configurator v2.15: Cloudflare Worker CORS proxy for Create & Install

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,22 @@
+name: Deploy CORS Proxy Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cloudflare-worker/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: cloudflare-worker

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -1,0 +1,48 @@
+# CORS proxy for the configurator
+
+The configurator's "Create & Install" flow tries to POST a config directly to
+each public AIOStreams instance's `/api/v1/user` endpoint from the browser.
+Most of those instances don't send `Access-Control-Allow-Origin`, so the
+browser request is blocked before a response ever comes back — today the
+configurator silently falls back to a manual paste-back flow when that happens.
+
+`worker.js` is a small Cloudflare Worker that re-issues the same request
+server-to-server (CORS doesn't apply there) and returns the result with
+permissive CORS headers, so the browser can use it. It only forwards to the
+seven hardcoded public AIOStreams hosts in `ALLOWED_HOSTS` — nothing else, and
+nothing is logged or stored.
+
+The configurator races a direct browser fetch against a proxied fetch via
+`raceHostFetch()` (`configurator/index.src.html`) — whichever responds first
+wins, so this is a pure improvement: if an instance ever adds CORS headers
+itself, the direct attempt keeps winning as before.
+
+## Deploy
+
+Requires a free Cloudflare account and [wrangler](https://developers.cloudflare.com/workers/wrangler/):
+
+```bash
+cd cloudflare-worker
+npx wrangler login
+npx wrangler deploy
+```
+
+The deploy output prints your Worker's URL:
+`https://core-builds-cors-proxy.<your-subdomain>.workers.dev`
+
+## Wire it into the configurator
+
+1. Open `configurator/index.src.html` and set `CORS_PROXY` to the URL above.
+2. Rebuild the obfuscated bundle: `node configurator/build.js`.
+3. Commit both `index.src.html` and `index.html`.
+
+Set `CORS_PROXY = ''` to disable the proxy and fall back to direct-fetch-only
+(today's behavior).
+
+## CI auto-deploy (optional)
+
+`.github/workflows/deploy-worker.yml` deploys automatically on push to
+`cloudflare-worker/**` if these repo secrets are set:
+
+- `CLOUDFLARE_API_TOKEN` — a token with Workers Scripts:Edit permission
+- `CLOUDFLARE_ACCOUNT_ID` — found on the Cloudflare dashboard's right sidebar

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -1,0 +1,82 @@
+// Core Builds — CORS proxy for the configurator's "Create & Install" flow.
+//
+// Most public AIOStreams instances don't send Access-Control-Allow-Origin, so a
+// browser POST/PATCH to their /api/v1/user endpoint fails before the configurator
+// ever sees a response. This Worker re-issues that same request server-to-server
+// (no CORS restriction applies there) and hands the result back with permissive
+// CORS headers, so the browser's Promise.any() race can pick it up.
+//
+// Nothing is logged, stored, or inspected — the request body (which may contain
+// the user's debrid credentials) is streamed through unchanged to the upstream host.
+
+const ALLOWED_HOSTS = new Set([
+  'https://aiostreams.elfhosted.com',
+  'https://aiostreams.fortheweak.cloud',
+  'https://aiostreamsfortheweebsstable.midnightignite.me',
+  'https://aiostreams.viren070.me',
+  'https://aiostreams.stremio.ru',
+  'https://aio.atbphosting.com',
+  'https://aiostreams.12312023.xyz',
+]);
+
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PATCH']);
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '86400',
+};
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+  });
+}
+
+export default {
+  async fetch(request) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith('/proxy/')) {
+      return json(404, { error: 'not found' });
+    }
+    if (!ALLOWED_METHODS.has(request.method)) {
+      return json(405, { error: 'method not allowed' });
+    }
+
+    const host = url.searchParams.get('host');
+    if (!host || !ALLOWED_HOSTS.has(host)) {
+      return json(403, { error: 'host not allowed' });
+    }
+
+    const upstreamPath = url.pathname.slice('/proxy'.length);
+    const upstreamUrl = host + upstreamPath;
+
+    const upstreamReq = new Request(upstreamUrl, {
+      method: request.method,
+      headers: { 'Content-Type': request.headers.get('Content-Type') || 'application/json' },
+      body: request.method === 'GET' ? undefined : await request.text(),
+    });
+
+    let upstreamRes;
+    try {
+      upstreamRes = await fetch(upstreamReq);
+    } catch (e) {
+      return json(502, { error: 'upstream unreachable' });
+    }
+
+    const body = await upstreamRes.text();
+    return new Response(body, {
+      status: upstreamRes.status,
+      headers: {
+        'Content-Type': upstreamRes.headers.get('Content-Type') || 'application/json',
+        ...CORS_HEADERS,
+      },
+    });
+  },
+};

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,6 @@
+name = "core-builds-cors-proxy"
+main = "worker.js"
+compatibility_date = "2026-01-01"
+
+[observability]
+enabled = false

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -612,7 +612,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .receipt-row[data-action]:hover{background:rgba(0,212,255,.05)}
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>
-<script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('cbTheme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'))}catch(e){}</script>
+<script>var _0x42ccdf=_0x548a;(function(_0x8dd5,_0x49c8cd){var _0x3a06fb={_0x2eb53d:0xa4,_0x4829b9:0x9c,_0x5ceb87:0x9e,_0x20e935:0x9b,_0x5bb497:0x98},_0x5af15a=_0x548a,_0x42ed54=_0x8dd5();while(!![]){try{var _0x1d6ac2=parseInt(_0x5af15a(0x9d))/(-0x1*-0x105f+-0x136c+-0x30e*-0x1)*(-parseInt(_0x5af15a(0xa2))/(0x959*0x3+0x3d4+0x1*-0x1fdd))+-parseInt(_0x5af15a(_0x3a06fb._0x2eb53d))/(-0x1e*0xb+-0xf*0x24+0x369)+-parseInt(_0x5af15a(_0x3a06fb._0x4829b9))/(-0x2591+-0x192d+0x115*0x3a)+-parseInt(_0x5af15a(0xa7))/(-0xcb2+-0xc0c*-0x3+-0x176d)*(-parseInt(_0x5af15a(_0x3a06fb._0x5ceb87))/(0xa22+0xe4*-0x23+0x1510))+parseInt(_0x5af15a(0x9a))/(0x1f1+-0x152+-0x8*0x13)*(parseInt(_0x5af15a(0x9f))/(0x1d3b*-0x1+0x2549+-0x806))+-parseInt(_0x5af15a(_0x3a06fb._0x20e935))/(-0x1a*0x92+-0xe63*-0x2+-0xde9*0x1)+parseInt(_0x5af15a(_0x3a06fb._0x5bb497))/(0x1*0x1fc+0xaff+-0xcf1);if(_0x1d6ac2===_0x49c8cd)break;else _0x42ed54['push'](_0x42ed54['shift']());}catch(_0x5d82be){_0x42ed54['push'](_0x42ed54['shift']());}}}(_0x3d07,-0x26*-0xbba+0x25cf*-0x1a+0x54029));try{document[_0x42ccdf(0xa5)][_0x42ccdf(0xa6)](_0x42ccdf(0xa3),localStorage[_0x42ccdf(0xa0)](_0x42ccdf(0xa1))||(window[_0x42ccdf(0xa8)]('(prefers-color-scheme:dark)')['matches']?_0x42ccdf(0x99):'light'));}catch(_0xf67c7f){}function _0x548a(_0x156a11,_0x9c30f){_0x156a11=_0x156a11-(0x967*-0x2+-0xfe+-0x244*-0x9);var _0x43ac01=_0x3d07();var _0x17fbca=_0x43ac01[_0x156a11];if(_0x548a['vYHYjS']===undefined){var _0x338ad9=function(_0x1eee17){var _0x51eaf6='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';var _0x345cae='',_0x378654='';for(var _0x526fe2=-0x222f+0xa07+0x1828,_0x1fe398,_0x543c6f,_0x384d6a=-0x156a+0x1582*-0x1+0x2aec;_0x543c6f=_0x1eee17['charAt'](_0x384d6a++);~_0x543c6f&&(_0x1fe398=_0x526fe2%(0x2494+0x1f8b+-0x37*0x13d)?_0x1fe398*(0x1a62+0xe99+0x28bb*-0x1)+_0x543c6f:_0x543c6f,_0x526fe2++%(-0x90+-0x10f+0x1*0x1a3))?_0x345cae+=String['fromCharCode'](-0xde8+-0x6d*-0x37+-0x884&_0x1fe398>>(-(-0x1*-0x182f+-0x1*0x17b9+-0x74)*_0x526fe2&0x1*-0x872+0x1922+-0x10aa)):-0x173c+-0x1*-0x2063+0x1*-0x927){_0x543c6f=_0x51eaf6['indexOf'](_0x543c6f);}for(var _0x2e1d21=0x1f2a+0x1605*-0x1+-0x925,_0x2d1caa=_0x345cae['length'];_0x2e1d21<_0x2d1caa;_0x2e1d21++){_0x378654+='%'+('00'+_0x345cae['charCodeAt'](_0x2e1d21)['toString'](-0x10e7*-0x1+0xb03+-0x1bda))['slice'](-(-0x8e9+0x24bc+-0x1bd1*0x1));}return decodeURIComponent(_0x378654);};_0x548a['RaTctR']=_0x338ad9,_0x548a['ZBkhgd']={},_0x548a['vYHYjS']=!![];}var _0x2ea0bb=_0x43ac01[0xe22+0x1c6*-0x12+0x11ca],_0x181858=_0x156a11+_0x2ea0bb,_0x59ae22=_0x548a['ZBkhgd'][_0x181858];return!_0x59ae22?(_0x17fbca=_0x548a['RaTctR'](_0x17fbca),_0x548a['ZBkhgd'][_0x181858]=_0x17fbca):_0x17fbca=_0x59ae22,_0x17fbca;}function _0x3d07(){var _0x5e9c46=['C2v0qxr0CMLIDxrL','mJbcB3PRvMG','Bwf0y2HnzwrPyq','mtm3otuYmgHjt29Syq','zgfYAW','nJn5tvvVteG','ntm2oduWyxrdAKPL','nduWntmYq3r1Dvfy','mJi2ndm5tLb6EMTJ','ndK0nti2r29wqvvS','mZi0ndCYs2vOzNvz','z2v0sxrLBq','y2juAgvTzq','mKHjCvb4qq','zgf0ys10AgvTzq','nJGYmJu0BwzrA0f1','zg9JDw1LBNrfBgvTzw50'];_0x3d07=function(){return _0x5e9c46;};return _0x3d07();}</script>
 </head>
 <body>
 <div id="cb-loader">
@@ -666,11 +666,15 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.14';
+const CONFIGURATOR_VERSION = '2.15';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.15', date:'Jul 5 2026', items:[
+    'Create & Install now races direct API calls against a Cloudflare Worker CORS proxy — most public AIOStreams hosts block cross-origin POST/PATCH, so the proxy (server-to-server, no CORS) usually wins where a direct call previously fell back to the manual paste-back flow',
+    'No behavior change if a host ever adds CORS headers itself — the direct attempt still wins the race',
+  ]},
   { v:'2.14', date:'Jul 4 2026', items:[
     'StreamNZB added to Other Services — self-hosted Usenet indexer + streamer',
     'StreamNZB manifest URL input on API step, stripped from import URLs for security',
@@ -863,6 +867,9 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
+// Cloudflare Worker CORS proxy — see cloudflare-worker/README.md for deployment.
+// Set to '' to disable and fall back to direct-only fetches.
+const CORS_PROXY = 'https://core-builds-cors-proxy.brevitya.workers.dev';
 const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', telemetryOk: false, simpleMode: false };
 
 const FORMATTERS = [
@@ -3070,7 +3077,7 @@ async function simpleInstall() {
   try {
     const winner = await Promise.any(
       hosts.map(([, host]) =>
-        fetchWithTimeout(`${host}/api/v1/user`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
+        raceHostFetch(host, '/api/v1/user', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
           .then(async res => {
             const data = await res.json().catch(() => ({}));
             if (res.ok && data?.success !== false) return { host, uuid: data?.uuid || data?.user?.uuid || data?.id };
@@ -3294,6 +3301,16 @@ async function fetchWithTimeout(url, options = {}, timeout = 6000) {
   finally { clearTimeout(id); }
 }
 
+// Races a direct browser fetch against the Cloudflare Worker CORS proxy for the same
+// AIOStreams host/path — most public instances don't send CORS headers, so the direct
+// attempt fails fast and the proxied one (server-to-server, no CORS) wins. Whichever
+// resolves first is used; if CORS_PROXY is unset only the direct attempt runs.
+function raceHostFetch(host, path, options, timeout) {
+  const attempts = [fetchWithTimeout(`${host}${path}`, options, timeout)];
+  if (CORS_PROXY) attempts.push(fetchWithTimeout(`${CORS_PROXY}/proxy${path}?host=${encodeURIComponent(host)}`, options, timeout));
+  return Promise.any(attempts);
+}
+
 async function uploadTemplateForImport() {
   const tmpl = build();
   if (tmpl.config) {
@@ -3382,7 +3399,7 @@ async function openInAIOStreams() {
     const existingUuid = validateUuid(uuid) ? uuid : null;
     const attempt = (id) => Promise.any(
       Object.values(HOST_URLS).map(host =>
-        fetchWithTimeout(id ? `${host}/api/v1/user/${id}` : `${host}/api/v1/user`, { method: id ? 'PATCH' : 'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
+        raceHostFetch(host, id ? `/api/v1/user/${id}` : '/api/v1/user', { method: id ? 'PATCH' : 'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
           .then(async res => {
             const data = await res.json().catch(()=>({}));
             if (res.ok && data?.success !== false) return { host, uuid: id || data?.uuid || data?.user?.uuid || data?.id };

--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -666,11 +666,15 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.14';
+const CONFIGURATOR_VERSION = '2.15';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
 const CHANGELOG = [
+  { v:'2.15', date:'Jul 5 2026', items:[
+    'Create & Install now races direct API calls against a Cloudflare Worker CORS proxy — most public AIOStreams hosts block cross-origin POST/PATCH, so the proxy (server-to-server, no CORS) usually wins where a direct call previously fell back to the manual paste-back flow',
+    'No behavior change if a host ever adds CORS headers itself — the direct attempt still wins the race',
+  ]},
   { v:'2.14', date:'Jul 4 2026', items:[
     'StreamNZB added to Other Services — self-hosted Usenet indexer + streamer',
     'StreamNZB manifest URL input on API step, stripped from import URLs for security',
@@ -863,6 +867,9 @@ let hadSavedState = false;
 let _savedStep = 0;
 let pasteMode = false;
 const HOST_BASE_URLS = { elfhosted:'https://aiostreams.elfhosted.com', fortheweak:'https://aiostreams.fortheweak.cloud', midnight:'https://aiostreamsfortheweebsstable.midnightignite.me', viren:'https://aiostreams.viren070.me', kuu:'https://aiostreams.stremio.ru', atbp:'https://aio.atbphosting.com', omni:'https://aiostreams.12312023.xyz' };
+// Cloudflare Worker CORS proxy — see cloudflare-worker/README.md for deployment.
+// Set to '' to disable and fall back to direct-only fetches.
+const CORS_PROXY = 'https://core-builds-cors-proxy.brevitya.workers.dev';
 const S = { service:null, device:null, resolution:null, audio:'limited', content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'apex-v2', p2pEnabled:false, qualityFirst:false, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', telemetryOk: false, simpleMode: false };
 
 const FORMATTERS = [
@@ -3070,7 +3077,7 @@ async function simpleInstall() {
   try {
     const winner = await Promise.any(
       hosts.map(([, host]) =>
-        fetchWithTimeout(`${host}/api/v1/user`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
+        raceHostFetch(host, '/api/v1/user', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
           .then(async res => {
             const data = await res.json().catch(() => ({}));
             if (res.ok && data?.success !== false) return { host, uuid: data?.uuid || data?.user?.uuid || data?.id };
@@ -3294,6 +3301,16 @@ async function fetchWithTimeout(url, options = {}, timeout = 6000) {
   finally { clearTimeout(id); }
 }
 
+// Races a direct browser fetch against the Cloudflare Worker CORS proxy for the same
+// AIOStreams host/path — most public instances don't send CORS headers, so the direct
+// attempt fails fast and the proxied one (server-to-server, no CORS) wins. Whichever
+// resolves first is used; if CORS_PROXY is unset only the direct attempt runs.
+function raceHostFetch(host, path, options, timeout) {
+  const attempts = [fetchWithTimeout(`${host}${path}`, options, timeout)];
+  if (CORS_PROXY) attempts.push(fetchWithTimeout(`${CORS_PROXY}/proxy${path}?host=${encodeURIComponent(host)}`, options, timeout));
+  return Promise.any(attempts);
+}
+
 async function uploadTemplateForImport() {
   const tmpl = build();
   if (tmpl.config) {
@@ -3382,7 +3399,7 @@ async function openInAIOStreams() {
     const existingUuid = validateUuid(uuid) ? uuid : null;
     const attempt = (id) => Promise.any(
       Object.values(HOST_URLS).map(host =>
-        fetchWithTimeout(id ? `${host}/api/v1/user/${id}` : `${host}/api/v1/user`, { method: id ? 'PATCH' : 'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
+        raceHostFetch(host, id ? `/api/v1/user/${id}` : '/api/v1/user', { method: id ? 'PATCH' : 'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ config:cfg, password:pwd }) }, 5000)
           .then(async res => {
             const data = await res.json().catch(()=>({}));
             if (res.ok && data?.success !== false) return { host, uuid: id || data?.uuid || data?.user?.uuid || data?.id };


### PR DESCRIPTION
## Description

The configurator's "Create & Install" flow (`simpleInstall()` / `openInAIOStreams()`) tries to POST/PATCH a config directly to each public AIOStreams instance's `/api/v1/user` endpoint from the browser via `Promise.any()`. Most of those instances don't send `Access-Control-Allow-Origin`, so the browser call is blocked before a response ever arrives — today that silently falls back to the manual paste-back flow (generate password → open AIOStreams → copy/paste manifest URL back).

This adds a Cloudflare Worker (`cloudflare-worker/worker.js`) that re-issues the same request server-to-server (CORS doesn't apply there) and returns the result with permissive CORS headers. It only forwards to the 7 hardcoded public AIOStreams hosts already used elsewhere in the configurator — nothing else — and doesn't log or store anything.

`raceHostFetch()` (new helper in `index.src.html`) races a direct browser fetch against the proxied fetch for each host; whichever responds first wins. This is a pure addition — if an instance ever adds CORS headers itself, the direct attempt keeps winning the race exactly as before.

**Note:** `CORS_PROXY` in `index.src.html` currently points at a placeholder URL (`https://core-builds-cors-proxy.brevitya.workers.dev`) since I don't have the repo owner's Cloudflare account to deploy against. Until the Worker is actually deployed at that URL (or `CORS_PROXY` is updated to match), the proxied attempt just fails harmlessly and behavior is identical to today — see `cloudflare-worker/README.md` for deploy steps and how to point `CORS_PROXY` at the real URL. A GitHub Actions workflow (`deploy-worker.yml`) is included to auto-deploy on push once `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` repo secrets are set.

## Type of Change
- [ ] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [ ] Documentation update
- [x] Workflow / infrastructure

## Testing
- Verified `index.src.html`'s script block parses without syntax errors and `raceHostFetch`/`CORS_PROXY` land correctly in the rebuilt `index.html` (`node configurator/build.js`)
- Verified `cloudflare-worker/worker.js` passes `node --check`
- Did not deploy the Worker (no Cloudflare credentials available in this session) — needs deployment + `CORS_PROXY` URL update per `cloudflare-worker/README.md` before it's live

## Related Issues
None


---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9mRCLarnZhKzG5GvKoKm)_