### PR TITLE
feat(ese+docs): LABS ESE v2.0 + docs restructure

### DIFF
--- a/Filtering/core-builds-eses-v2-beta.json
+++ b/Filtering/core-builds-eses-v2-beta.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "Standard ESE v2.0",
+    "expression": "/*Standard ESE v2.0 [git.tamtaro.de]*/[]",
+    "description": "Version marker — no-op expression"
+  },
+  {
+    "name": "G's Low Bitrate",
+    "expression": "/*G's Low Bitrate*/ count(negate((isAnime or 'Animation' in genres?bitrate(streams,1,'0.67Mbps'):merge(bitrate(quality(resolution(streams,'2160p'),'Bluray REMUX'),1,'25Mbps'),bitrate(quality(resolution(streams,'2160p'),'Bluray'),1,'13.6Mbps'),bitrate(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip'),1,'4.6Mbps'),bitrate(quality(resolution(streams,'2160p'),'HDTV'),1,'11.33Mbps'),bitrate(quality(resolution(streams,'1080p'),'Bluray REMUX'),1,'13.6Mbps'),bitrate(quality(resolution(streams,'1080p'),'Bluray'),1,'6.77Mbps'),bitrate(quality(resolution(streams,'1080p'),'WEB-DL','WEBRip'),1,'1.67Mbps'),bitrate(quality(resolution(streams,'1080p'),'HDTV'),1,'4.51Mbps'),bitrate(quality(resolution(streams,'720p'),'Bluray'),1,'3.43Mbps'),bitrate(quality(resolution(streams,'720p'),'WEB-DL','WEBRip'),1,'1.67Mbps'),bitrate(quality(resolution(streams,'720p'),'HDTV'),1,'2.28Mbps'),bitrate(streams,1,'0.67Mbps'))),cached(streams)))>10?(isAnime or 'Animation'in genres?bitrate(streams,1,'0.67Mbps'):merge(bitrate(quality(resolution(streams,'2160p'),'Bluray REMUX'),1,'25Mbps'),bitrate(quality(resolution(streams,'2160p'),'Bluray'),1,'13.6Mbps'),bitrate(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip'),1,'4.6Mbps'),bitrate(quality(resolution(streams,'2160p'),'HDTV'),1,'11.33Mbps'),bitrate(quality(resolution(streams,'1080p'),'Bluray REMUX'),1,'13.6Mbps'),bitrate(quality(resolution(streams,'1080p'),'Bluray'),1,'6.77Mbps'),bitrate(quality(resolution(streams,'1080p'),'WEB-DL','WEBRip'),1,'1.67Mbps'),bitrate(quality(resolution(streams,'1080p'),'HDTV'),1,'4.51Mbps'),bitrate(quality(resolution(streams,'720p'),'Bluray'),1,'3.43Mbps'),bitrate(quality(resolution(streams,'720p'),'WEB-DL','WEBRip'),1,'1.67Mbps'),bitrate(quality(resolution(streams,'720p'),'HDTV'),1,'2.28Mbps'),bitrate(streams,1,'0.67Mbps'))):[]",
+    "description": "count() activation threshold — only fires when 10+ cached streams exist"
+  },
+  {
+    "name": "Info & Other Unwanted",
+    "expression": "/*Info & Other Unwanted*/ merge(type(streams, 'info'), releaseGroup(type(streams,'usenet','stremio-usenet'),'sample'), type(keyword(streams, 'all', '-sample'), 'usenet', 'stremio-usenet'), message(type(streams,'usenet','stremio-usenet'),'includes','🚫'))",
+    "description": "Replaces Bad NZBs — adds info stream kill, -sample keyword filter, prohibited marker detection"
+  },
+  {
+    "name": "Protect Library",
+    "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
+    "description": "Library-aware replacement for Hard CAM Kill — library items survive even if tagged as low quality"
+  },
+  {
+    "name": "SeaDex Duplicates",
+    "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
+    "description": "Replaces Extra SeaDex — perGroup() dedup keeps 1 per release group for best and non-best tiers"
+  },
+  {
+    "name": "Bad 4k Anime",
+    "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+    "description": "rseMatched tier guards — won't nuke 4K anime if BD/Remux/Web tier groups match"
+  },
+  {
+    "name": "Upscaled 4k",
+    "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
+    "description": "rseMatched tier guards — won't nuke 4K if Bluray/Remux/Web tiers match (DE + EN names)"
+  },
+  {
+    "name": "Bad 4k Bluray — tier-guarded",
+    "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+    "description": "rseMatched tier guards on 4K Bluray kill (DE + EN tier names)"
+  },
+  {
+    "name": "Bad 1080P Bluray — tier-guarded",
+    "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+    "description": "rseMatched tier guards on 1080P Bluray kill (DE + EN tier names)"
+  },
+  {
+    "name": "Low Quality w/ No Release Group",
+    "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+    "description": "Kills low-quality streams with no release group — catches junk/spam uploads"
+  },
+  {
+    "name": "IQR Low Seeders",
+    "expression": "/*IQR Low Seeders*/ count(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)))>=8?seeders(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)),0,max(1,floor(q1(values(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)),'seeders'))-1.5*iqr(values(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)),'seeders'))))):count(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)))>=4?seeders(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)),0,max(1,floor(min(values(negate(merge(library(streams),seadex(streams),cached(streams)),uncached(streams)),'seeders'))*0.5))):[]",
+    "description": "CB's IQR-progressive low seeder guard — superior to Tamtaro's flat threshold"
+  }
+]

