### PR TITLE
docs: update all docs for v3.2.7 — Labs v0.14.0, version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 3.2.7 (2026-07-11)
+
+### Added
+- **LABS v0.14.0 SEL expressions** (6 Labs templates) — seven new expression features across all Labs templates:
+  - **Runtime-aware bitrate floors** — `(isAnime or 'Animation' in genres or (runtime > 0 and runtime < 25)) ? [] : [existing logic]` guard on Bitrate Floor ESEs. Animation and short-form content (< 25 min) legitimately encodes ~50% smaller; these now bypass the REMUX bitrate floors instead of being killed.
+  - **Anime language passthrough ISE** — `isAnime ? passthrough(streams, 'language') : []` bypasses language filtering for anime queries. Anime fansub groups use non-standard language tagging that the standard language filter rejects.
+  - **latestSeason-aware season pack kill** — `season >= latestSeason` guard added to the Season Pack Kill ESE. Prevents killing season packs on current-season shows where the pack is the only source.
+  - **Subtitle preference PSE** — `subtitles(streams, 'English')` inserted before Codec Efficiency Booster. Prioritises streams with embedded English subtitles.
+  - **`age` sort key** — `direction: "asc"` in `uncachedMovies` and `uncachedSeries` sort sections. Newer uncached torrents rank above older ones.
+  - **`cachedAnime` sort section** — seadex at position 2, 16 keys. Dedicated anime-optimised cached sort.
+  - **`uncachedAnime` sort section** — seadex at position 2, seeders promoted, age key, 17 keys. Anime-specific uncached sort with newer content ranked higher.
+- **LABS templates updated:** 4K Apex Labs (v0.11.6 → **v0.14.0**), Stream Labs (v0.8.6 → **v0.10.0**), All-Rounder Labs (v0.2.6 → **v0.4.0**), 4K Essential Labs (v0.3.6 → **v0.5.0**), Essential Labs (v0.2.6 → **v0.4.0**), Anime 4K Labs (v0.1.5 → **v0.3.0**).
+
+### Fixed
+- **Configurator regex allowlist** — 2 of 103 patterns in `RANKED_REGEX_COMMON` were not present in Vidhin05's 174-entry allowlist, causing "2/176 regexes not allowed" errors on self-hosted AIOStreams instances. Removed: `Radarr HD Bluray T3 [B]` (LoRD group, score 40) and `Anime LQ Groups` (score −75). Configurator now generates templates with 101 ranked regex patterns, all verified against Vidhin05.
+- **All-Rounder Labs addonName** — template had `"Core Nexus Stream Labs 🧪"` (copy-paste from Stream Labs) instead of `"Core Nexus All-Rounder Labs 🧪"`.
+
 ## 3.2.6 (2026-07-09)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,13 +162,13 @@ Meteor ≤ 5, Comet RD ≤ 5, MediaFusion ≤ 4, EZTV ≤ 3, HdHub ≤ 3, Torren
 - `Anime/core-nexus-anime-dub-lite.json` v2.8.11 — cachedAnime/uncachedAnime sort
 
 ### Nightly (gitignored — force-add to commit)
-- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.2.5 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
-- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.3.6 — Essential 4K experimental, ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Bitrate Floor ESEs (4K+1080p REMUX), perGroup() Extra Cached, configurable daf thresholds at import
-- `Nightly/Essential/core-nexus-essential-labs.json` v0.2.6 — Essential 1080p experimental, ESE v2.0 (Protect Library, SeaDex Duplicates, Low Quality filter), perGroup() Extra Cached, configurable daf thresholds at import
-- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.11.6 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins, Bitrate Floor ESEs (4K+1080p REMUX)
-- `Nightly/Single/core-nexus-stream-labs.json` v0.8.6 — ESE v2.0 (Protect Library, SeaDex Duplicates, Low Quality filter), perGroup() prototypes, dynamicAddonFetching, StreamNZB preset, Bitrate Floor ESEs (1080p REMUX AV1 kill + 8Mbps floor)
-- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.2.6 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, all LABS features
-- `Nightly/Anime/core-nexus-anime-4k-labs.json` v0.1.5 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Score IQR Guard, perGroup() dedup, Indexer Diversity, hasSeaDex conditional tiers, anime elite pins
+- `Nightly/AppleTV/core-nexus-apple-tv-4k.json` v0.2.7 — DV Profile 5/8, AV1 excluded, SeaDex ISE, REPACK ISE
+- `Nightly/Essential/core-nexus-4k-essential-labs.json` v0.5.0 — Essential 4K experimental, ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Bitrate Floor ESEs (4K+1080p REMUX, runtime-aware), perGroup() Extra Cached, anime language passthrough, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key
+- `Nightly/Essential/core-nexus-essential-labs.json` v0.4.0 — Essential 1080p experimental, ESE v2.0 (Protect Library, SeaDex Duplicates, Low Quality filter), perGroup() Extra Cached, anime language passthrough, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key
+- `Nightly/Single/core-nexus-4k-apex-labs.json` v0.14.0 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Score IQR Guard, perGroup() dedup, Indexer Diversity, Bad Dual Audio Groups, elite group pins, Bitrate Floor ESEs (4K+1080p REMUX, runtime-aware), anime language passthrough, latestSeason season pack kill, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key
+- `Nightly/Single/core-nexus-stream-labs.json` v0.10.0 — ESE v2.0 (Protect Library, SeaDex Duplicates, Low Quality filter), perGroup() prototypes, dynamicAddonFetching, StreamNZB preset, Bitrate Floor ESEs (1080p REMUX AV1 kill + 8Mbps floor, runtime-aware), anime language passthrough, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key
+- `Nightly/Single/core-nexus-all-rounder-labs.json` v0.4.0 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), isAnime+hasSeaDex conditional PSEs, anime+live-action scrapers, anime language passthrough, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key, all LABS features
+- `Nightly/Anime/core-nexus-anime-4k-labs.json` v0.3.0 — ESE v2.0 (Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter), Score IQR Guard, perGroup() dedup, Indexer Diversity, hasSeaDex conditional tiers, anime elite pins, anime language passthrough, subtitle PSE, cachedAnime/uncachedAnime sort, age sort key
 
 ---
 

