### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ on:
       - '**/*.md'
       - 'Assets/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run pytest suite


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/3](https://github.com/brevityA/Core-Builds/security/code-scanning/3)

Add an explicit `permissions` block with the minimum required scope so the workflow no longer relies on repository/organization defaults.

Best fix (without changing functionality): in `.github/workflows/tests.yml`, add a root-level `permissions` section after `on:` (or before `jobs:`) with:

- `contents: read`

This grants only what is needed for `actions/checkout` and keeps token access least-privileged for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
