### PR TITLE
Update WuPlay guide: config.wuplay.app setup flow + Profile Key

### DIFF
--- a/Assets/wuplay_config_example.svg
+++ b/Assets/wuplay_config_example.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" fill="none">
+  <!-- Background -->
+  <rect width="800" height="420" rx="12" fill="#1a1a2e"/>
+
+  <!-- Left sidebar -->
+  <rect x="0" y="0" width="180" height="420" rx="12" fill="#16162a"/>
+  <rect x="180" y="0" width="12" height="420" fill="#16162a"/>
+
+  <!-- Sidebar items -->
+  <text x="48" y="68" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Playback</text>
+  <text x="48" y="108" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Interface</text>
+  <text x="48" y="148" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Catalogs</text>
+  <text x="48" y="188" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Lists</text>
+
+  <!-- Selected item highlight -->
+  <rect x="8" y="207" width="164" height="40" rx="8" fill="#2a4a6e"/>
+  <text x="48" y="232" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#5cb8ff">Configuration</text>
+
+  <text x="48" y="276" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Device</text>
+  <text x="48" y="316" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">About</text>
+
+  <!-- Sidebar icons (simple circles as placeholders) -->
+  <circle cx="28" cy="64" r="6" fill="#8888aa" opacity="0.4"/>
+  <circle cx="28" cy="104" r="6" fill="#8888aa" opacity="0.4"/>
+  <circle cx="28" cy="144" r="6" fill="#8888aa" opacity="0.4"/>
+  <circle cx="28" cy="184" r="6" fill="#8888aa" opacity="0.4"/>
+  <circle cx="28" cy="228" r="6" fill="#5cb8ff" opacity="0.6"/>
+  <circle cx="28" cy="272" r="6" fill="#8888aa" opacity="0.4"/>
+  <circle cx="28" cy="312" r="6" fill="#8888aa" opacity="0.4"/>
+
+  <!-- Page title -->
+  <text x="220" y="52" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="600" fill="#e0e0f0">Configuration</text>
+
+  <!-- Profile Key section -->
+  <text x="380" y="100" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#e0e0f0">Your Profile Key</text>
+
+  <!-- Profile key box -->
+  <rect x="380" y="114" width="380" height="48" rx="8" fill="#2a2a3e"/>
+  <text x="570" y="144" font-family="'SF Mono', 'Fira Code', monospace" font-size="20" fill="#c0c0d8" text-anchor="middle" letter-spacing="6">a1b2c3</text>
+
+  <!-- Config link -->
+  <text x="380" y="190" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#8888aa">Manage add-ons and other options at:</text>
+  <text x="380" y="210" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#5cb8ff">config.wuplay.app</text>
+
+  <!-- Warning -->
+  <text x="394" y="240" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#aa8844">If you lose the profile key, you cannot recover this profile.</text>
+  <text x="382" y="240" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#ddaa33">!</text>
+
+  <!-- Divider -->
+  <line x1="220" y1="265" x2="760" y2="265" stroke="#2a2a3e" stroke-width="1"/>
+
+  <!-- Manage section -->
+  <text x="220" y="295" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#8888aa">Configure via config.wuplay.app:</text>
+
+  <!-- Left column -->
+  <circle cx="232" cy="322" r="2.5" fill="#5cb8ff"/>
+  <text x="244" y="326" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Add-ons</text>
+
+  <circle cx="232" cy="350" r="2.5" fill="#5cb8ff"/>
+  <text x="244" y="354" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Catalogs</text>
+
+  <circle cx="232" cy="378" r="2.5" fill="#5cb8ff"/>
+  <text x="244" y="382" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Layout</text>
+
+  <!-- Right column -->
+  <circle cx="460" cy="322" r="2.5" fill="#5cb8ff"/>
+  <text x="472" y="326" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Trakt</text>
+
+  <circle cx="460" cy="350" r="2.5" fill="#5cb8ff"/>
+  <text x="472" y="354" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Privacy &amp; Data</text>
+
+  <circle cx="460" cy="378" r="2.5" fill="#5cb8ff"/>
+  <text x="472" y="382" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#c0c0d8">Profile Manager</text>
+
+  <!-- Annotation arrow and label -->
+  <rect x="540" y="290" width="220" height="36" rx="6" fill="#1e3a5f" stroke="#5cb8ff" stroke-width="1"/>
+  <text x="650" y="313" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#5cb8ff" text-anchor="middle">Settings → Configuration</text>
+
+  <!-- Arrow from annotation to profile key -->
+  <path d="M 650 290 L 650 168 L 762 168" stroke="#5cb8ff" stroke-width="1.5" fill="none" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#5cb8ff"/>
+    </marker>
+  </defs>
+</svg>