--- a/Guides/LABS.md
+++ b/Guides/LABS.md
@@ -4,75 +4,142 @@ Nightly / Labs templates test new ideas before they're promoted to stable. They 
 
 ---
 
-## Active Labs
+## Active Labs Templates
 
-### Hybrid Regex + SEL Architecture
-
-**Templates:** 4K Apex Labs v0.4.0 · Stream Labs v0.2.0
-
-**The idea:** Replace simple group-name regex patterns with native SEL functions (`releaseGroup()`, `encode()`, `visualTag()`). Complex multi-condition patterns (Remux T1, Bluray T1, Obfuscated, etc.) stay as regex — those can't be replicated in SEL. Only the patterns that are a single `\b(GroupName)\b` word-boundary match get replaced.
+| Template | Version | Resolution | Base |
+|---|---|---|---|
+| **4K Apex Labs** | v0.14.0 | 4K + 1080p | 4K Apex |
+| **Stream Labs** | v0.10.0 | 1080p | Stream |
+| **All-Rounder Labs** | v0.4.0 | 1080p | Stream + Anime |
+| **4K Essential Labs** | v0.5.0 | 4K + 1080p | 4K Essential |
+| **Essential Labs** | v0.4.0 | 1080p | Essential |
+| **Anime 4K Labs** | v0.3.0 | 4K + 1080p | Anime 4K |
 
 ---
 
-### What Changed vs Stable
+## v0.14.0 Features
 
-| Area | Stable | Labs |
+### 1. Runtime-Aware Bitrate Floors
+
+Bitrate Floor ESEs now check content type before firing:
+
+```js
+(isAnime or 'Animation' in genres or (runtime > 0 and runtime < 25))
+  ? []
+  : [existing bitrate floor logic]
+```
+
+**Why:** Animation and short-form content (< 25 min) legitimately encodes 50% smaller than live-action. Without this guard, the REMUX bitrate floors killed valid anime and animation encodes.
+
+**Templates:** 4K Apex Labs, Stream Labs, 4K Essential Labs (only templates with bitrate floors).
+
+---
+
+### 2. Anime Language Passthrough ISE
+
+```js
+isAnime ? passthrough(streams, 'language') : []
+```
+
+Bypasses language filtering for anime queries. Anime fansub groups use non-standard language tagging (e.g. `Japanese` vs `jpn`, dual-audio labelled as English-only) that the standard language filter rejects — causing valid anime streams to be dropped silently.
+
+**Templates:** All 6 Labs templates.
+
+---
+
+### 3. latestSeason-Aware Season Pack Kill
+
+The Season Pack Kill ESE now includes:
+
+```js
+season >= latestSeason
+```
+
+**Before:** Season packs were killed whenever episode-level streams existed, even for the current season where the pack might be the only high-quality source.
+
+**After:** Season packs for the current season (where `season >= latestSeason`) are preserved. Older-season packs continue to be killed when individual episodes exist.
+
+**Templates:** 4K Apex Labs, Stream Labs, All-Rounder Labs, 4K Essential Labs, Essential Labs (not Anime — anime templates exempt from season pack kill).
+
+---
+
+### 4. Subtitle Preference PSE
+
+```js
+subtitles(streams, 'English')
+```
+
+Inserted before the Codec Efficiency Booster PSE. Gives a scoring boost to streams with embedded English subtitles. Does not exclude streams without subs — just ranks sub-carrying streams higher when all else is equal.
+
+**Templates:** All 6 Labs templates.
+
+---
+
+### 5. Age Sort Key
+
+`age` with `direction: "asc"` added to `uncachedMovies` and `uncachedSeries` sort sections. When all other sort criteria tie, newer uncached torrents rank above older ones — more likely to have active seeders.
+
+**Templates:** All 6 Labs templates.
+
+---
+
+### 6. Cached/Uncached Anime Sort Sections
+
+Two new granular sort sections for anime content:
+
+**`cachedAnime`** (16 keys): `cached → seadex → seMatched → seScore → library → resolution → quality → regexScore → visualTag → encode → audioTag → audioChannel → language → seeders → bitrate → size`
+
+SeaDex at position 2 — the strongest anime quality signal ranks immediately after cached status.
+
+**`uncachedAnime`** (17 keys): Same structure but with seeders promoted above audio criteria and `age` (asc) appended. Newer uncached anime torrents with more seeders rank higher.
+
+**Templates:** All 6 Labs templates.
+
+---
+
+## Previous LABS Features (still active)
+
+These features were introduced in earlier Labs versions and remain active:
+
+| Feature | Version | Description |
 |---|---|---|
