### PR TITLE
deploy: configure KV namespace for CF Worker paste endpoint

### DIFF
--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -7,6 +7,4 @@ enabled = false
 
 [[kv_namespaces]]
 binding = "TEMPLATES"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
-# Create with: wrangler kv namespace create TEMPLATES
-# Then paste the id here before deploying.
+id = "100cc344297b41c785f8c07dba85982c"


### PR DESCRIPTION
## Description
Deploys the Cloudflare Worker CORS proxy with KV storage for the template paste endpoint. Sets the real KV namespace ID (`100cc344297b41c785f8c07dba85982c`) in `wrangler.toml`, replacing the placeholder.

Worker is now live at `core-builds-cors-proxy.tlorenzato26.workers.dev` with all 3 endpoints verified:
- `/proxy/*` — CORS proxy to all 7 AIOStreams hosts (all returning 200)
- `POST /paste` — stores template JSON in KV (30-day TTL)
- `GET /t/{id}` — retrieves stored templates

## Type of Change
- [x] Workflow / infrastructure

## Template Checklist
N/A — no template files modified.

## Testing
- All 7 AIOStreams hosts verified reachable via proxy (200)
- Paste round-trip confirmed (POST → store → GET → retrieve)
- API POST forwarding verified (400 on empty body = expected)

## Related Issues
Follows up on #430 (auto-fallback import URL)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_