### PR TITLE
fix: clamp Fine-Tune tooltip popups to viewport on mobile

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -301,7 +301,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 /* ── Fine-Tune Info Tooltips ── */
 .ft-info{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);color:#6b7280;font-size:.6rem;font-weight:800;cursor:pointer;transition:all .15s;user-select:none;flex-shrink:0;font-style:normal;line-height:1}
 .ft-info:hover{background:rgba(0,212,255,.1);border-color:rgba(0,212,255,.3);color:#00d4ff}
-.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0}
+.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0;right:auto}
 .ft-popup.active{display:block}
 .ft-popup strong{color:#e6edf3;font-weight:600}
 .ft-popup .hl{color:#00d4ff;font-weight:600}
@@ -1370,7 +1370,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.62';
+const CONFIGURATOR_VERSION = '2.63';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1424,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.63', date:'Jul 18 2026', items:[
+    'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
+  ]},
   { v:'2.62', date:'Jul 18 2026', items:[
     'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
     'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
@@ -3829,12 +3832,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const popup = ftInfo.parentElement.querySelector('.ft-popup');
       if (popup) {
         const wasActive = popup.classList.contains('active');
-        document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
-        if (!wasActive) popup.classList.add('active');
+        document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
+        if (!wasActive) {
+          popup.style.left = '0'; popup.style.right = 'auto';
+          popup.classList.add('active');
+          const rect = popup.getBoundingClientRect();
+          if (rect.right > window.innerWidth - 12) {
+            popup.style.left = 'auto'; popup.style.right = '0';
+            const r2 = popup.getBoundingClientRect();
+            if (r2.left < 12) { popup.style.left = '0'; popup.style.right = 'auto'; popup.style.left = (-rect.left + 12) + 'px'; }
+          }
+          if (rect.left < 12) { popup.style.left = (-rect.left + 12) + 'px'; popup.style.right = 'auto'; }
+        }
       }
       return;
     }
-    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
+    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -1370,7 +1370,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.61';
+const CONFIGURATOR_VERSION = '2.62';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1424,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.62', date:'Jul 18 2026', items:[
+    'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
+    'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
+  ]},
   { v:'2.61', date:'Jul 17 2026', items:[
     'Onboarding Tutorial — interactive coach-mark walkthrough for first-time visitors with spotlight cutouts on key UI elements',
     'Tutorial auto-launches on first visit (skipped for returning users with saved state); accessible via the Tutorial preset on the splash screen',
@@ -2718,7 +2722,7 @@ function renderAdvancedPanel() {
         </div>
         ${(S.service !== 'http' && S.service !== 'p2p') ? `<div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px;margin-top:8px">
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
-            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what\\'s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
+            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what&apos;s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
           </div>
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">How stream quality tiers are built. Standard uses simple resolution/quality filters. Apex IQR uses statistical bitrate analysis matching the flagship Apex template.</div>
           <div style="display:flex;gap:5px">
@@ -2728,7 +2732,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it\\'s arranged. You can import custom formatters for different visual styles.')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it&apos;s arranged. You can import custom formatters for different visual styles.')}</div>
         ${fmtDropdownHtml()}
         <button data-action="import-formatter" style="margin-top:10px;width:100%;padding:10px;border-radius:8px;border:1.5px dashed rgba(167,139,250,.3);background:transparent;color:#a78bfa;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s" onmouseover="this.style.borderColor='rgba(167,139,250,.6)'" onmouseout="this.style.borderColor='rgba(167,139,250,.3)'">${S.customFormatter ? '⟳ Replace Custom Formatter' : ICO.folder(14,'#a78bfa')+' Import Custom Formatter'}</button>
       </div>
@@ -2775,7 +2779,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don\\'t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don&apos;t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
         <div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px">
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">Add browse catalogs to your Stremio home screen for discovering content.</div>
           <div style="display:flex;flex-direction:column;gap:5px">

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -1368,7 +1368,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.61';
+const CONFIGURATOR_VERSION = '2.62';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1422,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.62', date:'Jul 18 2026', items:[
+    'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
+    'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
+  ]},
   { v:'2.61', date:'Jul 17 2026', items:[
     'Onboarding Tutorial — interactive coach-mark walkthrough for first-time visitors with spotlight cutouts on key UI elements',
     'Tutorial auto-launches on first visit (skipped for returning users with saved state); accessible via the Tutorial preset on the splash screen',
@@ -2716,7 +2720,7 @@ function renderAdvancedPanel() {
         </div>
         ${(S.service !== 'http' && S.service !== 'p2p') ? `<div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px;margin-top:8px">
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
-            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what\\'s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
+            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what&apos;s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
           </div>
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">How stream quality tiers are built. Standard uses simple resolution/quality filters. Apex IQR uses statistical bitrate analysis matching the flagship Apex template.</div>
           <div style="display:flex;gap:5px">
@@ -2726,7 +2730,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it\\'s arranged. You can import custom formatters for different visual styles.')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it&apos;s arranged. You can import custom formatters for different visual styles.')}</div>
         ${fmtDropdownHtml()}
         <button data-action="import-formatter" style="margin-top:10px;width:100%;padding:10px;border-radius:8px;border:1.5px dashed rgba(167,139,250,.3);background:transparent;color:#a78bfa;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s" onmouseover="this.style.borderColor='rgba(167,139,250,.6)'" onmouseout="this.style.borderColor='rgba(167,139,250,.3)'">${S.customFormatter ? '⟳ Replace Custom Formatter' : ICO.folder(14,'#a78bfa')+' Import Custom Formatter'}</button>
       </div>
@@ -2773,7 +2777,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don\\'t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don&apos;t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
         <div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px">
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">Add browse catalogs to your Stremio home screen for discovering content.</div>
           <div style="display:flex;flex-direction:column;gap:5px">

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -301,7 +301,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 /* ── Fine-Tune Info Tooltips ── */
 .ft-info{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);color:#6b7280;font-size:.6rem;font-weight:800;cursor:pointer;transition:all .15s;user-select:none;flex-shrink:0;font-style:normal;line-height:1}
 .ft-info:hover{background:rgba(0,212,255,.1);border-color:rgba(0,212,255,.3);color:#00d4ff}
-.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0}
+.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0;right:auto}
 .ft-popup.active{display:block}
 .ft-popup strong{color:#e6edf3;font-weight:600}
 .ft-popup .hl{color:#00d4ff;font-weight:600}
@@ -1368,7 +1368,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.62';
+const CONFIGURATOR_VERSION = '2.63';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1422,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.63', date:'Jul 18 2026', items:[
+    'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
+  ]},
   { v:'2.62', date:'Jul 18 2026', items:[
     'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
     'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
@@ -3827,12 +3830,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const popup = ftInfo.parentElement.querySelector('.ft-popup');
       if (popup) {
         const wasActive = popup.classList.contains('active');
-        document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
-        if (!wasActive) popup.classList.add('active');
+        document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
+        if (!wasActive) {
+          popup.style.left = '0'; popup.style.right = 'auto';
+          popup.classList.add('active');
+          const rect = popup.getBoundingClientRect();
+          if (rect.right > window.innerWidth - 12) {
+            popup.style.left = 'auto'; popup.style.right = '0';
+            const r2 = popup.getBoundingClientRect();
+            if (r2.left < 12) { popup.style.left = '0'; popup.style.right = 'auto'; popup.style.left = (-rect.left + 12) + 'px'; }
+          }
+          if (rect.left < 12) { popup.style.left = (-rect.left + 12) + 'px'; popup.style.right = 'auto'; }
+        }
       }
       return;
     }
-    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
+    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;


### PR DESCRIPTION
## Description
Fine-Tune info bubble popups (the `?` icons) overflow off the right edge of the screen on mobile devices. This adds dynamic repositioning so popups stay within the viewport.

**What changed:**
- Popup positioning now checks `getBoundingClientRect()` after display and shifts `left`/`right` to keep content on-screen
- Styles reset when popups close so repositioning is recalculated each time
- Added `right:auto` default to `.ft-popup` CSS for clean left/right toggling

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)

## Template Checklist
N/A — this change only affects the configurator UI, not template JSON files.

## Testing
- Verified JS syntax passes `new Function()` check
- All 186 pytest tests pass
- Configurator version bumped to v2.63

## Related Issues
Reported via screenshot — tooltip popups for "Stream Layout (Formatter)" and others cut off on mobile viewport.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_