### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete multi-character sanitization

### DIFF
--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -1137,7 +1137,7 @@ function renderOpts(def) {
     if (def.noHero) {
       const rows = def.opts.map(o => `<div class="svc-list-row opt">${inp(o)}<label for="o_${o.v}">
         <div class="opt-icon">${o.icon}</div>
-        <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${o.desc.replace(/<[^>]*>/g,'')}</div></div>
+        <div class="opt-body"><div class="opt-name">${o.name}</div><div class="opt-desc">${String(o.desc).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}</div></div>
         ${o.help ? `<button type="button" class="help-btn" data-action="toggle-device-help" data-v="${o.v}" title="What does this mean?" aria-label="Explain ${o.name}">?</button>` : ''}
         <span class="svc-list-arr">›</span>
       </label>${o.help ? `<div class="device-help" id="help_${o.v}">${o.help}</div>` : ''}</div>`).join('');


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/9](https://github.com/brevityA/Core-Builds/security/code-scanning/9)

General fix: avoid trying to strip whole tags with a multi-character regex. Instead, safely encode HTML-special characters (`&`, `<`, `>`, `"`, `'`) before inserting text into HTML templates.

Best fix here (minimal behavior change): in `configurator/index_src.html`, line region around `renderOpts`, replace `o.desc.replace(/<[^>]*>/g,'')` with HTML escaping of `o.desc` text. This preserves readable text while preventing any HTML from being interpreted, and avoids the incomplete multi-character sanitization pitfall entirely.

No new imports or dependencies are needed. Implement inline escaping at the interpolation site using chained single-character/global replacements in safe order (`&` first).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