--- a/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
+++ b/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
@@ -5,7 +5,7 @@
     "description": "Nightly Labs build of Anime 4K. Tests SeaDex-aware conditional PSEs, perGroup() dedup, Score IQR Guard, Indexer Diversity, and anime elite group pins. Not a daily driver — report regressions before these features graduate to stable.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "category": "Anime",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json",
     "changelogUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/CHANGELOG.md",
@@ -474,23 +474,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray*/(queryType=='movie' or queryType =='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')):[]",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX'))==0 and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))==0) and count(seadex(resolution(streams,'1080p')))==0? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')):[]",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -522,11 +522,15 @@
         "enabled": true
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 4K build. Template directives: TorBox Search and exit thresholds configurable at import. Based on 4K Essential v2.8.2.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -276,23 +276,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray — tier-guarded (LABS)*/(queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams,'2160p'),'Radarr UHD Bluray T1','Radarr UHD Bluray T2','Radarr UHD Bluray T3','Radarr Remux T1','Sonarr Remux T1','Radarr Remux T2','Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray — tier-guarded (LABS)*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'),'Radarr HD Bluray T1','Sonarr HD Bluray T1','Radarr HD Bluray T2','Sonarr HD Bluray T2','Radarr Remux T1','Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -328,6 +328,10 @@
         "enabled": true
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
@@ -344,7 +348,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
+++ b/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: TorBox Essential debrid-only (no external scrapers). Runs on TorBox cache + TorBox Search only. 1080p build. Template directives: TorBox Search and exit thresholds configurable at import.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -279,23 +279,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray — tier-guarded (LABS)*/(queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams,'2160p'),'Radarr UHD Bluray T1','Radarr UHD Bluray T2','Radarr UHD Bluray T3','Radarr Remux T1','Sonarr Remux T1','Radarr Remux T2','Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray — tier-guarded (LABS)*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'),'Radarr HD Bluray T1','Sonarr HD Bluray T1','Radarr HD Bluray T2','Sonarr HD Bluray T2','Radarr Remux T1','Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -323,6 +323,10 @@
         "enabled": true
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
@@ -331,7 +335,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "id": "core-nexus-4k-apex-labs",
     "name": "Core Nexus 4K Apex Labs",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "Nightly Labs v0.9.0 — all LABS features enabled: Score IQR Guard (replaces fixed -50 gate), perGroup() Extra Cached/Uncached ESEs, Bad Dual Audio Groups, Indexer Diversity, elite group pins (4K Remux / 1080p Remux / LQ bottom). Based on 4K Apex v0.4.16.",
     "sourceUrl": "https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json",
     "source": "external",
