### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -7,6 +7,9 @@ on:
       - 'cloudflare-worker/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/1](https://github.com/brevityA/Core-Builds/security/code-scanning/1)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.  
Best fix: define workflow-level permissions with `contents: read`, since all jobs in this file can inherit it and no write scopes are shown as needed.

In `.github/workflows/deploy-worker.yml`, insert:

```yml
permissions:
  contents: read
```

right after the trigger section (`on:` block) and before `jobs:`.  
No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