--- a/Guides/WUPLAY_SETUP.md
+++ b/Guides/WUPLAY_SETUP.md
@@ -60,7 +60,7 @@ In AIOStreams:
 
 After saving, AIOStreams shows your **manifest URL**. Copy it. It looks like:
 
-```
+```text
 https://aiostreams.elfhosted.com/stremio/abcdef1234/manifest.json
 ```
 
@@ -84,7 +84,7 @@ Open WuPlay on your device and go to **Settings → Configuration**. Your **Prof
 
 Go back to WuPlay on your device. Browse movies and shows → select a title → pick a stream. The Core Builds formatter shows resolution, codec, audio, and file size for each stream. To cast, use the Chromecast icon in the player controls.
 
-> **Tip:** WuPlay uses the same manifest URL as Stremio and Nuvio — you can use all three clients with the same AIOStreams config.
+> **Tip:** WuPlay uses the same manifest URL as Stremio and Nuvio — you can use all three clients with the same AIOStreams config. Changes you make in AIOStreams apply to all of them.
 
 ---
 
@@ -109,7 +109,7 @@ Go back to WuPlay on your device. Browse movies and shows → select a title →
 
 ## Troubleshooting
 
-- **No streams appearing** → Make sure your manifest URL is correct and your TorBox API key is active
+- **No streams appearing** → Make sure your manifest URL is correct and your TorBox API key is active in AIOStreams
 - **Add-on not syncing** → Verify your Profile Key is correct in the configurator at [config.wuplay.app](https://config.wuplay.app/configure/)
 - **Cast not working** → Ensure your Chromecast and WuPlay device are on the same Wi-Fi network
 - **Streams buffer or stall** → Try a Speed or Flash template for faster cached results

--- a/Guides/WUPLAY_SETUP.md
+++ b/Guides/WUPLAY_SETUP.md
@@ -1,37 +1,46 @@
 # WuPlay Setup
 
-Use Core Builds with WuPlay — stream in your browser, cast to Chromecast, no app install required.
+Use Core Builds with WuPlay — a Stremio-compatible streaming client for Android TV, Chromecast, and more.
 
 ---
 
 ## What is WuPlay?
 
-WuPlay is a web-based streaming client that works with Stremio add-ons — including AIOStreams and Core Builds. No app install needed. It runs in your browser and supports Chromecast for casting to TVs.
+[WuPlay](https://wuplay.app) is a Stremio-compatible streaming client that works with all Stremio add-ons — including AIOStreams and Core Builds. Available on Android TV, Google TV, Fire Stick, and web browser. Supports Chromecast casting, Trakt integration, and configurable layouts.
+
+**Current version:** v0.7.3-beta
 
 **Use WuPlay when:**
-- Your device doesn't have a native Stremio app
-- You want to cast to a Chromecast or smart TV
-- You prefer streaming in a browser tab
+- You want a dedicated streaming app on Android TV / Fire Stick / Chromecast
+- You prefer a different UI from Stremio with built-in genre browsing and binge groups
+- You need Chromecast casting support
 
 ---
 
 ## Quick Import
 
-Already have a TorBox account and a configured AIOStreams template? Three steps:
+Already have a TorBox account and a configured AIOStreams template? Four steps:
 
 1. **Copy your manifest URL** — open your AIOStreams instance → copy the manifest URL from the top of the config page
-2. **Open WuPlay** — go to [wuplay.app](https://wuplay.app)
-3. **Add the manifest** — go to **Add-ons** → paste your manifest URL → click **Install**
+2. **Find your Profile Key** — in WuPlay, go to **Settings → Configuration**. Your Profile Key is displayed at the top (e.g. `a1b2c3`)
+3. **Open the WuPlay configurator** — go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in your browser. Enter your Profile Key
+4. **Add the manifest** — under **Add-ons**, paste your AIOStreams manifest URL and save. It syncs to your WuPlay app automatically
 
 ---
 
 ## Full Beginner Walkthrough
 
-### 1. Get a TorBox subscription
+### 1. Install WuPlay
+
+Download WuPlay using **downloader code `5781040`** on your device, or get it from:
+- **Android TV / Google TV / Fire Stick** → sideload via [WuPlay releases](https://github.com/wuplayapp/wuplay-releases)
+- **Web** → browser version at [wuplay.app](https://wuplay.app)
+
+### 2. Get a TorBox subscription
 
 Sign up at [torbox.app](https://torbox.app/subscription?referral=d1ccddb0-f094-45ca-b52b-942a2635855e). You need at least a **Standard** plan. Go to **Dashboard → API Keys** and copy your API key.
 
-### 2. Choose and import a template
+### 3. Choose and import a template
 
 1. Go to the [Template Directory](https://core-builds.mintlify.app/template-directory)
 2. Click **Import on ElfHosted** or **Import on Fortheweak** next to your chosen template
@@ -39,7 +48,7 @@ Sign up at [torbox.app](https://torbox.app/subscription?referral=d1ccddb0-f094-4
 
 Not sure which template? See [Which Template?](https://core-builds.mintlify.app/which-template). For most people: **4K Apex** (4K) or **Stream** (1080p).
 
-### 3. Configure AIOStreams
+### 4. Configure AIOStreams
 
 In AIOStreams:
 
@@ -47,7 +56,7 @@ In AIOStreams:
 2. *(Optional)* Add a TMDB Access Token from [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api)
 3. Click **Save**
 
-### 4. Copy your manifest URL
+### 5. Copy your manifest URL
 
 After saving, AIOStreams shows your **manifest URL**. Copy it. It looks like:
 
@@ -55,18 +64,27 @@ After saving, AIOStreams shows your **manifest URL**. Copy it. It looks like:
 https://aiostreams.elfhosted.com/stremio/abcdef1234/manifest.json
 ```
 