@@ -248,23 +248,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray — tier-guarded (LABS)*/(queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams,'2160p'),'Radarr UHD Bluray T1','Radarr UHD Bluray T2','Radarr UHD Bluray T3','Radarr Remux T1','Sonarr Remux T1','Radarr Remux T2','Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray — tier-guarded (LABS)*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'),'Radarr HD Bluray T1','Sonarr HD Bluray T1','Radarr HD Bluray T2','Sonarr HD Bluray T2','Radarr Remux T1','Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -308,6 +308,10 @@
         "enabled": true
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
@@ -316,7 +320,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
@@ -5,7 +5,7 @@
     "description": "Nightly Labs build — single template for live-action TV, movies, and anime. Uses isAnime + hasSeaDex conditional PSEs to switch between anime and live-action quality tiers dynamically. Includes SeaDex, AnimeTosho, NekoBT, Meteor, Comet, MediaFusion, and all LABS features. Not a daily driver.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -292,23 +292,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray — tier-guarded (LABS)*/(queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams,'2160p'),'Radarr UHD Bluray T1','Radarr UHD Bluray T2','Radarr UHD Bluray T3','Radarr Remux T1','Sonarr Remux T1','Radarr Remux T2','Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray — tier-guarded (LABS)*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'),'Radarr HD Bluray T1','Sonarr HD Bluray T1','Radarr HD Bluray T2','Sonarr HD Bluray T2','Radarr Remux T1','Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -356,6 +356,10 @@
         "enabled": false
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
@@ -372,7 +376,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
+++ b/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json
@@ -5,7 +5,7 @@
     "description": "Experimental Nightly. Tests: template directives (__if/__value interpolation) — optional scrapers (MediaFusion, SeaDex) toggled at import; dynamicAddonFetching thresholds configurable at import. Hybrid regex+SEL architecture. Based on Stream.",
     "source": "external",
     "author": "Branding-Brevity",
-    "version": "0.8.5",
+    "version": "0.8.6",
     "category": "Debrid",
     "serviceRequired": false,
     "setToSaveInstallMenu": true,