-| Elite groups (FraMeSToR, FLUX, SiC…) | Scored via `rankedRegexPatterns` (+80–100) | Removed from patterns → `pin(releaseGroup(streams, ...), 'top')` PSE |
-| IMAX streams | `rankedRegexPatterns` regex (+20) | `pin(visualTag(streams, 'IMAX'), 'top')` PSE — native AIOStreams field |
-| Remux pin (4K Labs only) | `keyword(..., 'releaseGroup', ...)` ESE | `releaseGroup(...)` ESE — exact-match, not substring |
-| LQ group pin (4K Labs only) | `keyword(...)` ESE bottom pin | `releaseGroup(...)` ESE bottom pin |
-| Bad Dual Audio Groups | `rankedRegexPatterns` penalty (−50) | Removed from patterns → **opt-in ESE** (disabled by default) |
-| x264 streams | `rankedRegexPatterns` penalty (−25) | Removed from patterns → **opt-in ESE** (disabled by default) |
+| **ESE v2.0** | v0.9.0 | Protect Library, SeaDex Duplicates, rseMatched tier guards, Low Quality filter |
+| **Score IQR Guard** | v0.9.0 | Tukey lower fence on `seScore` — removes statistical outliers at ≥8 streams |
+| **perGroup() dedup** | v0.9.0 | Single-expression `perGroup(..., 'resolution', 3)` replaces 20–35 clause merge/slice |
+| **Indexer Diversity** | v0.9.0 | `perGroup(..., 'indexer', 2)` caps per-scraper results at 2 when pool > 20 |
+| **Elite group pins** | v0.9.0 | `pin(releaseGroup(...))` for top/bottom group positioning |
+| **rseMatched() tiers** | v0.9.0 | Ranked regex entries as named matchers for tier-guarded kills |
+| **Bitrate Floor ESEs** | v0.11.0 | 4K + 1080p REMUX bitrate floors (now runtime-aware in v0.14.0) |
+| **Private tracker kill** | v0.12.0 | Hard-excludes results from private trackers |
+| **totalCachedStreams DAF** | v0.12.0 | Dynamic addon fetching exits on cached stream count |
+| **Strict year+title matching** | v0.13.0 | Tighter match criteria for content identification |
+| **SeaDex Best PSE tier** | v0.13.0 | Dedicated PSE tier for SeaDex best-rated releases |
 
-**Patterns removed from `rankedRegexPatterns`:**
+---
 
-| Template | Removed patterns |
+## What to Test & Report
+
+1. **Animation/anime results** — do anime titles still surface valid REMUX streams? The runtime guard should prevent bitrate floors from killing short-form and animated content.
+
+2. **Season packs on current-season shows** — when watching a show in its latest season, do season packs still appear? On older seasons, are they still properly killed when individual episodes exist?
+
+3. **Subtitle ranking** — do streams with embedded English subs rank above equivalent streams without subs? The effect should be subtle — a tiebreaker, not a dominant sort.
+
+4. **Uncached anime** — for anime content that isn't cached, do results with more seeders and newer upload dates surface higher?
+
+5. **Language filtering on anime** — do anime streams that were previously dropped by language filters now appear? This is most visible on niche anime with non-standard language metadata.
+
+---
+
+## Import URLs
+
+| Template | Import URL |
 |---|---|
-| 4K Apex Labs | 126811, FLUX, SiC, hallowed, TheFarm, BHDStudio (+80/60), Radarr Bad Dual Groups, Sonarr Bad Dual Groups (−50) |
-| Stream Labs | FraMeSToR, TheFarm (+100/80), Radarr Bad Dual Groups, Sonarr Bad Dual Groups (−50) |
+| **4K Apex Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Stream Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **All-Rounder Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
+| **4K Essential Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **Essential Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **Anime 4K Labs** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
 
