### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/configurator/index.src.html
+++ b/configurator/index.src.html
@@ -1109,6 +1109,12 @@ function label(key, val) {
 function renderOpts(def) {
   const key = def.key, id = def.id;
   const inp = (o) => `<input type="radio" name="${id}" id="o_${o.v}" value="${o.v}" ${S[key]===o.v?'checked':''} data-action="update-radio" data-key="${key}">`;
+  const escHtml = (s) => String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   const body = (o) => `<div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc}</div></div>`;
   const std = (o, cls='') => `<div class="opt${cls}">${inp(o)}<label for="o_${o.v}"><div class="opt-icon">${o.icon}</div>${body(o)}</label></div>`;
 
@@ -1137,7 +1143,7 @@ function renderOpts(def) {
     if (def.noHero) {
       const rows = def.opts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
         <div class="opt-icon">${o.icon}</div>
-        <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc.replace(/<[^>]*>/g,'')}</div></div>
+        <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${escHtml(o.desc)}</div></div>
         ${o.help ? `<button type="button" class="help-btn" data-action="toggle-device-help" data-v="${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>` : ''}
         <span class="svc-list-arr">›</span>
       </label>${o.help ? `<div class="device-help" id="help_${o.v}">${o.help}</div>` : ''}</div>`).join('');


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/6](https://github.com/brevityA/Core-Builds/security/code-scanning/6)

The best fix is to **HTML-escape untrusted text before interpolation**, rather than trying to strip tags with a regex. Escaping `&`, `<`, `>`, `"` and `'` guarantees that any residual tag/script syntax is rendered as text, not interpreted as HTML, while preserving displayed content.

In `configurator/index.src.html`, within `renderOpts(def)`, replace the inline `o.desc.replace(/<[^>]*>/g,'')` usage with a call to a small local escaping helper defined in the same function scope (so no imports/dependencies needed). Specifically:
- Add a helper like `escHtml` right after existing local helper declarations (`inp`, `body`, `std` area).
- Update line 1140 region to use `${escHtml(o.desc)}`.

This avoids incomplete sanitization and keeps functionality (displaying description text) intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