@@ -294,23 +294,23 @@
         "enabled": true
       },
       {
-        "expression": "/*Extra SeaDex*/count(seadex(streams,'best'))>1 or count(negate(seadex(streams,'best'),seadex(streams)))>1?merge(slice(negate(seadex(streams,'best'),seadex(streams)),1),slice(seadex(streams,'best'),1)):[]",
+        "expression": "/*SeaDex Duplicates*/ merge(negate(merge(perGroup(seadex(streams, 'best'), 'releaseGroup', 1), perGroup(negate(seadex(streams,'best'),seadex(streams)), 'releaseGroup', 1)), seadex(streams)), passthrough(seadex(streams), 'excluded'))",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0)? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
+        "expression": "/*Bad 4k Anime*/ (isAnime and originalLanguage == 'Japanese' and count(quality(resolution(cached(streams), '2160p'), 'Bluray REMUX')) == 0 and count(seadex(resolution(streams, '2160p'))) == 0 and count(rseMatched(resolution(cached(streams), '2160p'), 'BD T1', 'BD T2', 'BD T3', 'BD T4', 'BD T5', 'BD T6', 'BD T7', 'BD T8', 'Anime BD T1', 'Anime BD T2', 'Anime BD T3', 'Remux T1', 'Remux T2', 'Remux T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Web T1', 'Web T2', 'Web T3', 'Web T4', 'Web T5', 'Web T6')) == 0) ? negate(merge(library(streams), seadex(streams)), resolution(streams, '2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Upscaled 4k*/(queryType=='movie' or queryType =='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'2160p'),'WEB-DL','WEBRip')) == 0? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')):[]",
+        "expression": "/*Upscaled 4k*/ (queryType=='movie' or queryType=='series') and (count(quality(resolution(streams,'1080p'),'Bluray REMUX'))>=1) and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'DE Web T1', 'DE Web T2', 'DE Web T3', 'DE Web Scene', 'Web T1', 'Web T2', 'Web T3', 'Web Scene')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(streams,'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 4k Bluray — tier-guarded (LABS)*/(queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams,'2160p'),'Radarr UHD Bluray T1','Radarr UHD Bluray T2','Radarr UHD Bluray T3','Radarr Remux T1','Sonarr Remux T1','Radarr Remux T2','Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
+        "expression": "/*Bad 4k Bluray — tier-guarded*/ (queryType=='movie' or queryType=='series') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'2160p'))) == 0 and count(rseMatched(resolution(streams, '2160p'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'UHD Bluray T2', 'UHD Bluray T3', 'HD Bluray T1', 'HD Bluray T2', 'HD Bluray T3', 'Radarr UHD Bluray T1', 'Radarr UHD Bluray T2', 'Radarr UHD Bluray T3', 'Radarr Remux T1', 'Sonarr Remux T1', 'Radarr Remux T2', 'Sonarr Remux T2')) == 0 ? negate(merge(seadex(streams),library(streams)),resolution(quality(streams,'Bluray'),'2160p')) : []",
         "enabled": true
       },
       {
-        "expression": "/*Bad 1080P Bluray — tier-guarded (LABS)*/(queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'),'Radarr HD Bluray T1','Sonarr HD Bluray T1','Radarr HD Bluray T2','Sonarr HD Bluray T2','Radarr Remux T1','Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
+        "expression": "/*Bad 1080P Bluray — tier-guarded*/ (queryType=='movie') and count(quality(resolution(streams,'2160p'),'Bluray REMUX')) == 0 and count(quality(resolution(streams,'1080p'),'Bluray REMUX')) == 0 and count(seadex(resolution(streams,'1080p'))) == 0 and count(rseMatched(quality(resolution(streams,'1080p'),'Bluray'), 'DE Bluray T1', 'DE Bluray T2', 'DE Bluray T3', 'UHD Bluray T1', 'HD Bluray T1', 'UHD Bluray T2', 'HD Bluray T2', 'UHD Bluray T3', 'HD Bluray T3', 'Radarr HD Bluray T1', 'Sonarr HD Bluray T1', 'Radarr HD Bluray T2', 'Sonarr HD Bluray T2', 'Radarr Remux T1', 'Sonarr Remux T1')) == 0 ? negate(merge(seadex(streams),library(streams)),quality(resolution(streams,'1080p'),'Bluray')) : []",
         "enabled": true
       },
       {
@@ -366,6 +366,10 @@
         "enabled": false
       },
       {
+        "expression": "/*Low Quality w/ No Release Group*/ negate(merge(negate(releaseGroup(streams, '1', 'bit', '1080p'), releaseGroup(streams))), quality(merge(type(streams, 'p2p', 'usenet', 'stremio-usenet'), cached(type(streams, 'debrid'))), 'WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR', 'Unknown'))",
+        "enabled": true
+      },
+      {
         "expression": "/*Final Limit (All)*/ merge(count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip'))>12? quality(negate(merge(library(streams), seadex(streams)),streams),'HDRip','HC HD-Rip','DVDRip','HDTV','CAM','TS','TC','SCR'):count(quality(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'Bluray REMUX','Bluray','WEB-DL','WEBRip','HDRip','HC HD-Rip','DVDRip','HDTV'))>12? quality(streams,'CAM','TS','TC','SCR'):[], count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>15? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'720p','576p','480p','360p','240p','144p','Unknown'),3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>12? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>9? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'), 3))): count(resolution(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>6? negate(merge(library(streams), seadex(streams)),merge(type(uncached(streams),'debrid'), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),6))): count(resolution(negate(merge(library(streams), seadex(streams)), merge(cached(streams),type(streams,'p2p','http'))),'2160p','1440p','1080p','720p'))>3? negate(merge(library(streams), seadex(streams)),merge(slice(type(uncached(streams),'debrid'), 6), slice(resolution(merge(type(streams,'usenet','stremio-usenet','http','p2p'),type(cached(streams),'debrid')),'576p','480p','360p','240p','144p','Unknown'),-1))):[])",
         "enabled": true
       },