----
-
-### Opt-In ESEs
-
-Two ESEs ship disabled — enable them in AIOStreams to test:
-
-**`x264 Hard Exclude`**
-```js
-negate(encode(streams, 'x264', 'h.264'))
-```
-Replaces the `rankedRegexPatterns` −25 score penalty for x264. Uses AIOStreams' native encode detection instead of regex. Hard-excludes x264 streams rather than soft-penalising — more aggressive.
-
-**`Bad Dual Audio Groups`**
-```js
-releaseGroup(streams, 'alfaHD', 'BAT', 'BiOMA', 'BlackBit', 'BNd', ...)
-```
-Replaces the `rankedRegexPatterns` −50 score penalty for known bad dual-audio groups. Hard-excludes rather than soft-penalises.
-
-To enable: open AIOStreams → Stream Expressions → Excluded → find the LABS ESE → toggle on.
-
----
-
-### What to Test & Report
-
-1. **Do elite groups still appear at the top?** FraMeSToR, FLUX, SiC, BHDStudio etc. should rank ahead of unknown groups. If they're not floating up, the `pin()` PSE may not be evaluating before the IQR tier.
-
-2. **Is the `releaseGroup()` pin more or less reliable than the old `keyword()` pin?** The 4K Labs upgraded the Remux ESE pins from `keyword()` (substring match) to `releaseGroup()` (exact parsed field). If a group that should be pinned is no longer being caught, that's a `releaseGroup()` field-parse miss.
-
-3. **x264 Hard Exclude** — enable it and check: are x264 streams fully removed? Any false positives (streams that look like x264 in the filename but aren't)?
-
-4. **Bad Dual Audio Groups ESE** — enable it and check: are those group releases actually excluded? Or does the pattern miss releases where the group name doesn't match the parsed `releaseGroup` field exactly?
-
-5. **Size/result count** — do you get roughly the same number and quality of results as the stable template?
-
----
-
-### Why This Matters for Stable Templates
-
-If the hybrid architecture validates:
-
-- ~6 KB savings per 4K template, ~4 KB per 1080p template across 28 non-anime templates
-- Native field detection (`encode()`, `visualTag()`) is more robust than regex against edge-case filename formatting
-- `releaseGroup()` uses AIOStreams' own filename parser — same source as what populates the stream card display name
-- Simpler `rankedRegexPatterns` arrays = easier to audit and update
+Labs templates are nightly builds — they receive changes faster and without the same audit gate as stable templates.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/brevityA/Core-Builds/validate.yml?style=for-the-badge&label=BUILD&logo=github&logoColor=white&labelColor=1a1f27" alt="Build Status"/>
   </a>
   <a href="https://github.com/brevityA/Core-Builds/releases/latest">
-    <img src="https://img.shields.io/badge/RELEASE-v3.0.2-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
+    <img src="https://img.shields.io/badge/RELEASE-v3.2.7-00d4ff?style=for-the-badge&labelColor=1a1f27" alt="Latest Release"/>
   </a>
 </p>
 
@@ -165,12 +165,27 @@ SeaDex best-release enforcement · AnimeTosho · FLAC/AAC audio priority · Japa
 |---|---|---|---|
 | **Core Nexus Apple TV 4K** 🌙 | Apple TV 4K / Infuse | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 | **Core Nexus Samsung RU7100 4K** | Samsung RU7100 (2019) | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json` |
-| **Core Nexus Essential Labs** 🧪 | TorBox debrid-only 1080p | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| **Core Nexus 4K Essential Labs** 🧪 | TorBox debrid-only 4K | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
 
 > **Samsung TV:** DV-only streams excluded by default (Samsung TVs lack a DV licence on most models — DV-only files display as a black screen). TrueHD / DTS:X / FLAC also excluded for Tizen compatibility. DV+HDR10 dual-layer files pass through. TorBox Pro · Essential plan.
 
 > **Apple TV 4K:** Dolby Vision Profile 5/8 native via Infuse — DV streams prioritised. AV1 hard-excluded (no hardware decoder on A15). DD+ Atmos top audio. Based on Core Nexus 4K Apex · TorBox Pro.
+
+---
+
+### 🧪 Labs — Experimental Builds
+
+> Labs templates test new SEL expression architectures before promotion to stable. Currently testing v0.14.0 features: runtime-aware bitrate floors, anime language passthrough, latestSeason-aware season pack kill, subtitle preference PSE, and anime-specific sort sections.
+
+| Template | Version | Res | Import URL |
+|---|---|---|---|
+| **Core Nexus 4K Apex Labs** 🧪 | v0.14.0 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Core Nexus Stream Labs** 🧪 | v0.10.0 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **Core Nexus All-Rounder Labs** 🧪 | v0.4.0 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
+| **Core Nexus 4K Essential Labs** 🧪 | v0.5.0 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **Core Nexus Essential Labs** 🧪 | v0.4.0 | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **Core Nexus Anime 4K Labs** 🧪 | v0.3.0 | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
+
+> [**Full Labs changelog & testing guide →**](https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md)
 
 ---
 
@@ -227,7 +242,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 | **Deduplication** | filename + infoHash + smartDetect · 14 attributes · libraryBehaviour: prefer |
 | **Matching** | titleMatching contains/0.75 · yearMatching ±2yr · seasonEpisode non-strict |
 | **Auto features** | autoPlay · precacheNextEpisode · preloadStreams · dynamicAddonFetching · checkOwned |
-| **Scoring** | Inline `rankedRegexPatterns` (53 patterns, `|score|≥50`) + template-specific `preferredRegexPatterns` |
+| **Scoring** | Inline `rankedRegexPatterns` (107 patterns, 10 score tiers) + `syncedRankedRegexUrls` (Vidhin05) + template-specific `preferredRegexPatterns` |
 | **RPDB** | `t0-free-rpdb` baked in |
 | **TMDB** | `<template_placeholder>` — fill in during import for best matching |
 | **In-app updates** | `metadata.changelog` embedded — shows what changed on re-import |
@@ -238,7 +253,7 @@ All formatters use `id: tamtaro` with `definitions.overrides['tamtaro']`. Import
 
 | Folder | Contents |
 |---|---|
-| [`Templates/Torbox/`](https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox) | 39 active templates — 33 stable (25 standard + 8 Lite) + 6 Nightly |
+| [`Templates/Torbox/`](https://github.com/brevityA/Core-Builds/tree/main/Templates/Torbox) | 46 active templates — 33 stable (25 standard + 8 Lite) + 7 Nightly + 6 Labs |
 | [`Community-Templates/`](https://github.com/brevityA/Core-Builds/tree/main/Community-Templates) | Community-submitted templates |
 | [`Filtering/`](https://github.com/brevityA/Core-Builds/tree/main/Filtering) | Core Builds ESEs, PSEs, ISEs — standalone import files |
 | [`Formatters/`](https://github.com/brevityA/Core-Builds/tree/main/Formatters) | Elite, TV, and legacy formatters |
@@ -286,7 +301,7 @@ Full docs at **[core-builds.mintlify.app](https://core-builds.mintlify.app)**
 
 ## 📜 Version
 
-Current: **`v3.0.2`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
+Current: **`v3.2.7`** · [Full changelog](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md) · [Releases](https://github.com/brevityA/Core-Builds/releases)
 
 ---
 

--- a/Templates/Torbox/README.md
+++ b/Templates/Torbox/README.md
@@ -17,7 +17,7 @@
 
 All active templates for AIOStreams v2.30+. Every template requires a **TorBox subscription**. All templates ship with the **Core Syntax Formatter**, Tamtaro standard ESEs + Core Builds kill ESEs, Tamtaro ISEs, and in-app update notifications.
 
-> **Current version: v3.2.4** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
+> **Current version: v3.2.7** · [CHANGELOG](https://github.com/brevityA/Core-Builds/blob/main/CHANGELOG.md)
 
 > 📖 **New here?** Start with the [Complete Setup Guide](https://github.com/brevityA/Core-Builds/wiki) — it covers picking a template, importing, API keys, device profiles, and troubleshooting.
 
@@ -31,13 +31,15 @@ Nightly templates test new optimisations before they're promoted to stable. They
 
 | Template | Version | Testing | Import URL |
 |---|---|---|---|
-| **4K Apex Labs** | v0.8.6 | Hybrid regex+SEL architecture — elite groups via `releaseGroup()` pin, x264/IMAX via native `encode()`/`visualTag()`. `dynamicAddonFetching`: exit at 5+ cached 4K or 6s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Stream Labs** | v0.6.7 | Same hybrid regex+SEL as 4K Apex Labs — 1080p variant. `dynamicAddonFetching`: exit at 5+ cached 1080p or 5s. | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| **Apple TV 4K** | v0.1.9 | Device profile — DV Profile 5/8, AV1 excluded, Atmos preferred | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| **Essential Labs** | v0.1.7 | TorBox debrid-only 1080p — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| **4K Essential Labs** | v0.1.7 | TorBox debrid-only 4K — no external scrapers, TorBox Search toggle + exit thresholds | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **4K Apex Labs** | v0.14.0 | v0.14.0 SEL — runtime-aware bitrate floors, anime passthrough, latestSeason packs, subtitle PSE, age sort, cachedAnime/uncachedAnime sort | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
+| **Stream Labs** | v0.10.0 | v0.14.0 SEL — 1080p variant, all LABS features except bitrate floors | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **All-Rounder Labs** | v0.4.0 | v0.14.0 SEL — single template for TV, movies, and anime with isAnime/hasSeaDex conditional tiers | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
+| **4K Essential Labs** | v0.5.0 | v0.14.0 SEL — Essential 4K with runtime-aware bitrate floors, all LABS features | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **Essential Labs** | v0.4.0 | v0.14.0 SEL — Essential 1080p, all LABS features except bitrate floors | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **Anime 4K Labs** | v0.3.0 | v0.14.0 SEL — anime-specific with hasSeaDex conditional PSEs, anime group pins | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
+| **Apple TV 4K** | v0.2.7 | Device profile — DV Profile 5/8, AV1 excluded, Atmos preferred | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 
-> **[What's being tested? → Full Labs changelog & testing guide](https://github.com/brevityA/Core-Builds/wiki/Nightly-and-Labs)**
+> **[What's being tested? → Full Labs changelog & testing guide](https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md)**
 
 ### 🗂️ Stable Templates
 
@@ -149,10 +151,12 @@ Getting too few results / low-overhead host? → use the Lite variant of any tem
 | **Core Nexus Apple TV 4K** 🌙 | TorBox Pro | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 | **Core Nexus 4K Apex Labs** 🧪 | TorBox Pro | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
 | **Core Nexus Stream Labs** 🧪 | TorBox Pro | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
+| **Core Nexus All-Rounder Labs** 🧪 | TorBox Pro | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
 | **Core Nexus Samsung RU7100 4K** | TorBox Pro | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json` |
 | **Core Nexus Ultrawide** | TorBox Pro | 1080p + 4K | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Windows/core-nexus-ultrawide.json` |
 | **Core Nexus Essential Labs** 🧪 | TorBox Essential | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
 | **Core Nexus 4K Essential Labs** 🧪 | TorBox Essential | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **Core Nexus Anime 4K Labs** 🧪 | Essential | 4K + 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
 | **Core Nexus 4K Hybrid** | Pro + NZBGeek | 4K+1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
 | **Core Nexus Hybrid** | Pro + NZBGeek | 1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
 | **Core Nexus 4K Essential** | Essential | 4K+1080p | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
@@ -208,7 +212,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-4k-apex.json` |
-| **Version** | v0.4.16 |
+| **Version** | v0.7.8 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-4k-apex.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ✅ cacheAndPlay + nzbFailover |
@@ -222,7 +226,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream.json` |
-| **Version** | v2.9.6 |
+| **Version** | v2.10.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ via Newznab (opt-in) |
@@ -236,7 +240,7 @@ Flagship 4K build for TorBox Pro. Full addon stack — DV/HDR, TrueHD/Atmos, Blu
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Single/core-nexus-stream-firestick.json` |
-| **Version** | v2.9.5 |
+| **Version** | v2.10.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Single/core-nexus-stream-firestick.json` |
 | **Resolution** | 1080p · SDR |
 | **Usenet** | ❌ |
@@ -250,7 +254,7 @@ Stream-based 1080p template for Samsung TVs and devices without Dolby Vision sup
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json` |
-| **Version** | v0.2.13 |
+| **Version** | v0.3.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ❌ |
@@ -264,7 +268,7 @@ Stream-based 1080p template for Samsung TVs and devices without Dolby Vision sup
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json` |
-| **Version** | v0.2.13 |
+| **Version** | v0.3.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-tv-4k.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -278,7 +282,7 @@ Full 4K template for the Samsung RU7100 (2019). Runs the complete APEX IQR PSE s
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json` |
-| **Version** | v0.2.16 |
+| **Version** | v0.3.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Samsung/core-nexus-samsung-ru7100-4k.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -292,7 +296,7 @@ Windows PC / ultrawide monitor template. Prioritises 1080p quality tiers (S/A/B/
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Device/Windows/core-nexus-ultrawide.json` |
-| **Version** | v0.1.0 |
+| **Version** | v0.2.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Device/Windows/core-nexus-ultrawide.json` |
 | **Resolution** | 1080p primary · 1440p + 2160p fallback |
 | **Usenet** | ✅ |
@@ -306,7 +310,7 @@ Windows PC / ultrawide monitor template. Prioritises 1080p quality tiers (S/A/B/
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
-| **Version** | v0.1.9 |
+| **Version** | v0.2.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/AppleTV/core-nexus-apple-tv-4k.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
@@ -317,17 +321,17 @@ Windows PC / ultrawide monitor template. Prioritises 1080p quality tiers (S/A/B/
 
 ### 🧪 Labs Templates
 
-Experimental builds testing new PSE architectures and addon configurations before promotion to stable. All Labs templates embed regex patterns inline — no synced URLs.
+Experimental builds testing new SEL expression architectures before promotion to stable. Currently on v0.14.0 — runtime-aware bitrate floors, anime language passthrough, latestSeason-aware season pack kill, subtitle preference PSE, age sort, and cachedAnime/uncachedAnime sort sections. [Full testing guide →](https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md)
 
 #### Core Nexus 4K Apex Labs
 
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
-| **Version** | v0.8.6 |
+| **Version** | v0.14.0 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json` |
 | **Resolution** | 2160p · 1080p fallback |
-| **Base** | 4K Apex v0.4.16 |
+| **Base** | 4K Apex |
 | **Usenet** | ❌ |
 
 #### Core Nexus Stream Labs
@@ -335,33 +339,53 @@ Experimental builds testing new PSE architectures and addon configurations befor
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
-| **Version** | v0.6.7 |
+| **Version** | v0.10.0 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-stream-labs.json` |
 | **Resolution** | 1080p |
-| **Base** | Stream v2.9.6 |
+| **Base** | Stream |
 | **Usenet** | ❌ |
 
-#### Core Nexus Essential Labs
+#### Core Nexus All-Rounder Labs
 
-TorBox debrid-only 1080p — no external scrapers. Tests template directives for TorBox Search toggle and exit thresholds.
+Single template for TV, movies, and anime with `isAnime`/`hasSeaDex` conditional tiers. Anime+live-action scrapers combined.
 
 | | |
 |---|---|
-| **File** | `Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
-| **Version** | v0.1.7 |
-| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **File** | `Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
+| **Version** | v0.4.0 |
+| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json` |
 | **Resolution** | 1080p |
 | **Usenet** | ❌ |
 
 #### Core Nexus 4K Essential Labs
 
-TorBox debrid-only 4K — no external scrapers. Tests template directives for TorBox Search toggle and exit thresholds.
-
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
-| **Version** | v0.1.7 |
+| **Version** | v0.5.0 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-4k-essential-labs.json` |
+| **Resolution** | 2160p · 1080p fallback |
+| **Usenet** | ❌ |
+
+#### Core Nexus Essential Labs
+
+| | |
+|---|---|
+| **File** | `Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **Version** | v0.4.0 |
+| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Essential/core-nexus-essential-labs.json` |
+| **Resolution** | 1080p |
+| **Usenet** | ❌ |
+
+#### Core Nexus Anime 4K Labs
+
+Anime-specific with `hasSeaDex` conditional PSEs, SeaDex Best pin, anime elite group pins.
+
+| | |
+|---|---|
+| **File** | `Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
+| **Version** | v0.3.0 |
+| **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json` |
 | **Resolution** | 2160p · 1080p fallback |
 | **Usenet** | ❌ |
 
@@ -374,7 +398,7 @@ TorBox Pro + NZBGeek. Full 4K with maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
-| **Version** | v2.9.5 |
+| **Version** | v2.12.8 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-4k-hybrid.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **HDR** | ✅ Full HDR — DV, HDR10+, HDR10 |
@@ -392,7 +416,7 @@ TorBox Pro + NZBGeek. Maximum source diversity.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
-| **Version** | v2.9.6 |
+| **Version** | v2.10.8 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Hybrid/core-nexus-hybrid.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ✅ NZBGeek API key required |
@@ -410,7 +434,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-4k-essential.json` |
-| **Version** | v2.9.4 |
+| **Version** | v2.12.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-4k-essential.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 | **Usenet** | ❌ |
@@ -424,7 +448,7 @@ Full 4K for Essential plan. No Usenet.
 | | |
 |---|---|
 | **File** | `Templates/Torbox/Essential/core-nexus-essential.json` |
-| **Version** | v2.9.5 |
+| **Version** | v2.10.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Essential/core-nexus-essential.json` |
 | **Resolution** | 1080p · 720p fallback |
 | **Usenet** | ❌ |
@@ -442,7 +466,7 @@ Full 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD
 | | |
 |---|---|
 | **File** | `Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json` |
-| **Version** | v0.1.12 |
+| **Version** | v0.4.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 
@@ -453,7 +477,7 @@ Full 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD
 | | |
 |---|---|
 | **File** | `Templates/Torbox/AllDebrid/core-nexus-alldebrid.json` |
-| **Version** | v0.1.12 |
+| **Version** | v0.2.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid.json` |
 | **Resolution** | 1080p · 720p fallback |
 
@@ -464,7 +488,7 @@ Full 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD
 | | |
 |---|---|
 | **File** | `Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json` |
-| **Version** | v0.1.9 |
+| **Version** | v0.2.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-4k-alldebrid-lite.json` |
 | **Resolution** | 2160p primary, 1080p fallback |
 
@@ -475,7 +499,7 @@ Full 4K for AllDebrid. IQR Tukey fence bitrate PSEs · DV/HDR priority · TrueHD
 | | |
 |---|---|
 | **File** | `Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json` |
-| **Version** | v0.1.11 |
+| **Version** | v0.2.7 |
 | **Import URL** | `https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/AllDebrid/core-nexus-alldebrid-lite.json` |
 | **Resolution** | 1080p · 720p fallback |
 
@@ -564,19 +588,19 @@ Every standard template has a `-lite` variant. Lite removes 12 quality-gate ESEs
 
 ---
 
-## 🛠️ Common to All Templates (v2.9.7)
+## 🛠️ Common to All Templates (v3.2.7)
 
 | Feature | Detail |
 |---|---|
 | **Formatter** | Core Syntax · `id: tamtaro` · `overrides['tamtaro']` |
 | **ESEs (standard)** | 24 total — 20 Tamtaro standard + Hard CAM Kill, YouTube Kill, 3D Kill, Season Pack Guard |
 | **ESEs (Lite)** | 12 total — quality gates removed, hard kills retained |
-| **ISEs** | 6 Tamtaro ISEs — Library, 0Cached, digitalRelease Bypass, SeaDex (anime only) |
-| **Sort** | cached → matched → score → resolution → quality → audio → language |
+| **ISEs** | 6 Tamtaro ISEs — Library, 0Cached, digitalRelease Bypass, SeaDex (anime only), REPACK Passthrough |
+| **Sort** | 16 keys: cached → seMatched → seScore → seadex → resolution → quality → regexScore → visualTag → audioTag → audioChannel → language → encode → library → seeders → bitrate → size |
 | **Deduplication** | filename + infoHash + smartDetect · 14 attributes · `libraryBehaviour: prefer` |
 | **Matching** | title `contains/0.75` · year `±2yr` · season/episode `non-strict` |
 | **Auto features** | autoPlay · precacheNextEpisode · preloadStreams · dynamicAddonFetching · checkOwned |
-| **Scoring** | Inline `rankedRegexPatterns` (53 patterns, `\|score\|≥50`) + template-specific `preferredRegexPatterns` |
+| **Scoring** | Inline `rankedRegexPatterns` (107 patterns, 10 score tiers) + `syncedRankedRegexUrls` (Vidhin05) + `preferredRegexPatterns` |
 | **RPDB** | `t0-free-rpdb` baked in |
 | **In-app updates** | `metadata.changelog` embedded |
 

--- a/posts/scheduled/2026-07-11-labs-v0140-update.md
+++ b/posts/scheduled/2026-07-11-labs-v0140-update.md
@@ -1,0 +1,81 @@
+---
+title: "Labs v0.14.0 — 7 new SEL features across all 6 Labs templates"
+subreddit: CoreBuilds
+scheduled: 2026-07-11
+flair: Update
+---
+
+Labs v0.14.0 is live across all 6 nightly templates. Seven new SEL expression features that improve anime handling, season pack logic, subtitle ranking, and uncached stream sorting.
+
+## What's new
+
+**1. Runtime-Aware Bitrate Floors**
+
+The REMUX bitrate floor ESEs now check whether the content is animation or short-form before firing. Animation legitimately encodes ~50% smaller than live-action, so a 4K REMUX anime at 25 Mbps was getting incorrectly killed by floors designed for live-action at 40+ Mbps. Short episodes (< 25 min) also bypass the floors. Only affects templates with bitrate floors (4K Apex Labs, Stream Labs, 4K Essential Labs).
+
+**2. Anime Language Passthrough**
+
+`passthrough(streams, 'language')` — bypasses language filtering entirely for anime queries. Anime fansub groups use non-standard language tagging (e.g. listing Japanese audio as English, or dual-audio tagged as mono) that the standard language filter rejects silently. This was causing valid anime streams to disappear on some titles.
+
+**3. latestSeason-Aware Season Pack Kill**
+
+Season packs for the current season are now preserved. Previously, the season pack kill fired whenever individual episodes existed — even for a current-season show where the pack might be the only high-quality source. Now only older-season packs get killed when episodes are available.
+
+**4. Subtitle Preference PSE**
+
+Streams with embedded English subtitles get a scoring boost. Not a hard filter — streams without subs still appear. But when two streams are otherwise equal, the one with embedded subs ranks higher.
+
+**5. Age Sort Key**
+
+Newer uncached torrents rank above older ones in `uncachedMovies` and `uncachedSeries` sort sections. More recent uploads are more likely to have active seeders.
+
+**6–7. cachedAnime / uncachedAnime Sort Sections**
+
+Dedicated sort sections for anime content. SeaDex is promoted to position 2 (right after cached status) — it's the strongest anime quality signal. The uncached anime sort also promotes seeders and adds the age key.
+
+## Templates updated
+
+| Template | Version |
+|---|---|
+| 4K Apex Labs | v0.14.0 |
+| Stream Labs | v0.10.0 |
+| All-Rounder Labs | v0.4.0 |
+| 4K Essential Labs | v0.5.0 |
+| Essential Labs | v0.4.0 |
+| Anime 4K Labs | v0.3.0 |
+
+## Import links
+
+Pick your template and click for your instance:
+
+**4K Apex Labs** (flagship 4K, all features)
+
+ElfHosted: https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+
+Fortheweak: https://aiostreams.fortheweak.cloud/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-4k-apex-labs.json
+
+---
+
+**All-Rounder Labs** (single template for TV + movies + anime)
+
+ElfHosted: https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
+
+Fortheweak: https://aiostreams.fortheweak.cloud/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Single/core-nexus-all-rounder-labs.json
+
+---
+
+**Anime 4K Labs** (anime-specific with SeaDex conditional tiers)
+
+ElfHosted: https://aiostreams.elfhosted.com/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
+
+Fortheweak: https://aiostreams.fortheweak.cloud/stremio/configure?template=https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Templates/Torbox/Nightly/Anime/core-nexus-anime-4k-labs.json
+
+---
+
+All other Labs templates: https://github.com/brevityA/Core-Builds/blob/main/Guides/LABS.md
+
+## Also fixed
+
+- **Configurator:** 2 regex patterns (`Radarr HD Bluray T3 [B]` and `Anime LQ Groups`) that weren't in Vidhin05's allowlist have been removed — configurator-generated templates no longer trigger the "2/176 regexes not allowed" error on self-hosted instances.
+
+Most useful feedback: anime results that improved or regressed, season pack handling on current-season shows, and any title where the subtitle PSE caused an unexpected ranking change.


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — new v3.2.7 entry covering Labs v0.14.0 SEL features (7 new expressions), configurator regex fix (2 patterns removed), and All-Rounder addonName fix
- **Guides/LABS.md** — complete rewrite for v0.14.0: runtime-aware bitrate floors, anime language passthrough, latestSeason season pack kill, subtitle PSE, age sort key, cachedAnime/uncachedAnime sort sections. All 6 Labs templates listed with current versions and import URLs
- **Templates/Torbox/README.md** — added All-Rounder Labs and Anime 4K Labs to Nightly and All Templates tables. Updated all 19 stable template versions (were stale from v2.9.x/v0.1.x era). Updated Labs versions to v0.14.0. Fixed scoring description (53 patterns → 107 with syncedRankedRegexUrls). Common features section updated to v3.2.7
- **README.md** — version badge v3.0.2 → v3.2.7, version text updated, added dedicated Labs section with all 6 templates, updated template count (46), fixed scoring description
- **CLAUDE.md** — Nightly inventory updated to v0.14.0 versions and feature descriptions
- **posts/** — new Labs v0.14.0 Reddit post with import links for all instances

## Test plan

- [ ] Verify all import URLs in docs resolve to valid JSON files
- [ ] Confirm template versions in docs match actual `metadata.version` in template files
- [ ] Check markdown renders correctly on GitHub (tables, code blocks, links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_