-### 5. Set up WuPlay
+### 6. Find your WuPlay Profile Key
 
-1. Go to [wuplay.app](https://wuplay.app)
-2. Navigate to **Add-ons**
-3. Paste your AIOStreams manifest URL
-4. Click **Install** or **Add**
+Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen.
 
-### 6. Start streaming
+![WuPlay Configuration](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/wuplay_config_example.svg)
 
-Browse movies and shows in WuPlay. Click any title → select a stream → playback starts in your browser. To cast, use the Chromecast icon in the player controls.
+> **Warning:** If you lose your Profile Key, you cannot recover your profile. Save it somewhere safe.
 
-> **Tip:** WuPlay uses the same manifest URL as Stremio — you can use both clients with the same AIOStreams config.
+### 7. Add the add-on via WuPlay configurator
+
+1. Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in a browser (phone or computer)
+2. Enter your **Profile Key** to connect to your WuPlay device
+3. Navigate to **Add-ons**
+4. Paste your AIOStreams manifest URL
+5. Save — the add-on syncs to your WuPlay app automatically
+
+### 8. Start streaming
+
+Go back to WuPlay on your device. Browse movies and shows → select a title → pick a stream. The Core Builds formatter shows resolution, codec, audio, and file size for each stream. To cast, use the Chromecast icon in the player controls.
+
+> **Tip:** WuPlay uses the same manifest URL as Stremio and Nuvio — you can use all three clients with the same AIOStreams config.
 
 ---
 
@@ -74,18 +92,28 @@ Browse movies and shows in WuPlay. Click any title → select a stream → playb
 
 | | WuPlay | Stremio |
 |---|---|---|
-| Platform | Web browser (any device) | Desktop + mobile apps |
-| Install required | No | Yes |
+| Platform | Android TV, Fire Stick, Chromecast, web | Desktop + mobile apps |
+| Configuration | Via [config.wuplay.app](https://config.wuplay.app/configure/) + Profile Key | In-app settings |
 | Chromecast | Built-in cast support | Not natively supported |
-| Offline use | No | Download for offline (desktop) |
-| Library sync | No | Syncs across devices via account |
-| Best for | Casting, quick access, no-install | Daily use, full library management |
+| Genre browsing | Built-in genres screen (reality, anime, etc.) | Add-on dependent |
+| Trakt | Built-in integration | Via add-on |
+| Binge mode | Binge groups with auto-play | Manual next episode |
+| Best for | TV devices, casting, lean-back viewing | Desktop, mobile, full library management |
+
+## WuPlay Links
+
+- **GitHub releases** → [github.com/wuplayapp/wuplay-releases](https://github.com/wuplayapp/wuplay-releases)
+- **Downloader code** → `5781040`
+- **Discord** → [discord.gg/PvZjHVGtE9](https://discord.gg/PvZjHVGtE9)
+- **Ko-fi** → [ko-fi.com/wuplaydev](https://ko-fi.com/wuplaydev)
 
 ## Troubleshooting
 
 - **No streams appearing** → Make sure your manifest URL is correct and your TorBox API key is active
-- **Cast not working** → Ensure your Chromecast and browser are on the same Wi-Fi network
+- **Add-on not syncing** → Verify your Profile Key is correct in the configurator at [config.wuplay.app](https://config.wuplay.app/configure/)
+- **Cast not working** → Ensure your Chromecast and WuPlay device are on the same Wi-Fi network
 - **Streams buffer or stall** → Try a Speed or Flash template for faster cached results
-- **Playback error** → Some codecs may not play in-browser. Try a different stream — H.264 is most reliable in browsers
+- **FLAC audio issues** → WuPlay v0.7.3+ automatically transcodes FLAC tracks (ExoPlayer limitation)
+- **"No compatible streams" on resume** → Fixed in v0.7.3 — update WuPlay if you see this
 
-More help: [Troubleshooting](https://core-builds.mintlify.app/troubleshooting) · [FAQ](https://core-builds.mintlify.app/faq)
+More help: [Troubleshooting](https://core-builds.mintlify.app/troubleshooting) · [FAQ](https://core-builds.mintlify.app/faq) · [WuPlay Discord](https://discord.gg/PvZjHVGtE9)

--- a/docs/wuplay-setup.mdx
+++ b/docs/wuplay-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "WuPlay Setup"
 sidebarTitle: "WuPlay"
-description: "Use Core Builds with WuPlay — stream in your browser, cast to Chromecast, no app install required."
+description: "Use Core Builds with WuPlay — a Stremio-compatible streaming client for Android TV, Chromecast, and more."
 ---
 
 <Frame>
@@ -14,26 +14,31 @@ description: "Use Core Builds with WuPlay — stream in your browser, cast to Ch
 
 ## What is WuPlay?
 
-WuPlay is a web-based streaming client that works with Stremio add-ons — including AIOStreams and Core Builds. No app install needed. It runs entirely in your browser and supports Chromecast for casting to TVs.
+[WuPlay](https://wuplay.app) is a Stremio-compatible streaming client that works with all Stremio add-ons — including AIOStreams and Core Builds. Available on Android TV, Google TV, Fire Stick, and web browser. Supports Chromecast casting, Trakt integration, and configurable layouts.
+
+**Current version:** v0.7.3-beta
 
 **Use WuPlay when:**
-- Your device doesn't have a native Stremio app
-- You want to cast to a Chromecast or smart TV
-- You prefer streaming in a browser tab
+- You want a dedicated streaming app on Android TV / Fire Stick / Chromecast
+- You prefer a different UI from Stremio with built-in genre browsing and binge groups
+- You need Chromecast casting support
 
 ## Quick Import
 
-Already have a TorBox account and a configured AIOStreams template? Three steps:
+Already have a TorBox account and a configured AIOStreams template? Four steps:
 
 <Steps>
   <Step title="Copy your manifest URL">
     Open your AIOStreams instance → your manifest URL is shown at the top of the config page. Copy it.
   </Step>
-  <Step title="Open WuPlay">
-    Go to [wuplay.app](https://wuplay.app) in your browser.
+  <Step title="Find your Profile Key">
+    In WuPlay, go to **Settings → Configuration**. Your **Profile Key** is displayed at the top (e.g. `a1b2c3`). Note it down.
   </Step>
-  <Step title="Add the manifest">
-    In WuPlay, go to **Add-ons** → paste your AIOStreams manifest URL → click **Install**. Browse content and streams appear just like in Stremio.
+  <Step title="Open the WuPlay configurator">
+    Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in your browser. Enter your Profile Key to link your device.
+  </Step>
+  <Step title="Add the manifest as an add-on">
+    In the configurator under **Add-ons**, paste your AIOStreams manifest URL and save. The add-on syncs to your WuPlay app automatically.
   </Step>
 </Steps>
 
@@ -41,11 +46,17 @@ Already have a TorBox account and a configured AIOStreams template? Three steps:
 
 ## Full Beginner Walkthrough
 
-### 1. Get a TorBox subscription
+### 1. Install WuPlay
+
+Download WuPlay using **downloader code `5781040`** on your device, or get it from:
+- **Android TV / Google TV / Fire Stick** → sideload via [WuPlay releases](https://github.com/wuplayapp/wuplay-releases)
+- **Web** → use the browser version at [wuplay.app](https://wuplay.app)
+
+### 2. Get a TorBox subscription
 
 Sign up at [torbox.app](https://torbox.app/subscription?referral=d1ccddb0-f094-45ca-b52b-942a2635855e). You need at least a **Standard** plan. Go to **Dashboard → API Keys** and copy your API key.
 
-### 2. Choose and import a template
+### 3. Choose and import a template
 
 1. Go to the [Template Directory](/template-directory)
 2. Click **Import on ElfHosted** or **Import on Fortheweak** next to your chosen template
@@ -53,7 +64,7 @@ Sign up at [torbox.app](https://torbox.app/subscription?referral=d1ccddb0-f094-4
 
 Not sure which template? See [Which Template?](/which-template). For most people: **4K Apex** (4K) or **Stream** (1080p).
 
-### 3. Configure AIOStreams
+### 4. Configure AIOStreams
 
 In AIOStreams:
 
@@ -61,29 +72,44 @@ In AIOStreams:
 2. *(Optional)* Add a TMDB Access Token from [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api)
 3. Click **Save**
 
-### 4. Copy your manifest URL
+### 5. Copy your manifest URL
 
-After saving, AIOStreams shows your **manifest URL** at the top of the page. It looks like:
+After saving, AIOStreams shows your **manifest URL**. Copy it. It looks like:
 
 ```
 https://aiostreams.elfhosted.com/stremio/abcdef1234/manifest.json
 ```
 
-Copy this URL — you'll paste it into WuPlay.
+### 6. Find your WuPlay Profile Key
 
-### 5. Set up WuPlay
+Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen.
 
-1. Go to [wuplay.app](https://wuplay.app)
-2. Navigate to **Add-ons** (or the add-on/plugin section)
-3. Paste your AIOStreams manifest URL
-4. Click **Install** or **Add**
+<Frame>
+  <img
+    src="https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/wuplay_config_example.svg"
+    alt="WuPlay Configuration — find your Profile Key under Settings → Configuration"
+    style={{ width: '100%', display: 'block' }}
+  />
+</Frame>
 
-### 6. Start streaming
+<Warning>
+  If you lose your Profile Key, you cannot recover your profile. Save it somewhere safe.
+</Warning>
 
-Browse movies and shows in WuPlay. Click any title → select a stream from the list → playback starts in your browser. To cast, use the Chromecast icon in the player controls.
+### 7. Add the add-on via WuPlay configurator
+
+1. Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in a browser (phone or computer)
+2. Enter your **Profile Key** to connect to your WuPlay device
+3. Navigate to **Add-ons**
+4. Paste your AIOStreams manifest URL
+5. Save — the add-on syncs to your WuPlay app automatically
+
+### 8. Start streaming
+
+Go back to WuPlay on your device. Browse movies and shows → select a title → pick a stream. The Core Builds formatter shows resolution, codec, audio, and file size for each stream. To cast, use the Chromecast icon in the player controls.
 
 <Tip>
-  WuPlay uses the same manifest URL as Stremio — you can use both clients with the same AIOStreams config. Changes you make in AIOStreams (re-importing a template, changing settings) apply to both.
+  WuPlay uses the same manifest URL as Stremio and Nuvio — you can use all three clients with the same AIOStreams config. Changes you make in AIOStreams apply to all of them.
 </Tip>
 
 ---
@@ -92,18 +118,28 @@ Browse movies and shows in WuPlay. Click any title → select a stream from the 
 
 | | WuPlay | Stremio |
 |---|---|---|
-| Platform | Web browser (any device) | Desktop + mobile apps |
-| Install required | No | Yes |
+| Platform | Android TV, Fire Stick, Chromecast, web | Desktop + mobile apps |
+| Configuration | Via [config.wuplay.app](https://config.wuplay.app/configure/) + Profile Key | In-app settings |
 | Chromecast | Built-in cast support | Not natively supported |
-| Offline use | No | Download for offline (desktop) |
-| Library sync | No | Syncs across devices via account |
-| Best for | Casting, quick access, no-install setups | Daily use, full library management |
+| Genre browsing | Built-in genres screen (reality, anime, etc.) | Add-on dependent |
+| Trakt | Built-in integration | Via add-on |
+| Binge mode | Binge groups with auto-play | Manual next episode |
+| Best for | TV devices, casting, lean-back viewing | Desktop, mobile, full library management |
+
+## WuPlay Links
+
+- **GitHub releases** → [github.com/wuplayapp/wuplay-releases](https://github.com/wuplayapp/wuplay-releases)
+- **Downloader code** → `5781040`
+- **Discord** → [discord.gg/PvZjHVGtE9](https://discord.gg/PvZjHVGtE9)
+- **Ko-fi** → [ko-fi.com/wuplaydev](https://ko-fi.com/wuplaydev)
 
 ## Troubleshooting
 
 - **No streams appearing** → Make sure your manifest URL is correct and your TorBox API key is active in AIOStreams
-- **Cast not working** → Ensure your Chromecast and browser are on the same Wi-Fi network
+- **Add-on not syncing** → Verify your Profile Key is correct in the configurator at [config.wuplay.app](https://config.wuplay.app/configure/)
+- **Cast not working** → Ensure your Chromecast and WuPlay device are on the same Wi-Fi network
 - **Streams buffer or stall** → Try a [Speed](/template-directory#speed-torbox) or [Flash](/template-directory#flash) template for faster cached results
-- **Playback error** → Some codecs may not play in-browser. Try a different stream from the list — browser players handle H.264 most reliably
+- **FLAC audio issues** → WuPlay v0.7.3+ automatically transcodes FLAC tracks (ExoPlayer limitation)
+- **"No compatible streams" on resume** → Fixed in v0.7.3 — update WuPlay if you see this
 
-More help: [Troubleshooting](/troubleshooting) · [FAQ](/faq)
+More help: [Troubleshooting](/troubleshooting) · [FAQ](/faq) · [WuPlay Discord](https://discord.gg/PvZjHVGtE9)


### PR DESCRIPTION
## Description

Rewrites the WuPlay setup guide with the correct configuration flow — add-ons are managed via `config.wuplay.app/configure/` using a Profile Key (found in Settings → Configuration), not by pasting a manifest URL directly in-app.

## Type of Change
- [x] Documentation update

## Changes

- **Correct setup flow**: WuPlay add-ons are configured through the web configurator at `config.wuplay.app/configure/` using the device's Profile Key, not via in-app manifest paste
- **SVG illustration**: New `Assets/wuplay_config_example.svg` showing the Configuration screen with example Profile Key
- **v0.7.3-beta info**: Added current version, downloader code (`5781040`), and WuPlay links (GitHub releases, Discord, Ko-fi)
- **Updated comparison table**: Added genre browsing, Trakt integration, and binge mode features
- **Troubleshooting**: Added v0.7.3-specific entries (FLAC transcoding, resume fix)
- **Both versions updated**: Mintlify (`docs/wuplay-setup.mdx`) and GitHub (`Guides/WUPLAY_SETUP.md`)

## Template Checklist
N/A — documentation only

## Testing
- Verified SVG renders correctly
- Cross-referenced setup flow against WuPlay v0.7.3-beta Configuration screen

## Related Issues
N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_