### PR TITLE
Potential fix for code scanning alert no. 7: Bad HTML filtering regexp

### DIFF
--- a/configurator/build.js
+++ b/configurator/build.js
@@ -13,7 +13,7 @@ const outPath = path.join(__dirname, 'index.html');
 
 const html = fs.readFileSync(srcPath, 'utf8');
 
-const scriptBlocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+const scriptBlocks = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/gi)];
 if (!scriptBlocks.length) { console.error('No <script> blocks found'); process.exit(1); }
 
 let largest = scriptBlocks[0];


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/7](https://github.com/brevityA/Core-Builds/security/code-scanning/7)

In general, avoid custom HTML-tag regex parsing where possible and use an HTML parser library. Given the constraints and minimal-change requirement, the best fix is to harden the existing regex so it handles case-insensitive tag names and common script tag forms (attributes/whitespace in opening and closing tags).

In `configurator/build.js`, replace line 16’s regex with a case-insensitive pattern that:
- matches `<script` with word boundary,
- allows attributes in opening tag (`[^>]*`),
- captures content non-greedily (`[\s\S]*?`),
- matches closing `</script>` allowing optional trailing junk before `>` (browser-tolerant),
- uses `gi` flags (global + case-insensitive).

No new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
