### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 8 * * 1'   # Every Monday at 8am UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/2](https://github.com/brevityA/Core-Builds/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the minimum needed appears to be:

- `contents: read` (for checkout and reading repo files)
- `issues: write` (required to create an issue in the final step)

Edit `.github/workflows/link-checker.yml` by inserting the `permissions` section after the `on:` block and before `jobs:`. This preserves existing behavior while explicitly constraining the token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
