### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,9 @@
 name: Validate Templates
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/4](https://github.com/brevityA/Core-Builds/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root (applies to all jobs) in `.github/workflows/validate.yml`, directly under `name:` and before `on:`.

Best minimal permissions for current behavior:
- `contents: read` (needed for repository read/fetch operations)
- `pull-requests: write` (needed to post PR comments via Issues/PR comments API)

This preserves existing functionality while constraining token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
