### PR TITLE
docs: add Configurator v2.55–v2.56 (Resolution First, Foreign Language Kill, UX overhaul)

### DIFF
--- a/docs/configurator.mdx
+++ b/docs/configurator.mdx
@@ -17,11 +17,7 @@ The **Template Configurator** generates a ready-to-import AIOStreams template ba
   Opens in a new tab — runs entirely in your browser. No data is sent anywhere.
 </Card>
 
-<iframe
-  src="https://brevitya.github.io/Core-Builds/"
-  style={{ width: '100%', height: '920px', border: 'none', borderRadius: '12px', marginTop: '16px' }}
-  title="Core Builds Template Configurator"
-/>
+<iframe src="https://brevitya.github.io/Core-Builds/" style={{ width: '100%', height: '920px', border: 'none', borderRadius: '12px', marginTop: '16px' }} title="Core Builds Template Configurator" />
 
 <Note>
   **Offline use:** the configurator is a self-contained HTML file — save it and open it locally with no internet needed. [Download from GitHub](https://github.com/brevityA/Core-Builds/blob/main/configurator/index.html) → Raw → Save As.
@@ -46,7 +42,7 @@ Jump straight to the full configuration panel with all options visible at once. 
 One-tap presets for common setups — no questions asked:
 
 | Preset | What it does |
-|---|---|
+| --- | --- |
 | **4K Apex** | Flagship 4K template with full expression stack. Requires TorBox Pro |
 | **1080p Stream** | Optimised 1080p streaming. Requires TorBox Pro |
 | **Free Streaming** | HTTP direct-play sources — no debrid service needed |
@@ -65,29 +61,28 @@ Quick Deploy presets generate a template with sensible defaults and install it o
     Choose your streaming service. The splash screen shows service chips — tap one to select it and proceed. This sets which presets, cache layer, and search addons are included.
 
     | Choice | Cache layer | Key addons |
-    |---|---|---|
+    | --- | --- | --- |
     | **TorBox Pro** | StremThru Torz | TorBox Search · HdHub · full scraper stack |
     | **TorBox Essential** | StremThru Torz | Same scrapers, Essential plan limits |
     | **AllDebrid** | StremThru Store | HdHub disabled (no AllDebrid support) |
     | **Real-Debrid** | StremThru Store | Standard scraper stack |
     | **EasyDebrid** | StremThru Store | Multi-debrid aggregator |
-    | **PikPak** | StremThru Store | Cloud torrent + download caching |
+    | **PikPak** | StremThru Store | Cloud torrent \+ download caching |
     | **Seedr** | StremThru Store | Cloud torrent streaming |
-    | **Hybrid (TorBox + RD)** | Both | TorBox-priority with RD fallback |
-    | **EasyNews** | N/A | EasyNews search + usenet scrapers |
+    | **Hybrid (TorBox \+ RD)** | Both | TorBox-priority with RD fallback |
+    | **EasyNews** | N/A | EasyNews search \+ usenet scrapers |
     | **Free (No Debrid)** | None | P2P or HTTP direct-play sources only |
   </Step>
-
   <Step title="Your Device">
     Device profile sets audio exclusions, codec restrictions, and HDR/DV handling automatically. If your device isn't listed, "Generic" works for most setups.
 
     | Device | Audio excluded | Encodes excluded | DV-Only Kill |
-    |---|---|---|---|
+    | --- | --- | --- | --- |
     | Generic TV / Box | — | — | Off |
     | Samsung TV (Tizen) | TrueHD · DTS-HD MA · DTS:X · FLAC | AV1 · VC-1 | **On** |
     | Apple TV 4K (1st / 2nd gen) | — | AV1 | Off |
     | Apple TV 4K (3rd gen / A15) | — | — | Off |
-    | LG TV (webOS 2019+) | — | — | Off |
+    | LG TV (webOS 2019\+) | — | — | Off |
     | Windows PC / Ultrawide | — | VC-1 | Off |
     | Fire Stick (HD) | TrueHD · DTS-HD MA · DTS:X · FLAC | AV1 · VC-1 | **On** |
     | Fire Stick 4K Max | TrueHD · DTS-HD MA · DTS:X · FLAC | VC-1 | Off |
@@ -96,40 +91,36 @@ Quick Deploy presets generate a template with sensible defaults and install it o
       See [Device Profiles](/device-profiles) for full codec support details and recommended settings for each device.
     </Tip>
   </Step>
-
   <Step title="Resolution">
     Determines the PSE stack, resolution locks, and which streams get filtered out.
 
     | Choice | What happens | Best for |
-    |---|---|---|
+    | --- | --- | --- |
     | **4K HDR primary** | Full 4K tier stack with 1080p fallback | 4K TVs and monitors |
     | **1080p only** | Hard-kills 4K/1440p streams entirely | 1080p TVs, Fire Stick HD |
-    | **1080p-first + 4K** | Prefers 1080p, falls through to 4K | Bandwidth-limited setups |
+    | **1080p-first \+ 4K** | Prefers 1080p, falls through to 4K | Bandwidth-limited setups |
   </Step>
-
   <Step title="Audio">
     Sets `excludedAudioTags` and `preferredAudioChannels`. "Device-managed" means Step 2's device profile decides — usually the right choice.
 
     | Choice | Excluded | Channels | Best for |
-    |---|---|---|---|
+    | --- | --- | --- | --- |
     | **Full lossless** | Nothing | 7.1 · 5.1 · 2.0 | Home theater with receiver |
-    | **DD+ / Atmos** | Nothing | 5.1 · 2.0 | Soundbar / TV speakers |
+    | **DD\+ / Atmos** | Nothing | 5.1 · 2.0 | Soundbar / TV speakers |
     | **Device-managed** | Per device profile | Per device profile | Most users |
   </Step>
-
   <Step title="Content Type">
     Controls SeaDex integration and anime-specific filtering.
 
     | Choice | SeaDex | Bad Dual Audio ESE | Best for |
-    |---|---|---|---|
+    | --- | --- | --- | --- |
     | **Live-action only** | Off | Included | Movies & TV only |
-    | **Live-action + Anime** | On (all matches) | Included | Mixed library |
+    | **Live-action \+ Anime** | On (all matches) | Included | Mixed library |
     | **Anime-focused** | On (best only) | Off | Dedicated anime setup |
   </Step>
-
   <Step title="Review & Install">
-    See a summary of your choices, enter your API key, and optionally give the template a custom name. 
-    
+    See a summary of your choices, enter your API key, and optionally give the template a custom name.
+
     Click **Create & Install** to generate the template and deploy it to a supported AIOStreams instance in one step. You can also download the raw JSON file to import manually.
 
     The configurator will ask you to pick an AIOStreams instance (ElfHosted, ForthWeak, and others are available) and create your config automatically.
@@ -141,6 +132,21 @@ Quick Deploy presets generate a template with sensible defaults and install it o
 ## Additional Options
 
 The configurator includes several optional features accessible during setup:
+
+### Resolution First (v2.56)
+
+By default, cached streams always sort above uncached — a cached 1080p WEB-DL beats an uncached 4K REMUX because it plays instantly. **Resolution First** flips this for users who'd rather wait for the download: 4K always ranks above 1080p/720p regardless of cache status. Within the same resolution, cached still beats uncached.
+
+- Default: `cached → resolution → quality`
+- Resolution First: `resolution → quality → cached`
+
+Toggle this in the wizard's **Video Preferences** step.
+
+### Foreign Language Kill (v2.56)
+
+Blocks foreign-language streams from movies and TV results. On by default — matches what the fleet templates have always done. Adapts to your **Language Preferences**: if you've added Spanish or French, those languages pass through. Library, SeaDex, and anime content are always exempt.
+
+Disable this in the wizard's **Language Preferences** if you want unfiltered multilingual results.
 
 ### Multi-Service Support
 
@@ -193,8 +199,7 @@ Every generated template contains the full production infrastructure from Core B
     - **1080p:** Elite REMUX pin → S/A/B/C 1080p tiers → 720p fallback → codec booster
     - **Ultrawide:** 1080p tiers → 1440p → 4K REMUX → 4K WEB-DL HDR → any 4K → 720p → boosters
 
-    Release group pins (top): FraMeSToR · DON · FLUX · HIFI · playBD · BMF · QxR · EPSiLON  
-    Release group pins (bottom): YIFY · RARBG · EVO · YTS · PSA · MeGusta · Tigole
+    Release group pins (top): FraMeSToR · DON · FLUX · HIFI · playBD · BMF · QxR · EPSiLON<br />Release group pins (bottom): YIFY · RARBG · EVO · YTS · PSA · MeGusta · Tigole
   </Accordion>
 
   <Accordion title="Regex & sorting">

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -44,7 +44,7 @@ description: "Quick answers to the most common Core Builds questions."
   </Accordion>
 
   <Accordion title="Only a handful of streams for older TV shows">
-    Normal for older content. Classic TV episodes under 512 MB and older encodes often have unrecognised audio or encode tags that trip size and quality filters. Templates from v2.4.6 onwards lower size minimums and add `Unknown` fallbacks. For niche or foreign content with low seeders, consider a [Speed 4K+](/master-guide) or [Hybrid](/master-guide) template that adds Usenet coverage.
+    Normal for older content. Classic TV episodes under 512 MB and older encodes often have unrecognised audio or encode tags that trip size and quality filters. Templates from v2.4.6 onwards lower size minimums and add `Unknown` fallbacks. For niche or foreign content with low seeders, consider a [Speed 4K\+](/master-guide) or [Hybrid](/master-guide) template that adds Usenet coverage.
   </Accordion>
 
   <Accordion title="Very few results on any content — even popular films">
@@ -53,6 +53,12 @@ description: "Quick answers to the most common Core Builds questions."
 
   <Accordion title="MediaFusion and HdHub appeared in my add-ons after re-importing">
     This is expected from v2.9.4 onwards. Both scrapers are now enabled out of the box — MediaFusion for regional and international content that TorBox's native scraper misses, and HdHub for additional TorBox-cached P2P sources. If you don't want either of them, go to **Addons**, find the scraper, and toggle it off. Your stream results for popular English content will be unchanged; the main impact is on non-English and niche titles where TorBox's native search returns nothing.
+  </Accordion>
+
+  <Accordion title="I'm seeing foreign language streams in my results">
+    The Foreign Language Kill ESE blocks non-English streams from movies and TV results. Fleet templates have always included it, but configurator-generated templates were missing it before v2.56.
+
+    **Fix:** If you use the configurator, regenerate your template with v2.56\+ — the Foreign Language Kill is now on by default. If you want certain non-English languages (e.g. Spanish, French), add them in the configurator's Language Preferences — they'll pass through while other languages are still blocked. Library, SeaDex, and anime content are always exempt regardless of this setting.
   </Accordion>
 
   <Accordion title="NZBGeek returns nothing (Hybrid template only)">

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -6,11 +6,14 @@ description: "Planned work, active development, and recently completed milestone
 ## Recently Completed
 
 | Version | Item |
-|---|---|
+| --- | --- |
+| v2.56 | Configurator — Resolution First toggle (4K always ranks above 1080p/720p regardless of cache status) |
+| v2.56 | Configurator — Foreign Language Kill ESE (blocks non-English streams from movies/TV; adapts to Language Preferences; Library/SeaDex/anime exempt) |
+| v2.55 | Configurator — UX overhaul (staggered splash animations, smart service pre-selection, contextual Quick Deploy presets, keyboard navigation, step dot tooltips, auto-saved indicator, prefers-reduced-motion support) |
 | v3.0.0 | Bad Dual Audio Groups ESE — 27 mislabelled dual-audio release groups excluded across all 28 stable non-Anime templates; graduated from Labs |
-| v3.0.0 | Indexer Diversity ESE — perGroup(indexer) caps 2 results per scraper when pool > 20; all 28 stable non-Anime templates; graduated from Labs |
+| v3.0.0 | Indexer Diversity ESE — perGroup(indexer) caps 2 results per scraper when pool \> 20; all 28 stable non-Anime templates; graduated from Labs |
 | v3.0.0 | Score IQR Guard ESE — Tukey lower-fence filter on seScore distribution; 4K Apex (v0.5.0), 4K Apex TorBox (v2.10.0), 4K Hybrid (v2.10.0), 4K Essential (v2.10.0), 4K AllDebrid (v0.2.0); graduated from Labs |
-| v3.0.0 | Core Builds Base Config draft — parent config with all scraper presets + universal ESE/ISE layer for AIOStreams parent/child architecture (activation deferred until hosted instance available) |
+| v3.0.0 | Core Builds Base Config draft — parent config with all scraper presets \+ universal ESE/ISE layer for AIOStreams parent/child architecture (activation deferred until hosted instance available) |
 | v3.0.0 | Flash plain-string ESE fix — converted bare-string ESE to standard dict format |
 | v2.9.9 | Anime BD T1 regex drift fix — Vidhin05 removed ZR/NAN0; pattern updated across all 34 non-Anime templates; resolves "1 regex not allowed" on elfhosted |
 | v2.9.9 | NZBGeek preset disabled by default — Hybrid, Hybrid Lite, 4K Hybrid — prevents IP-mismatch bans on shared hosting (ElfHosted, fortheweak.cloud) |
@@ -18,23 +21,23 @@ description: "Planned work, active development, and recently completed milestone
 | v2.9.8 | REPACK/PROPER Passthrough ISE — pins REPACK/PROPER releases ahead of limit/excluded filters; all templates via shared ISE file |
 | v2.9.8 | Codec Efficiency Booster PSE — HEVC/AV1 over AVC; AllDebrid and Samsung TV templates |
 | v2.9.8 | Audio Pinnacle PSE — Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 priority; AllDebrid and Samsung TV templates |
-| v2.9.8 | HDR / DV Priority PSE — DV/HDR10+/HDR10 over SDR within 4K; AllDebrid and Samsung TV templates |
+| v2.9.8 | HDR / DV Priority PSE — DV/HDR10\+/HDR10 over SDR within 4K; AllDebrid and Samsung TV templates |
 | v2.9.8 | Apple TV 4K Nightly — SeaDex passthrough ISE added (was missing despite SeaDex preset being enabled) |
 | v2.9.8 | Speed TorBox templates — broken dynamic group instanceId references fixed; disabled MediaFusion fallback added |
 | v2.9.7 | Meteor timeout 10000ms → 6000ms — 28 templates — fixes Nuvio "addon request timed out" on niche/new series |
-| v2.9.7 | 4K Apex v0.4.17 — time-based dynamicAddonFetching exit (5s hard cap + ≥5 cached 4K) |
+| v2.9.7 | 4K Apex v0.4.17 — time-based dynamicAddonFetching exit (5s hard cap \+ ≥5 cached 4K) |
 | v2.9.6 | Hybrid TorBox-priority PSEs — Hybrid (IQR twins) and Hybrid Lite (CB-style twins) complete the pattern from 4K Hybrid |
-| v2.9.5 | TorrentsDB added to 13 non-Lite templates — 21+ provider coverage (YTS, 1337x, Nyaa, AnimeTosho, regional), TorBox native, no API key, flood guard ≤1 |
+| v2.9.5 | TorrentsDB added to 13 non-Lite templates — 21\+ provider coverage (YTS, 1337x, Nyaa, AnimeTosho, regional), TorBox native, no API key, flood guard ≤1 |
 | v2.9.4 | Stream 720p fallback PSEs — surfaces 720p WEB-DL/WEBRip when no 1080p source exists |
 | v2.9.4 | MediaFusion and HdHub enabled by default on all non-Speed, non-Flash TorBox templates |
 | v2.9.4 | Cached-only TorBox Apex variant fixed — StremThru Torz now on by default |
 | v2.9.4 | Nightly and Labs templates — all 6 import cleanly (regex blockers, missing metadata, audio/resolution fixes) |
 | v2.9.3 | 4K WEB-DL exemption — prevents new theatrical releases from being suppressed when no Blu-ray exists |
 | v2.9.2 | Knaben and Torrent Galaxy demoted to backup scrapers (≤1 result each) |
-| v2.9.2 | OpenSubtitles V3+ removed — AIOSubtitle covers the same sources with no redundant network call |
+| v2.9.2 | OpenSubtitles V3\+ removed — AIOSubtitle covers the same sources with no redundant network call |
 | v2.9.1 | Per-Addon Flood Guard ESE — AllDebrid and Samsung TV templates |
-| v2.9.0 | Regex compatibility — fortheweak whitelist sync (11 ranked + 3 excluded removed from all 33 non-Anime templates) |
-| v2.9.0 | Debrid timeout raised 3000ms → 5000ms on 35 templates — fixes playback errors on Nuvio and AIOStreams v2.24.0+ |
+| v2.9.0 | Regex compatibility — fortheweak whitelist sync (11 ranked \+ 3 excluded removed from all 33 non-Anime templates) |
+| v2.9.0 | Debrid timeout raised 3000ms → 5000ms on 35 templates — fixes playback errors on Nuvio and AIOStreams v2.24.0\+ |
 | v2.9.0 | AllDebrid setup guide |
 | v2.9.0 | Docs expansion — formatters (3→16), device profiles, troubleshooting rewrite, Choosing a Host section |
 | v2.8.4 | Boost Cached Usenet PSE restored — all 27 TorBox templates |
@@ -48,8 +51,8 @@ description: "Planned work, active development, and recently completed milestone
 | v2.8.0 | pow() exponential age-decay replaces hard 60-day cliff |
 | v2.8.0 | Core Builds Expression Layer — 24 ESEs, 3 ISEs, IQR PSEs deployed |
 | v2.7.5 | Addon timeout tuning — fixes silent Usenet result drops |
-| v2.7.5 | Dedup tiebreakers — torrent_seeders + usenet_age |
-| v2.7.0 | Core Nexus 4K Hybrid — TorBox + NZBGeek Usenet |
+| v2.7.5 | Dedup tiebreakers — torrent\_seeders \+ usenet\_age |
+| v2.7.0 | Core Nexus 4K Hybrid — TorBox \+ NZBGeek Usenet |
 | v2.7.0 | IQR Tukey fence PSEs |
 
 ---
@@ -57,8 +60,8 @@ description: "Planned work, active development, and recently completed milestone
 ## In Progress
 
 | Item | Notes |
-|---|---|
-| `hasSeaDex` + `seMatched()` anime gating | Adaptive anime quality gate — if SeaDex data exists, require SeaDex-matched stream in top tier; else fall through to standard sort |
+| --- | --- |
+| `hasSeaDex` \+ `seMatched()` anime gating | Adaptive anime quality gate — if SeaDex data exists, require SeaDex-matched stream in top tier; else fall through to standard sort |
 
 ---
 
@@ -66,7 +69,7 @@ description: "Planned work, active development, and recently completed milestone
 
 ### Parent/Child Config Architecture
 
-The Core Builds Base Config (`Templates/Core-Builds-Base-Config.json`) is drafted and ready — it contains all scraper presets, the universal ESE layer, ISEs, sort criteria, formatter, and synced URLs. Activation is deferred until a permanent hosted AIOStreams instance is available to hold the parent config UUID. Once live, each child template only needs its service preset + PSEs + template-specific ESEs. One timeout change in the parent propagates to all templates instantly.
+The Core Builds Base Config (`Templates/Core-Builds-Base-Config.json`) is drafted and ready — it contains all scraper presets, the universal ESE layer, ISEs, sort criteria, formatter, and synced URLs. Activation is deferred until a permanent hosted AIOStreams instance is available to hold the parent config UUID. Once live, each child template only needs its service preset \+ PSEs \+ template-specific ESEs. One timeout change in the parent propagates to all templates instantly.
 
 ### Expression Layer
 
@@ -74,15 +77,19 @@ The Core Builds Base Config (`Templates/Core-Builds-Base-Config.json`) is drafte
   <Accordion title="Usenet Propagation Guard ESE">
     Holds back NZBs younger than 2 hours when propagated alternatives exist. Eliminates corrupt early-propagation grabs. All Usenet-enabled templates.
   </Accordion>
+
   <Accordion title="Codec Efficiency Booster PSE — broader rollout">
     Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Stream, Essential, Anime.
   </Accordion>
+
   <Accordion title="Audio Pinnacle PSE — broader rollout">
     Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Apex, 4K Hybrid, 4K Essential.
   </Accordion>
+
   <Accordion title="HDR / DV Priority PSE — broader rollout">
     Shipped on AllDebrid and Samsung TV in v2.9.8. Planned expansion: Apex, 4K Essential, 4K Hybrid, Flash 4K.
   </Accordion>
+
   <Accordion title="pin() top result">
     Pin the #1 PSE-matched stream to position 1 regardless of sort order.
   </Accordion>
@@ -108,7 +115,7 @@ The Core Builds Base Config (`Templates/Core-Builds-Base-Config.json`) is drafte
 ## Ideas / Under Consideration
 
 | Idea | Status |
-|---|---|
+| --- | --- |
 | New unified template suite | Under consideration — tighter 6-template lineup built around the Core Builds expression layer |
 | Debrid-Link template | Under research — supported in AIOStreams |
 | Premiumize template | Under research — natively supported |

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -13,9 +13,11 @@ Before troubleshooting, confirm what you're running.
 
     Alternatively, check the template JSON directly: open the raw URL in a browser and look for `"version"` inside the `"metadata"` object.
   </Accordion>
+
   <Accordion title="How do I check my AIOStreams version?">
-    In AIOStreams → **About** — the AIOStreams version is shown in the footer. Core Builds templates require **v2.30+**.
+    In AIOStreams → **About** — the AIOStreams version is shown in the footer. Core Builds templates require **v2.30\+**.
   </Accordion>
+
   <Accordion title="How do I update a template?">
     Re-import the same URL — AIOStreams merges the new version over your existing config and preserves your API keys. Check for an in-app update notification first (AIOStreams will prompt you automatically when a new version is available).
   </Accordion>
@@ -31,7 +33,7 @@ Before troubleshooting, confirm what you're running.
 
     **Fix: re-import the latest template.** As of v2.9.0, all pattern strings are synced to the host allowlists. The most common cause is importing an older template that predates the v2.8.9 / v2.9.0 sync.
 
-    If you're still seeing this after re-importing v2.9.0+, paste the exact error text in the community thread — it may indicate the allowlist has been updated again.
+    If you're still seeing this after re-importing v2.9.0\+, paste the exact error text in the community thread — it may indicate the allowlist has been updated again.
   </Accordion>
 
   <Accordion title='"Forbidden URL" error on import'>
@@ -64,15 +66,14 @@ Before troubleshooting, confirm what you're running.
 <AccordionGroup>
   <Accordion title="No results / very few results">
     **Check first:**
+
     - Is the title in TorBox's cache? Search at [torbox.app](https://torbox.app)
     - Are your API keys entered? TorBox key in Services, TMDB in Settings
     - Are your scrapers enabled? Open AIOStreams → Add-ons — from v2.9.4, MediaFusion and HdHub are on by default; on older imports they may be toggled off
 
-    **If you're on a Flash or Speed template:**
-    These templates exit as soon as they find cached results. If TorBox doesn't have the title cached, Flash returns nothing. Switch to Core Nexus Essential for full coverage with uncached fallback.
+    **If you're on a Flash or Speed template:** These templates exit as soon as they find cached results. If TorBox doesn't have the title cached, Flash returns nothing. Switch to Core Nexus Essential for full coverage with uncached fallback.
 
-    **Try the Lite variant:**
-    The standard template runs quality-gate ESEs (low bitrate, low seeders, bad encodes). Lite removes those gates — hard kills stay but quality filters are gone. If Lite returns results, one of the quality gates is filtering your content.
+    **Try the Lite variant:** The standard template runs quality-gate ESEs (low bitrate, low seeders, bad encodes). Lite removes those gates — hard kills stay but quality filters are gone. If Lite returns results, one of the quality gates is filtering your content.
   </Accordion>
 
   <Accordion title="Stream returns only 1080p — no 720p results">
@@ -91,13 +92,24 @@ Before troubleshooting, confirm what you're running.
     Fixed in v2.8.3. `seadexBestOnly: true` was dropping all non-SeaDex streams on several non-Anime templates. Re-import to pick up the fix.
   </Accordion>
 
+  <Accordion title="Foreign language streams appearing in results">
+    If you're seeing Spanish, Portuguese, or other non-English streams mixed into your movie and TV results, the Foreign Language Kill ESE is missing or disabled.
+
+    **If you use a fleet template:** Re-import the latest version — the Foreign Language Kill has always been included in fleet templates.
+
+    **If you use the configurator:** Update to configurator v2.56\+. The Foreign Language Kill is now on by default. If you've already generated a template, regenerate it or manually add the ESE in AIOStreams.
+
+    **If you want some non-English languages:** Go to the configurator's Language Preferences and add the languages you want (e.g. Spanish, French). The Foreign Language Kill adapts — added languages pass through while others are still blocked. Library, SeaDex, and anime content are always exempt.
+  </Accordion>
+
   <Accordion title="Usenet results slow or not appearing">
     Fixed in v2.7.5. The newznab timeout was 3000ms — too short for TorBox Usenet. Updated to 10,000ms. Additionally `searchMode: auto` and `checkOwned: true` are now set. Re-import your template.
   </Accordion>
 
   <Accordion title="Results appear but nothing plays">
     Most common causes:
-    - **Debrid link timeout (Nuvio / AIOStreams v2.24.0+)** — If you see a visible Playback Error, the debrid link resolver timed out. Re-import the v2.9.0+ template — the `stremthruTorz`/`stremthruStore` timeout was raised to 5000ms to cover congested periods. If errors persist, check [TorBox's status page](https://torbox.app/status) for outages, or try a different stream from the list.
+
+    - **Debrid link timeout (Nuvio / AIOStreams v2.24.0\+)** — If you see a visible Playback Error, the debrid link resolver timed out. Re-import the v2.9.0\+ template — the `stremthruTorz`/`stremthruStore` timeout was raised to 5000ms to cover congested periods. If errors persist, check [TorBox's status page](https://torbox.app/status) for outages, or try a different stream from the list.
     - **Codec not supported on your device** — check the stream's codec in the formatter display. If it's AV1 on a device without hardware AV1 decode (Fire Stick 4K, older Samsung Tizen), the stream will buffer or fail. Switch to a device-specific template (Samsung TV, Fire Stick) which hard-exclude unsupported codecs.
     - **DV-only stream on a non-DV device** — the Samsung templates have a DV-Only Kill ESE enabled by default. If you're on a generic template, enable the DV-Only Kill ESE manually in AIOStreams.
     - **Bitrate too high** — very high-bitrate REMUX streams can stall on slower connections or budget hardware. Try the B-tier or lower result in the list.
@@ -117,12 +129,13 @@ Before troubleshooting, confirm what you're running.
 
   <Accordion title="Samsung TV — Dolby Vision streams still appearing">
     The DV-Only Kill ESE is enabled by default on Samsung templates. If you're still seeing DV streams:
+
     - Re-import the latest Samsung TV template
     - Check you haven't disabled the `No DV-Only` ESE in the AIOStreams expression editor
   </Accordion>
 
   <Accordion title="Fire Stick — playback stuttering or buffering">
-    Use the **Stream (Fire Stick)** template. It hard-excludes AV1 (no hardware decoder on most Fire Stick models), HDR10+, Dolby Vision, and lossless audio. If you're on a generic Stream template, these formats may be served and cause transcoding or failure.
+    Use the **Stream (Fire Stick)** template. It hard-excludes AV1 (no hardware decoder on most Fire Stick models), HDR10\+, Dolby Vision, and lossless audio. If you're on a generic Stream template, these formats may be served and cause transcoding or failure.
   </Accordion>
 
   <Accordion title="Apple TV — DV not playing in Infuse">
@@ -142,7 +155,7 @@ Before troubleshooting, confirm what you're running.
   </Accordion>
 
   <Accordion title="Which public host should I use — elfhosted or fortheweak?">
-    Both work with Core Builds v2.9.0+. The main difference is the regex whitelist — fortheweak is stricter. As of v2.9.0, all templates are verified against both allowlists.
+    Both work with Core Builds v2.9.0\+. The main difference is the regex whitelist — fortheweak is stricter. As of v2.9.0, all templates are verified against both allowlists.
 
     If you're self-hosting, no whitelist applies — all templates work as-is.
   </Accordion>

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -8,22 +8,34 @@ For full technical details, see the [Changelog](/changelog).
 
 ---
 
+## Configurator v2.56 — July 2026
+
+**Resolution First toggle.** Users reported 720p/1080p streams ranking above 4K — this is by design (cached streams always sort above uncached). The new **Resolution First** toggle in the configurator's Video Preferences changes this: when enabled, 4K always ranks above 1080p/720p regardless of cache status. Within the same resolution, cached still beats uncached.
+
+- Default sort: `cached → resolution → quality`
+- Resolution First: `resolution → quality → cached`
+
+**Foreign Language Kill.** The fleet templates have always had a hard ESE blocking foreign-language streams from movies and TV results. The configurator wasn't generating it — so configurator users were getting Spanish, Portuguese, and other non-English streams in their results. Now on by default. Adapts to your Language Preferences — if you've added Spanish or French, those pass through too. Library, SeaDex, and anime content are always exempt.
+
+**Configurator v2.55 UX overhaul.** Staggered splash animations, smart service pre-selection (remembers your last service), contextual Quick Deploy presets (debrid shows 4K/1080p, free shows Free Streaming/P2P), keyboard navigation throughout splash (arrow keys, Enter/Space), step dot tooltips showing current selection on hover, auto-saved indicator, and `prefers-reduced-motion` support.
+
+**How to update:** Generate a fresh template from the [configurator](/configurator), or use "Update Existing Template" to see the diff and cherry-pick changes. The Foreign Language Kill and Resolution First toggles are in the wizard's advanced preferences.
+
+---
+
 ## v3.2.5 — July 2026
 
-**ESE v2.0 — fleet-wide rollout.**
-Three foundational ESE improvements have been deployed across all 42 active templates:
+**ESE v2.0 — fleet-wide rollout.** Three foundational ESE improvements have been deployed across all 42 active templates:
 
 - **Info & Other Unwanted** replaces Bad NZBs — now catches info-type streams, `-sample` keyword Usenet files, and streams with prohibited markers, in addition to everything Bad NZBs already handled.
-- **G's Low Bitrate count() fix** — the bitrate floor now activates at 10+ cached streams (was incorrectly thresholding against the wrong pool).
+- **G's Low Bitrate count() fix** — the bitrate floor now activates at 10\+ cached streams (was incorrectly thresholding against the wrong pool).
 - **Standard ESE v2.0 version marker** — a no-op tag for tracking which ESE generation a template runs.
 
 Re-import from the [Template Directory](/template-directory) to pick up these changes.
 
-**Configurator overhauled.**
-The Template Configurator has been completely redesigned with a new splash screen, Quick Deploy presets (one-tap installs for common setups), and a guided 6-step wizard. Key validation has been removed — the old "API key failed validation" dialog was unreliable on mobile and behind CORS-restricted services. The configurator now accepts your key directly and lets AIOStreams validate it on first use. See [Configurator](/configurator) for the full walkthrough.
+**Configurator overhauled.** The Template Configurator has been completely redesigned with a new splash screen, Quick Deploy presets (one-tap installs for common setups), and a guided 6-step wizard. Key validation has been removed — the old "API key failed validation" dialog was unreliable on mobile and behind CORS-restricted services. The configurator now accepts your key directly and lets AIOStreams validate it on first use. See [Configurator](/configurator) for the full walkthrough.
 
-**ESE v2.0 experimental features in LABS.**
-Six LABS templates now carry the full ESE v2.0 experimental stack — features being validated before fleet-wide promotion:
+**ESE v2.0 experimental features in LABS.** Six LABS templates now carry the full ESE v2.0 experimental stack — features being validated before fleet-wide promotion:
 
 - **Protect Library** — library-aware CAM/TS kill. Library items survive even when tagged as low quality (replaces Hard CAM Kill).
 - **SeaDex Duplicates** — `perGroup()` dedup keeps 1 per release group for best and non-best SeaDex tiers (replaces Extra SeaDex).
@@ -36,131 +48,105 @@ See [Nightly and Labs](/nightly-and-labs) for import links.
 
 ## v3.0.0 — June 2026
 
-**Bad dual-audio groups are now excluded from every template.**
-27 release groups that falsely label streams as dual-audio (alfaHD, BAT, BiOMA, BlackBit, and 23 others) are now excluded across all 28 stable non-Anime templates. These groups produce streams where the English track is either absent or a low-quality dub — the label is inaccurate. You won't see those results any more without any manual configuration.
+**Bad dual-audio groups are now excluded from every template.** 27 release groups that falsely label streams as dual-audio (alfaHD, BAT, BiOMA, BlackBit, and 23 others) are now excluded across all 28 stable non-Anime templates. These groups produce streams where the English track is either absent or a low-quality dub — the label is inaccurate. You won't see those results any more without any manual configuration.
 
-**One scraper can no longer flood your results.**
-A new Indexer Diversity rule caps any single scraper at 2 results when your total stream pool exceeds 20. Previously, if Meteor or MediaFusion returned 15 results for a popular title, they could crowd out higher-quality matches from other scrapers that returned fewer. Now every active scraper gets fair representation in the list. Applied to all 28 stable non-Anime templates.
+**One scraper can no longer flood your results.** A new Indexer Diversity rule caps any single scraper at 2 results when your total stream pool exceeds 20. Previously, if Meteor or MediaFusion returned 15 results for a popular title, they could crowd out higher-quality matches from other scrapers that returned fewer. Now every active scraper gets fair representation in the list. Applied to all 28 stable non-Anime templates.
 
-**Score IQR Guard — statistical outlier filtering on 4K full templates.**
-The five 4K templates with IQR-adaptive quality tiers (4K Apex, 4K Apex TorBox, 4K Hybrid, 4K Essential, 4K AllDebrid) now automatically filter streams whose quality score falls below the statistical lower fence of the pool. In plain terms: if your stream list has a clear quality cluster and a handful of results that scored much worse, those low outliers are now removed rather than appearing at the bottom. This has been in Labs for several releases — it's now stable.
+**Score IQR Guard — statistical outlier filtering on 4K full templates.** The five 4K templates with IQR-adaptive quality tiers (4K Apex, 4K Apex TorBox, 4K Hybrid, 4K Essential, 4K AllDebrid) now automatically filter streams whose quality score falls below the statistical lower fence of the pool. In plain terms: if your stream list has a clear quality cluster and a handful of results that scored much worse, those low outliers are now removed rather than appearing at the bottom. This has been in Labs for several releases — it's now stable.
 
 ---
 
 ## v2.9.9 — June 2026
 
-**Anime BD T1 regex updated — resolves the "1 regex not allowed" import error.**
-Vidhin05 (the source elfhosted uses to validate allowed regex patterns) silently updated their file, removing two release groups — ZR and NAN0 — from the Anime BD T1 pattern. If you saw a "1 out of N regexes not allowed" error when importing a template, this was the cause. All templates now match Vidhin05's current version of the pattern. Re-import from the [Template Directory](/template-directory) to clear the error.
+**Anime BD T1 regex updated — resolves the "1 regex not allowed" import error.** Vidhin05 (the source elfhosted uses to validate allowed regex patterns) silently updated their file, removing two release groups — ZR and NAN0 — from the Anime BD T1 pattern. If you saw a "1 out of N regexes not allowed" error when importing a template, this was the cause. All templates now match Vidhin05's current version of the pattern. Re-import from the [Template Directory](/template-directory) to clear the error.
 
-**NZBGeek preset now disabled by default on Hybrid templates.**
-NZBGeek has been issuing account bans to users running AIOStreams on shared hosting (ElfHosted, fortheweak.cloud). The root cause is an IP mismatch: on these platforms, search queries and NZB grabs can come from different IPs, which NZBGeek flags as multi-account sharing. The NZBGeek preset is still included in all Hybrid templates — it is just switched off out of the box. Re-enabling it on ElfHosted requires routing requests through the [Zyclops proxy](https://zyclops.elfhosted.com) so both operations share a single IP. On a private or self-hosted instance where all requests originate from one IP, you can enable the preset directly. See [Importing a Template](/importing) for the full setup steps.
+**NZBGeek preset now disabled by default on Hybrid templates.** NZBGeek has been issuing account bans to users running AIOStreams on shared hosting (ElfHosted, fortheweak.cloud). The root cause is an IP mismatch: on these platforms, search queries and NZB grabs can come from different IPs, which NZBGeek flags as multi-account sharing. The NZBGeek preset is still included in all Hybrid templates — it is just switched off out of the box. Re-enabling it on ElfHosted requires routing requests through the [Zyclops proxy](https://zyclops.elfhosted.com) so both operations share a single IP. On a private or self-hosted instance where all requests originate from one IP, you can enable the preset directly. See [Importing a Template](/importing) for the full setup steps.
 
 ---
 
 ## v2.9.8 — June 2026
 
-**REPACK/PROPER releases now always surface, even when they'd normally be filtered out.**
-When a release group issues a REPACK or PROPER — a corrected re-encode replacing a broken or mislabelled original — the previous filtering logic could suppress it if it fell outside the quality window or hit a limit cap. It now bypasses those filters and always reaches your stream list. This is especially relevant for anime fansub groups, which frequently issue REPACKs for audio sync or subtitle fixes. Applied to all templates via the shared ISE file.
+**REPACK/PROPER releases now always surface, even when they'd normally be filtered out.** When a release group issues a REPACK or PROPER — a corrected re-encode replacing a broken or mislabelled original — the previous filtering logic could suppress it if it fell outside the quality window or hit a limit cap. It now bypasses those filters and always reaches your stream list. This is especially relevant for anime fansub groups, which frequently issue REPACKs for audio sync or subtitle fixes. Applied to all templates via the shared ISE file.
 
-**Booster PSEs added to AllDebrid and Samsung TV templates.**
-Three new priority expressions are now active on all AllDebrid and Samsung TV templates: Codec Efficiency Booster (surfaces HEVC/AV1 ahead of AVC at equivalent quality), Audio Pinnacle (promotes Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 within each quality tier), and HDR/DV Priority (surfaces Dolby Vision and HDR10+ ahead of HDR10 and SDR within 4K results). These were previously Apex and 4K Hybrid only — the AllDebrid and Samsung families now have the same priority stack.
+**Booster PSEs added to AllDebrid and Samsung TV templates.** Three new priority expressions are now active on all AllDebrid and Samsung TV templates: Codec Efficiency Booster (surfaces HEVC/AV1 ahead of AVC at equivalent quality), Audio Pinnacle (promotes Atmos/TrueHD → DTS-HD MA/DTS-X → EAC3 within each quality tier), and HDR/DV Priority (surfaces Dolby Vision and HDR10\+ ahead of HDR10 and SDR within 4K results). These were previously Apex and 4K Hybrid only — the AllDebrid and Samsung families now have the same priority stack.
 
-**Apple TV 4K Nightly — SeaDex passthrough fixed.**
-The Apple TV 4K Nightly template had SeaDex enabled in its preset list and its config, but was missing the SeaDex passthrough ISE that tells AIOStreams to treat SeaDex-matched streams as untouchable. In practice this meant SeaDex results were subject to the same limit and exclusion filters as everything else. Fixed — SeaDex streams now bypass those filters on Apple TV 4K exactly as they do on every other template.
+**Apple TV 4K Nightly — SeaDex passthrough fixed.** The Apple TV 4K Nightly template had SeaDex enabled in its preset list and its config, but was missing the SeaDex passthrough ISE that tells AIOStreams to treat SeaDex-matched streams as untouchable. In practice this meant SeaDex results were subject to the same limit and exclusion filters as everything else. Fixed — SeaDex streams now bypass those filters on Apple TV 4K exactly as they do on every other template.
 
-**Speed templates — dynamic group references corrected.**
-All four Speed TorBox templates (Speed 4K, Speed 4K Lite, Speed, Speed Lite) had a broken reference in their dynamic addon grouping: the group was pointing at instanceIds `nx-fix-01` and `nx-fix-02` which don't exist in any of the templates. AIOStreams' group validation was failing silently on import. Fixed to point at the correct Zilean and StremThru Torz instanceIds. A disabled MediaFusion preset has also been added as a fallback so fresh imports don't fail validation before TorBox credentials are configured.
+**Speed templates — dynamic group references corrected.** All four Speed TorBox templates (Speed 4K, Speed 4K Lite, Speed, Speed Lite) had a broken reference in their dynamic addon grouping: the group was pointing at instanceIds `nx-fix-01` and `nx-fix-02` which don't exist in any of the templates. AIOStreams' group validation was failing silently on import. Fixed to point at the correct Zilean and StremThru Torz instanceIds. A disabled MediaFusion preset has also been added as a fallback so fresh imports don't fail validation before TorBox credentials are configured.
 
 ---
 
 ## v2.9.7 — June 2026
 
-**Meteor scraper timeout lowered — fixes "addon request timed out" on Nuvio and similar players.**
-Meteor was set to a 10-second timeout on all templates. For new or niche series, the template's secondary scraper group (Meteor + Comet RD) almost always fires because the faster primary scrapers don't find enough cached results. With Meteor waiting up to 10 seconds, the total addon request time was regularly exceeding Nuvio's internal timeout — showing "the addon request timed out" even when streams actually exist. Lowered to 6 seconds across all 28 affected templates. Samsung TV templates were already at 3 seconds and are unchanged. Re-import your template to pick up this fix.
+**Meteor scraper timeout lowered — fixes "addon request timed out" on Nuvio and similar players.** Meteor was set to a 10-second timeout on all templates. For new or niche series, the template's secondary scraper group (Meteor \+ Comet RD) almost always fires because the faster primary scrapers don't find enough cached results. With Meteor waiting up to 10 seconds, the total addon request time was regularly exceeding Nuvio's internal timeout — showing "the addon request timed out" even when streams actually exist. Lowered to 6 seconds across all 28 affected templates. Samsung TV templates were already at 3 seconds and are unchanged. Re-import your template to pick up this fix.
 
-**4K Apex now has a 5-second hard cap on scraper wait time.**
-4K Apex v0.4.16 adds a time-based exit to its dynamic addon fetching: if 5 seconds pass and fewer than 5 cached 4K streams have been found, AIOStreams stops querying and shows what's available rather than waiting for slow scrapers to time out. Previously the only exit condition required 10+ cached 4K streams — a threshold that almost never fired for new or niche content. This change is live on 4K Apex only while it's being validated; it will extend to other full templates once confirmed.
+**4K Apex now has a 5-second hard cap on scraper wait time.** 4K Apex v0.4.16 adds a time-based exit to its dynamic addon fetching: if 5 seconds pass and fewer than 5 cached 4K streams have been found, AIOStreams stops querying and shows what's available rather than waiting for slow scrapers to time out. Previously the only exit condition required 10\+ cached 4K streams — a threshold that almost never fired for new or niche content. This change is live on 4K Apex only while it's being validated; it will extend to other full templates once confirmed.
 
 ---
 
 ## v2.9.6 — June 2026
 
-**Hybrid templates now prioritise TorBox streams first.**
-If you use the Hybrid or Hybrid Lite template (TorBox + Real-Debrid), your TorBox-cached streams will now appear before equivalent Real-Debrid results at the top two quality tiers. The logic has been in 4K Hybrid since v2.9.4 — this release brings it to the 1080p Hybrid variants. Hybrid uses the same IQR-adaptive prioritisation as 4K Hybrid; Hybrid Lite uses a simpler quality-tier version consistent with its lighter design. The change only affects ordering within the same quality tier — if no TorBox stream matches, the expression returns empty and falls through to the all-service result as before. Re-import from the [Template Directory](/template-directory) to pick up this update.
+**Hybrid templates now prioritise TorBox streams first.** If you use the Hybrid or Hybrid Lite template (TorBox \+ Real-Debrid), your TorBox-cached streams will now appear before equivalent Real-Debrid results at the top two quality tiers. The logic has been in 4K Hybrid since v2.9.4 — this release brings it to the 1080p Hybrid variants. Hybrid uses the same IQR-adaptive prioritisation as 4K Hybrid; Hybrid Lite uses a simpler quality-tier version consistent with its lighter design. The change only affects ordering within the same quality tier — if no TorBox stream matches, the expression returns empty and falls through to the all-service result as before. Re-import from the [Template Directory](/template-directory) to pick up this update.
 
 ---
 
 ## v2.9.5 — June 2026
 
-**More scraper coverage — TorrentsDB added to all full templates.**
-TorrentsDB is a Torrentio fork that indexes 21+ torrent providers including YTS, 1337x, Nyaa, AnimeTosho, and a handful of regional trackers that the existing scrapers don't hit. It works natively with TorBox — no API key or account needed. It's configured as a backup scraper (capped at one result like Knaben and Torrent Galaxy), so it won't slow down queries on popular titles that Meteor, MediaFusion, and HdHub already cover well. Where it makes a difference is niche content, older releases, and anime — titles where TorBox's native scraper and the faster general scrapers come up short. Added to all 13 full-feature templates; Lite, Flash, and Speed templates unchanged.
+**More scraper coverage — TorrentsDB added to all full templates.** TorrentsDB is a Torrentio fork that indexes 21\+ torrent providers including YTS, 1337x, Nyaa, AnimeTosho, and a handful of regional trackers that the existing scrapers don't hit. It works natively with TorBox — no API key or account needed. It's configured as a backup scraper (capped at one result like Knaben and Torrent Galaxy), so it won't slow down queries on popular titles that Meteor, MediaFusion, and HdHub already cover well. Where it makes a difference is niche content, older releases, and anime — titles where TorBox's native scraper and the faster general scrapers come up short. Added to all 13 full-feature templates; Lite, Flash, and Speed templates unchanged.
 
 ---
 
 ## v2.9.4 — June 2026
 
-**Stream template now shows 720p when no 1080p source exists.**
-The base Stream template was missing the 720p fallback that the Lite and Fire Stick variants already had. If you searched for an older or niche title where only 720p streams are indexed, Stream returned zero results instead of showing what was available. It now surfaces 720p WEB-DL and WEBRip as a fallback tier below the four 1080p priority tiers — so for any title where 1080p exists, your list is unchanged; for titles with only 720p sources, you now get results. Re-import from the [Template Directory](/template-directory) to pick up this fix.
+**Stream template now shows 720p when no 1080p source exists.** The base Stream template was missing the 720p fallback that the Lite and Fire Stick variants already had. If you searched for an older or niche title where only 720p streams are indexed, Stream returned zero results instead of showing what was available. It now surfaces 720p WEB-DL and WEBRip as a fallback tier below the four 1080p priority tiers — so for any title where 1080p exists, your list is unchanged; for titles with only 720p sources, you now get results. Re-import from the [Template Directory](/template-directory) to pick up this fix.
 
-**MediaFusion and HdHub now on by default.**
-Previously these two scrapers were opt-in — you had to manually enable them after every template import before they'd contribute any results. They're now enabled out of the box so templates work fully on a fresh import. MediaFusion adds regional content coverage that TorBox's native scraper misses; HdHub is a TorBox-native P2P scraper for additional cached sources. If you don't want either of them, toggle them off in the Addons section of your AIOStreams dashboard.
+**MediaFusion and HdHub now on by default.** Previously these two scrapers were opt-in — you had to manually enable them after every template import before they'd contribute any results. They're now enabled out of the box so templates work fully on a fresh import. MediaFusion adds regional content coverage that TorBox's native scraper misses; HdHub is a TorBox-native P2P scraper for additional cached sources. If you don't want either of them, toggle them off in the Addons section of your AIOStreams dashboard.
 
-**Cached-only template fixed — streams now actually load.**
-The 4K Apex TorBox variant (the cached-only version of 4K Apex) was shipping with its stream delivery addon disabled. This meant importing it and hitting play returned nothing — the template was technically correct but the service that delivers the streams was switched off. Fixed. The cached-only behaviour is preserved through the exclude-uncached setting, not by disabling the provider.
+**Cached-only template fixed — streams now actually load.** The 4K Apex TorBox variant (the cached-only version of 4K Apex) was shipping with its stream delivery addon disabled. This meant importing it and hitting play returned nothing — the template was technically correct but the service that delivers the streams was switched off. Fixed. The cached-only behaviour is preserved through the exclude-uncached setting, not by disabling the provider.
 
-**Nightly and Labs templates fixed — all 6 now import cleanly.**
-A batch of import blockers has been cleared across the full Nightly and Labs template set. Every template had eleven regex patterns in its scoring layer that were being rejected by fortheweak's stricter import filter — those have been removed. Additional per-template fixes: Apple TV Nightly (v0.1.9) was clean besides the regex; Samsung Nightly (v0.2.14) had wrong audio exclusions and missing SEL sync URLs; Essential Labs (v0.1.7) was missing a changelog link and a resolution kill rule; 4K Essential Labs (v0.1.7) was missing its changelog link; 4K Apex Labs (v0.8.6) had six required metadata fields completely absent; Stream Labs (v0.6.7) had a contradiction between its resolution settings and its exclusion filter that was blocking 720p streams it was supposed to allow.
+**Nightly and Labs templates fixed — all 6 now import cleanly.** A batch of import blockers has been cleared across the full Nightly and Labs template set. Every template had eleven regex patterns in its scoring layer that were being rejected by fortheweak's stricter import filter — those have been removed. Additional per-template fixes: Apple TV Nightly (v0.1.9) was clean besides the regex; Samsung Nightly (v0.2.14) had wrong audio exclusions and missing SEL sync URLs; Essential Labs (v0.1.7) was missing a changelog link and a resolution kill rule; 4K Essential Labs (v0.1.7) was missing its changelog link; 4K Apex Labs (v0.8.6) had six required metadata fields completely absent; Stream Labs (v0.6.7) had a contradiction between its resolution settings and its exclusion filter that was blocking 720p streams it was supposed to allow.
 
 ---
 
 ## v2.9.3 — June 2026
 
-**4K WEB-DL streams no longer suppressed on new releases.**
-When a film releases digitally before its Blu-ray ships — think Spider-Man: Brand New Day — the template was accidentally blocking all 4K WEB-DL streams. The logic was designed to avoid showing upscaled content when a proper 4K Blu-ray exists, but it was too aggressive: it also blocked legitimate 4K streaming masters for titles that simply don't have a Blu-ray yet. Fixed. Streaming masters for theatrical releases come through correctly now. Once the Blu-ray arrives and remuxes are indexed, those will rank above the WEB-DL as normal.
+**4K WEB-DL streams no longer suppressed on new releases.** When a film releases digitally before its Blu-ray ships — think Spider-Man: Brand New Day — the template was accidentally blocking all 4K WEB-DL streams. The logic was designed to avoid showing upscaled content when a proper 4K Blu-ray exists, but it was too aggressive: it also blocked legitimate 4K streaming masters for titles that simply don't have a Blu-ray yet. Fixed. Streaming masters for theatrical releases come through correctly now. Once the Blu-ray arrives and remuxes are indexed, those will rank above the WEB-DL as normal.
 
 ---
 
 ## v2.9.2 — June 2026
 
-**Knaben and Torrent Galaxy moved to backup scrapers.**
-Both scrapers were confirmed slow and only useful for content already in debrid cache — they weren't meaningfully adding results that faster scrapers missed. They're still in the template as last-resort sources (capped at one result each) so they can catch a cache hit when everything else comes up empty, but they no longer slow down your stream request on every query.
+**Knaben and Torrent Galaxy moved to backup scrapers.** Both scrapers were confirmed slow and only useful for content already in debrid cache — they weren't meaningfully adding results that faster scrapers missed. They're still in the template as last-resort sources (capped at one result each) so they can catch a cache hit when everything else comes up empty, but they no longer slow down your stream request on every query.
 
-**AIOSubtitle is now the sole subtitle source.**
-OpenSubtitles V3+ has been removed from all templates. AIOSubtitle covers the same subtitle content, so there's no loss in coverage — this just removes a redundant network call on every stream request.
+**AIOSubtitle is now the sole subtitle source.** OpenSubtitles V3\+ has been removed from all templates. AIOSubtitle covers the same subtitle content, so there's no loss in coverage — this just removes a redundant network call on every stream request.
 
 ---
 
 ## v2.9.1 — June 2026
 
-**Per-addon flood guard extended to AllDebrid and Samsung TV templates.**
-A flood guard that caps how many results any single scraper can contribute to your list has been in the main TorBox templates for a while. It prevents one slow or noisy scraper from flooding your stream list with 20 low-quality results. This release extends that guard to the AllDebrid and Samsung TV templates that were previously missing it.
+**Per-addon flood guard extended to AllDebrid and Samsung TV templates.** A flood guard that caps how many results any single scraper can contribute to your list has been in the main TorBox templates for a while. It prevents one slow or noisy scraper from flooding your stream list with 20 low-quality results. This release extends that guard to the AllDebrid and Samsung TV templates that were previously missing it.
 
 ---
 
 ## v2.9.0 — June 2026
 
-**Templates now work on both ElfHosted and fortheweak.cloud.**
-If you use Yeb's AIOStreams instance at fortheweak.cloud, you may have seen regex import errors with earlier templates — patterns that imported cleanly on ElfHosted were being rejected on fortheweak's stricter setup. Eleven ranking patterns and three exclusion patterns that caused these rejections have been removed from all templates. All Core Builds templates from v2.9.0 onwards are verified clean on both hosts. Quality ranking and LQ exclusion are preserved through the remaining patterns and the shared Tamtaro exclusion list.
+**Templates now work on both ElfHosted and fortheweak.cloud.** If you use Yeb's AIOStreams instance at fortheweak.cloud, you may have seen regex import errors with earlier templates — patterns that imported cleanly on ElfHosted were being rejected on fortheweak's stricter setup. Eleven ranking patterns and three exclusion patterns that caused these rejections have been removed from all templates. All Core Builds templates from v2.9.0 onwards are verified clean on both hosts. Quality ranking and LQ exclusion are preserved through the remaining patterns and the shared Tamtaro exclusion list.
 
 ---
 
 ## v2.8.4 — June 2026
 
-**Cached Usenet streams now rank where they belong.**
-TorBox supports Usenet (NZB) sources alongside torrents. When a cached Usenet stream didn't fit neatly inside the quality-window filters, it was falling below all the ranked torrent streams — sometimes even below uncached content. A new sorting pass at the end of each template catches any remaining cached Usenet streams that slipped through and promotes them above uncached results. If you use TorBox Pro's Usenet features, NZB results now appear in a sensible position.
+**Cached Usenet streams now rank where they belong.** TorBox supports Usenet (NZB) sources alongside torrents. When a cached Usenet stream didn't fit neatly inside the quality-window filters, it was falling below all the ranked torrent streams — sometimes even below uncached content. A new sorting pass at the end of each template catches any remaining cached Usenet streams that slipped through and promotes them above uncached results. If you use TorBox Pro's Usenet features, NZB results now appear in a sensible position.
 
 ---
 
 ## v2.8.0 — June 2026
 
-**AllDebrid template family launched.**
-Four dedicated templates for AllDebrid users: 4K AllDebrid, 4K AllDebrid Lite, AllDebrid, and AllDebrid Lite. The full quality filtering stack — IQR Tukey fence adaptive bitrate windows, all the hard quality kills, regex scoring — carries over from the TorBox equivalents. The only structural difference is that AllDebrid uses a different stream delivery service than TorBox.
+**AllDebrid template family launched.** Four dedicated templates for AllDebrid users: 4K AllDebrid, 4K AllDebrid Lite, AllDebrid, and AllDebrid Lite. The full quality filtering stack — IQR Tukey fence adaptive bitrate windows, all the hard quality kills, regex scoring — carries over from the TorBox equivalents. The only structural difference is that AllDebrid uses a different stream delivery service than TorBox.
 
-**Fire Stick optimised template added.**
-Core Nexus Stream Fire Stick is a 1080p template tuned for Fire Stick codec constraints — same quality filtering as Core Nexus Stream, adjusted for the hardware limitations of Fire Stick and similar low-RAM devices.
+**Fire Stick optimised template added.** Core Nexus Stream Fire Stick is a 1080p template tuned for Fire Stick codec constraints — same quality filtering as Core Nexus Stream, adjusted for the hardware limitations of Fire Stick and similar low-RAM devices.
 
-**Age-decay replaces the hard 60-day cliff.**
-Previously, when a title had very few ranked peers, content older than 60 days fell through all quality filters and ended up at the bottom of your list. Day 59 got a bitrate window; day 61 got nothing. This has been replaced with a smooth exponential curve — content gradually ages out of the quality window over about 90 days rather than hitting an abrupt cutoff. Newer releases get tighter filtering; older releases progressively relax until they're no longer windowed at all. Applied to the 4K Apex, 4K Hybrid, and 4K Essential templates.
+**Age-decay replaces the hard 60-day cliff.** Previously, when a title had very few ranked peers, content older than 60 days fell through all quality filters and ended up at the bottom of your list. Day 59 got a bitrate window; day 61 got nothing. This has been replaced with a smooth exponential curve — content gradually ages out of the quality window over about 90 days rather than hitting an abrupt cutoff. Newer releases get tighter filtering; older releases progressively relax until they're no longer windowed at all. Applied to the 4K Apex, 4K Hybrid, and 4K Essential templates.
 
 ---
 


### PR DESCRIPTION
Updates 5 docs pages to cover Configurator v2.55–v2.56 features:

- **whats-new**: New "Configurator v2.56" section with Resolution First, Foreign Language Kill, and v2.55 UX overhaul
- **configurator**: Resolution First and Foreign Language Kill subsections under Additional Options
- **troubleshooting**: Foreign language streams troubleshooting accordion in Results Issues
- **faq**: Foreign language streams FAQ accordion in No Streams section
- **roadmap**: v2.55 and v2.56 entries added to Recently Completed table

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/core-builds/core-builds/editor/admin-mcp%2Fv256-docs-update-a7026bf?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->