### PR TITLE
Add QR code references to WuPlay guides

### DIFF
--- a/Assets/wuplay_config_example.svg
+++ b/Assets/wuplay_config_example.svg
@@ -31,6 +31,27 @@
   <!-- Page title -->
   <text x="220" y="52" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="600" fill="#e0e0f0">Configuration</text>
 
+  <!-- QR code (stylised placeholder) -->
+  <rect x="220" y="80" width="120" height="120" rx="8" fill="#2a2a3e"/>
+  <rect x="232" y="92" width="24" height="24" rx="3" fill="#c0c0d8"/>
+  <rect x="268" y="92" width="12" height="12" rx="2" fill="#c0c0d8"/>
+  <rect x="292" y="92" width="24" height="24" rx="3" fill="#c0c0d8"/>
+  <rect x="232" y="124" width="12" height="12" rx="2" fill="#c0c0d8"/>
+  <rect x="252" y="124" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="268" y="128" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="284" y="120" width="12" height="12" rx="2" fill="#c0c0d8"/>
+  <rect x="304" y="124" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="232" y="148" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="248" y="144" width="12" height="12" rx="2" fill="#c0c0d8"/>
+  <rect x="268" y="148" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="284" y="148" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="300" y="144" width="12" height="12" rx="2" fill="#c0c0d8"/>
+  <rect x="232" y="168" width="24" height="24" rx="3" fill="#c0c0d8"/>
+  <rect x="268" y="172" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="284" y="168" width="8" height="8" rx="1" fill="#c0c0d8"/>
+  <rect x="292" y="168" width="24" height="24" rx="3" fill="#c0c0d8"/>
+  <text x="280" y="212" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#8888aa" text-anchor="middle">Scan to configure</text>
+
   <!-- Profile Key section -->
   <text x="380" y="100" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#e0e0f0">Your Profile Key</text>
 

--- a/Guides/WUPLAY_SETUP.md
+++ b/Guides/WUPLAY_SETUP.md
@@ -23,7 +23,7 @@ Already have a TorBox account and a configured AIOStreams template? Four steps:
 
 1. **Copy your manifest URL** — open your AIOStreams instance → copy the manifest URL from the top of the config page
 2. **Find your Profile Key** — in WuPlay, go to **Settings → Configuration**. Your Profile Key is displayed at the top (e.g. `a1b2c3`)
-3. **Open the WuPlay configurator** — go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in your browser. Enter your Profile Key
+3. **Open the WuPlay configurator** — scan the **QR code** on the Configuration screen, or go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) manually and enter your Profile Key
 4. **Add the manifest** — under **Add-ons**, paste your AIOStreams manifest URL and save. It syncs to your WuPlay app automatically
 
 ---
@@ -65,7 +65,7 @@ https://aiostreams.elfhosted.com/stremio/abcdef1234/manifest.json
 
 ### 6. Find your WuPlay Profile Key
 
-Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen.
+Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen. A **QR code** is also displayed — scan it with your phone to open the WuPlay configurator directly, pre-linked to your device.
 
 ![WuPlay Configuration](https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/wuplay_config_example.svg)
 
@@ -73,8 +73,7 @@ Open WuPlay on your device and go to **Settings → Configuration**. Your **Prof
 
 ### 7. Add the add-on via WuPlay configurator
 
-1. Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in a browser (phone or computer)
-2. Enter your **Profile Key** to connect to your WuPlay device
+1. **Scan the QR code** shown on the Configuration screen to open the configurator pre-linked to your device — or go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) manually and enter your **Profile Key**
 3. Navigate to **Add-ons**
 4. Paste your AIOStreams manifest URL
 5. Save — the add-on syncs to your WuPlay app automatically

--- a/docs/wuplay-setup.mdx
+++ b/docs/wuplay-setup.mdx
@@ -35,7 +35,7 @@ Already have a TorBox account and a configured AIOStreams template? Four steps:
     In WuPlay, go to **Settings → Configuration**. Your **Profile Key** is displayed at the top (e.g. `a1b2c3`). Note it down.
   </Step>
   <Step title="Open the WuPlay configurator">
-    Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in your browser. Enter your Profile Key to link your device.
+    Scan the **QR code** on the Configuration screen to open the configurator pre-linked to your device — or go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) manually and enter your Profile Key.
   </Step>
   <Step title="Add the manifest as an add-on">
     In the configurator under **Add-ons**, paste your AIOStreams manifest URL and save. The add-on syncs to your WuPlay app automatically.
@@ -81,7 +81,7 @@ https://aiostreams.elfhosted.com/stremio/abcdef1234/manifest.json
 
 ### 6. Find your WuPlay Profile Key
 
-Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen.
+Open WuPlay on your device and go to **Settings → Configuration**. Your **Profile Key** is shown at the top of the screen. A **QR code** is also displayed — scan it with your phone to open the WuPlay configurator directly, pre-linked to your device.
 
 <Frame>
   <img
@@ -97,8 +97,7 @@ Open WuPlay on your device and go to **Settings → Configuration**. Your **Prof
 
 ### 7. Add the add-on via WuPlay configurator
 
-1. Go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) in a browser (phone or computer)
-2. Enter your **Profile Key** to connect to your WuPlay device
+1. **Scan the QR code** shown on the Configuration screen to open the configurator pre-linked to your device — or go to [config.wuplay.app/configure](https://config.wuplay.app/configure/) manually and enter your **Profile Key**
 3. Navigate to **Add-ons**
 4. Paste your AIOStreams manifest URL
 5. Save — the add-on syncs to your WuPlay app automatically


### PR DESCRIPTION
## Summary

WuPlay's Configuration screen displays a QR code that links directly to the web configurator, pre-linked to the device. This PR mentions the QR code throughout both guides so users know they can scan instead of typing the URL.

### Changes

- **Profile Key section**: Notes the QR code is displayed alongside the Profile Key
- **Step 7 / Quick Import step 3**: "Scan the QR code" as the primary action, with manual URL as fallback
- **SVG illustration**: Added a stylised QR code placeholder to `wuplay_config_example.svg` with "Scan to configure" label
- Both MD and MDX versions updated consistently

## Test plan

- [x] QR code mentioned in Quick Import (both versions)
- [x] QR code mentioned in full walkthrough step 6 and step 7 (both versions)
- [x] SVG illustration includes QR code placeholder
- [x] Manual URL fallback preserved in all locations

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_