### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_status_check.py
+++ b/tests/test_status_check.py
@@ -102,8 +102,8 @@ class TestBuildTable:
     def test_table_strips_https_prefix_for_display(self):
         with patch("status_check.check", return_value="🟢 Online"):
             table = status_check.build_table(self.INSTANCES)
-        # The display URL omits "https://"
-        assert "example.com" in table
+        # The display URL omits "https://" while preserving full URL as href
+        assert "[example.com](https://example.com/stremio/configure)" in table
 
     def test_table_strips_stremio_configure_suffix(self):
         with patch("status_check.check", return_value="🟢 Online"):


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/5](https://github.com/brevityA/Core-Builds/security/code-scanning/5)

Replace the broad substring assertion with an exact expected markdown link fragment for the display URL and href.  
In `tests/test_status_check.py`, update `test_table_strips_https_prefix_for_display` so it asserts that the table contains `[example.com](https://example.com/stremio/configure)` (or equivalent exact rendering used by `build_table`), rather than just `"example.com"` anywhere.

This preserves functionality (still testing that `https://` is removed in display text) while eliminating incomplete substring matching. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