@@ -382,7 +386,7 @@
         "enabled": true
       },
       {
-        "expression": "/* CB | Hard CAM Kill */ quality(streams, 'CAM', 'SCR', 'TS', 'TC', 'HC HD-Rip')",
+        "expression": "/*Protect Library*/ passthrough(negate(quality(streams, 'CAM','TS','TC','SCR'), library(streams)), 'excluded', 'required')",
         "enabled": true
       },
       {

--- a/docs/configurator.mdx
+++ b/docs/configurator.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Template Configurator"
-description: "Build a custom AIOStreams template in 6 steps — no manual JSON editing required."
+description: "Build a custom AIOStreams template in under 2 minutes — no manual JSON editing required."
 ---
 
 <Frame>
@@ -11,7 +11,7 @@ description: "Build a custom AIOStreams template in 6 steps — no manual JSON e
   />
 </Frame>
 
-The **Template Configurator** is a self-contained HTML tool that generates a ready-to-import AIOStreams template based on your setup. Answer 5 questions, download the JSON, import it — done.
+The **Template Configurator** generates a ready-to-import AIOStreams template based on your setup. Pick your service, device, and resolution — the configurator handles presets, expressions, sorting, and formatting automatically.
 
 <Card title="Open Template Configurator" icon="wand-magic-sparkles" href="https://brevitya.github.io/Core-Builds/">
   Opens in a new tab — runs entirely in your browser. No data is sent anywhere.
@@ -24,27 +24,59 @@ The **Template Configurator** is a self-contained HTML tool that generates a rea
 />
 
 <Note>
-  **Offline use:** the configurator is also a self-contained HTML file — save it and open it locally with no internet needed. [Download from GitHub](https://github.com/brevityA/Core-Builds/blob/main/configurator/index.html) → Raw → Save As.
+  **Offline use:** the configurator is a self-contained HTML file — save it and open it locally with no internet needed. [Download from GitHub](https://github.com/brevityA/Core-Builds/blob/main/configurator/index.html) → Raw → Save As.
 </Note>
 
 ---
 
-## The 6 Steps
+## Splash Screen
+
+The configurator opens to a splash screen with three ways to get started:
+
+### Guided Setup (Core Start)
+
+The step-by-step wizard. Answer 5–6 questions about your setup and the configurator builds the template for you. Best for first-time users or anyone who wants full control over every option.
+
+### Core Configure
+
+Jump straight to the full configuration panel with all options visible at once. Best if you already know what you want and just need to generate the JSON.
+
+### Quick Deploy
+
+One-tap presets for common setups — no questions asked:
+
+| Preset | What it does |
+|---|---|
+| **4K Apex** | Flagship 4K template with full expression stack. Requires TorBox Pro |
+| **1080p Stream** | Optimised 1080p streaming. Requires TorBox Pro |
+| **Free Streaming** | HTTP direct-play sources — no debrid service needed |
+| **Free P2P** | Peer-to-peer torrents — no debrid service needed |
+| **Quick Start Guide** | Opens the [Quick Start](/quick-start) docs |
+| **Paste Manifest** | Import an existing AIOStreams manifest URL directly |
+
+Quick Deploy presets generate a template with sensible defaults and install it on a supported AIOStreams instance in one click. You'll be asked for your API key and then taken directly to the install screen.
+
+---
+
+## Guided Setup — The 6 Steps
 
 <Steps>
   <Step title="Debrid Service">
-    Choose your streaming service. This sets which presets are included and how the cache layer is configured.
+    Choose your streaming service. The splash screen shows service chips — tap one to select it and proceed. This sets which presets, cache layer, and search addons are included.
 
-    | Choice | What changes |
-    |---|---|
-    | **TorBox Pro** | `StremThru Torz` cache · HdHub enabled · `TorBox Search` included |
-    | **TorBox Essential** | Same scraper stack as Pro, Essential plan |
-    | **AllDebrid** | `StremThru AllDebrid` (Store) · HdHub disabled |
-    | **Hybrid (TorBox + RD)** | TorBox primary · Comet+Meteor conditional group fetching |
+    | Choice | Cache layer | Key addons |
+    |---|---|---|
+    | **TorBox Pro** | StremThru Torz | TorBox Search · HdHub · full scraper stack |
+    | **TorBox Essential** | StremThru Torz | Same scrapers, Essential plan limits |
+    | **AllDebrid** | StremThru Store | HdHub disabled (no AllDebrid support) |
+    | **Real-Debrid** | StremThru Store | Standard scraper stack |
+    | **Hybrid (TorBox + RD)** | Both | TorBox-priority with RD fallback |
+    | **EasyNews** | N/A | EasyNews search + usenet scrapers |
+    | **Free (No Debrid)** | None | P2P or HTTP direct-play sources only |
   </Step>
 
   <Step title="Your Device">
-    Device profile sets audio exclusions, codec restrictions, and HDR/DV handling automatically.
+    Device profile sets audio exclusions, codec restrictions, and HDR/DV handling automatically. If your device isn't listed, "Generic" works for most setups.
 
     | Device | Audio excluded | Encodes excluded | DV-Only Kill |
     |---|---|---|---|
@@ -56,42 +88,72 @@ The **Template Configurator** is a self-contained HTML tool that generates a rea
     | Windows PC / Ultrawide | — | VC-1 | Off |
     | Fire Stick (HD) | TrueHD · DTS-HD MA · DTS:X · FLAC | AV1 · VC-1 | **On** |
     | Fire Stick 4K Max | TrueHD · DTS-HD MA · DTS:X · FLAC | VC-1 | Off |
+
+    <Tip>
+      See [Device Profiles](/device-profiles) for full codec support details and recommended settings for each device.
+    </Tip>
   </Step>
 
   <Step title="Resolution">
-    Determines the PSE stack, resolution locks, and dynamic addon fetching threshold.
+    Determines the PSE stack, resolution locks, and which streams get filtered out.
 
-    | Choice | `requiredResolutions` | PSE stack | Hard Kill ESE |
-    |---|---|---|---|
-    | **4K HDR primary** | `[]` | 4K tiers → 1080p fallback | — |
-    | **1080p only** | `["1080p","720p"]` | 1080p tiers → 720p fallback | Excludes 2160p + 1440p |
-    | **1080p-first + 4K** | `[]` | 1080p → 1440p → 4K → 720p | — |
+    | Choice | What happens | Best for |
+    |---|---|---|
+    | **4K HDR primary** | Full 4K tier stack with 1080p fallback | 4K TVs and monitors |
+    | **1080p only** | Hard-kills 4K/1440p streams entirely | 1080p TVs, Fire Stick HD |
+    | **1080p-first + 4K** | Prefers 1080p, falls through to 4K | Bandwidth-limited setups |
   </Step>
 
   <Step title="Audio">
-    Sets `excludedAudioTags` and `preferredAudioChannels`. Device-managed means the device profile (Step 2) decides.
+    Sets `excludedAudioTags` and `preferredAudioChannels`. "Device-managed" means Step 2's device profile decides — usually the right choice.
 
-    | Choice | Excluded | Channels |
-    |---|---|---|
-    | **Full lossless** | Nothing | 7.1 · 5.1 · 2.0 |
-    | **DD+ / Atmos** | Nothing | 5.1 · 2.0 |
-    | **Device-managed** | Per device profile | Per device profile |
+    | Choice | Excluded | Channels | Best for |
+    |---|---|---|---|
+    | **Full lossless** | Nothing | 7.1 · 5.1 · 2.0 | Home theater with receiver |
+    | **DD+ / Atmos** | Nothing | 5.1 · 2.0 | Soundbar / TV speakers |
+    | **Device-managed** | Per device profile | Per device profile | Most users |
   </Step>
 
   <Step title="Content Type">
-    Controls SeaDex integration and Bad Dual Audio Groups filtering.
+    Controls SeaDex integration and anime-specific filtering.
 
-    | Choice | `enableSeadex` | `seadexBestOnly` | Bad Dual Audio ESE |
+    | Choice | SeaDex | Bad Dual Audio ESE | Best for |
     |---|---|---|---|
-    | **Live-action only** | `false` | `false` | ✅ Included |
-    | **Live-action + Anime** | `true` | `false` | ✅ Included |
-    | **Anime-focused** | `true` | `true` | — |
+    | **Live-action only** | Off | Included | Movies & TV only |
+    | **Live-action + Anime** | On (all matches) | Included | Mixed library |
+    | **Anime-focused** | On (best only) | Off | Dedicated anime setup |
   </Step>
 
-  <Step title="Review & Download">
-    See a summary of your choices, optionally give the template a custom name, then click **Generate & Download**. The file is saved as a `.json` ready to import directly into AIOStreams.
+  <Step title="Review & Install">
+    See a summary of your choices, enter your API key, and optionally give the template a custom name. 
+    
+    Click **Create & Install** to generate the template and deploy it to a supported AIOStreams instance in one step. You can also download the raw JSON file to import manually.
+
+    The configurator will ask you to pick an AIOStreams instance (ElfHosted, ForthWeak, and others are available) and create your config automatically.
   </Step>
 </Steps>
+
+---
+
+## Additional Options
+
+The configurator includes several optional features accessible during setup:
+
+### Multi-Service Support
+
+Add secondary services alongside your primary debrid provider:
+
+- **EasyNews** — usenet source alongside torrent scrapers (requires EasyNews subscription)
+- **NZBGeek** — premium usenet indexer
+- **StreamNZB** — self-hosted usenet streaming
+
+### TMDB Integration
+
+Adding your TMDB Read Access Token or API Key improves title matching accuracy — especially for anime and foreign-language content. The configurator shows format hints to help you paste the right value. See [AIO Metadata](/aiometadata) for setup details.
+
+### Custom Formatters
+
+Import a custom stream formatter to replace the default Tamtaro layout. The configurator accepts any valid AIOStreams formatter JSON — see [Formatters](/formatters) for the full gallery.
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,16 +41,28 @@
             "pages": [
               "introduction",
               "quick-start",
-              "master-guide",
-              "how-it-works",
               "which-template",
               "importing",
               "lite-vs-standard",
-              "instance-status",
+              "how-it-works",
+              "master-guide"
+            ]
+          },
+          {
+            "group": "Configurator",
+            "pages": [
+              "configurator",
+              "customising",
+              "aiometadata"
+            ]
+          },
+          {
+            "group": "Services & Devices",
+            "pages": [
               "debrid-comparison",
-              "aiometadata",
               "alldebrid-setup",
               "easynews-setup",
+              "device-profiles",
               "regional-content"
             ]
           },
@@ -58,23 +70,24 @@
             "group": "Templates",
             "pages": [
               "template-directory",
-              "configurator",
-              "customising",
-              "community-templates"
+              "community-templates",
+              "nightly-and-labs"
             ]
           },
           {
-            "group": "Reference",
+            "group": "Expressions & Addons",
             "pages": [
               "expression-layer",
-              "device-profiles",
-              "formatters",
-              "formatter-gallery",
+              "addon-guide",
+              "addon-reference"
+            ]
+          },
+          {
+            "group": "Formatters",
+            "pages": [
               "which-formatter",
-              "glossary",
-              "nightly-and-labs",
-              "addon-reference",
-              "addon-guide"
+              "formatters",
+              "formatter-gallery"
             ]
           },
           {
@@ -83,6 +96,8 @@
               "whats-new",
               "faq",
               "troubleshooting",
+              "instance-status",
+              "glossary",
               "changelog",
               "roadmap"
             ]


### PR DESCRIPTION
## Summary

### LABS ESE v2.0 experimental upgrades
- `Extra SeaDex` → `SeaDex Duplicates` — `perGroup('releaseGroup', 1)` dedup
- `Bad 4k Anime` / `Upscaled 4k` / `Bad 4k Bluray` / `Bad 1080P Bluray` → `rseMatched()` tier guards (DE + EN names)
- `Hard CAM Kill` → `Protect Library` — library-aware passthrough
- NEW: `Low Quality w/ No Release Group` filter
- Beta ESE file: `Filtering/core-builds-eses-v2-beta.json` (11 expressions)

| Template | Version | ESEs |
|---|---|---|
| 4K Apex Labs | 0.11.6 | 36 |
| Stream Labs | 0.8.6 | 43 |
| All-Rounder Labs | 0.2.6 | 40 |
| 4K Essential Labs | 0.3.6 | 35 |
| Essential Labs | 0.2.6 | 31 |
| Anime 4K Labs | 0.1.5 | 28 |

### Docs restructure
Navigation reorganised from 4 flat groups into 7 focused groups:
- **Getting Started** trimmed 13 → 7 pages (onboarding only)
- **Configurator** gets its own group (+ Customising, AIO Metadata)
- **Services & Devices** groups all service/hardware setup pages
- **Templates** focused (Directory, Community, Nightly)
- **Expressions & Addons** for technical reference
- **Formatters** groups all 3 formatter pages
- **Support** picks up Instance Status + Glossary

### Configurator page expanded
- Splash screen docs (Guided Setup, Core Configure, Quick Deploy)
- Quick Deploy presets table
- Multi-service, TMDB integration, custom formatter sections
- Improved step descriptions with "best for" guidance

## Test plan
- [x] `python -m pytest tests/ -x -q` — 186 tests pass
- [ ] Verify Mintlify deploys with new navigation structure
- [ ] Import a LABS template and verify rseMatched guards work

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_