### PR TITLE
feat: replace formatter dropdown with horizontal scroll carousel

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -301,7 +301,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 /* ── Fine-Tune Info Tooltips ── */
 .ft-info{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);color:#6b7280;font-size:.6rem;font-weight:800;cursor:pointer;transition:all .15s;user-select:none;flex-shrink:0;font-style:normal;line-height:1}
 .ft-info:hover{background:rgba(0,212,255,.1);border-color:rgba(0,212,255,.3);color:#00d4ff}
-.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0}
+.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0;right:auto}
 .ft-popup.active{display:block}
 .ft-popup strong{color:#e6edf3;font-weight:600}
 .ft-popup .hl{color:#00d4ff;font-weight:600}
@@ -1370,7 +1370,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.62';
+const CONFIGURATOR_VERSION = '2.63';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1424,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.63', date:'Jul 18 2026', items:[
+    'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
+  ]},
   { v:'2.62', date:'Jul 18 2026', items:[
     'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
     'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
@@ -3829,12 +3832,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const popup = ftInfo.parentElement.querySelector('.ft-popup');
       if (popup) {
         const wasActive = popup.classList.contains('active');
-        document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
-        if (!wasActive) popup.classList.add('active');
+        document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
+        if (!wasActive) {
+          popup.style.left = '0'; popup.style.right = 'auto';
+          popup.classList.add('active');
+          const rect = popup.getBoundingClientRect();
+          if (rect.right > window.innerWidth - 12) {
+            popup.style.left = 'auto'; popup.style.right = '0';
+            const r2 = popup.getBoundingClientRect();
+            if (r2.left < 12) { popup.style.left = '0'; popup.style.right = 'auto'; popup.style.left = (-rect.left + 12) + 'px'; }
+          }
+          if (rect.left < 12) { popup.style.left = (-rect.left + 12) + 'px'; popup.style.right = 'auto'; }
+        }
       }
       return;
     }
-    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
+    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -557,6 +557,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   .srh-ring{width:40px;height:40px}
   .srh-num{font-size:.95rem}
   .summary{grid-template-columns:1fr}
+  .td-tiles{grid-template-columns:1fr}
+  .hero-sub{grid-template-columns:1fr}
+  .cmp-row{grid-template-columns:70px 1fr 1fr;font-size:.68rem}
+  .cmp-label,.cmp-val{padding:4px 6px}
 }
 /* Touch devices — larger tap targets */
 @media(pointer:coarse){
@@ -1370,7 +1374,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.64';
+const CONFIGURATOR_VERSION = '2.65';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1428,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.65', date:'Jul 18 2026', items:[
+    'Mobile UX — grids (test drive tiles, hero sections, compare table) now collapse to single column on extra-small screens (≤360px)',
+    'Family v3 preview card updated to reflect fixed formatter (removed raw boolean values, added visual tags)',
+  ]},
   { v:'2.64', date:'Jul 18 2026', items:[
     'Fix — Family v3 formatter: preloading and library fields now use conditional formatting instead of showing raw true/false',
     'Family v3 formatter: added uncached badge, visual tags line, and spacing fixes',
@@ -2439,7 +2447,7 @@ function renderOpts(def) {
 const FMT_PREVIEWS = {
   'family-v3': {
     n:'Torrentio | "Frankenstein" S01 • E05',
-    d:['✅ Plays Fast  🥇Good Stream','📺 From Apple TV','🖥️ Highest Resolution 4k','🎥 WEB-DL • HEVC','🔊 5.1 • Atmos, EAC3','💾 4.2 GB • ☁️ false','🏞️ torbox • debrid • 📚 false','🗣️ English']
+    d:['✅ Plays Fast 🥇 Good Stream','📺 From Apple TV','🖥️ Highest Resolution 4k','🎥 WEB-DL • HEVC • HDR10+','🔊 5.1 • Atmos, EAC3','💾 4.2 GB','🏞️ torbox • debrid','🗣️ English']
   },
   'ultra': {
     n:'4K · ⚡ TORBOX · REMUX · FRANKENSTEIN',

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -1370,7 +1370,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.63';
+const CONFIGURATOR_VERSION = '2.64';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1424,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.64', date:'Jul 18 2026', items:[
+    'Fix — Family v3 formatter: preloading and library fields now use conditional formatting instead of showing raw true/false',
+    'Family v3 formatter: added uncached badge, visual tags line, and spacing fixes',
+  ]},
   { v:'2.63', date:'Jul 18 2026', items:[
     'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
   ]},
@@ -1881,7 +1885,7 @@ const FORMATTERS = [
     desc: 'Human-readable · ✅ Plays Fast · network source · edition badges · by RB3',
     img: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/Formatters/rb3-formatter-preview.svg',
     name: `{addon.name} | {stream.title::exists["\"{stream.title}\""||\"\"]}{stream.season::>=0[" S"||""]}{stream.season::<=9["0"||""]}{stream.season::>0["{stream.season}"||""]}{stream.episode::>=0[" • E"||""]}{stream.episode::<=9["0"||""]}{stream.episode::>0["{stream.episode}"||""]}`,
-    d: `{service.cached::istrue["✅ Plays Fast"||""]}{stream.nSeScore::exists::and::stream.nSeScore::>=75::istrue["🥇Good Stream"||""]}\n{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEB-DL::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEBRip::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}\n{stream.resolution::exists["🖥️ {stream.resolution::replace('2160p', 'Highest Resolution 4k')::replace('1440p','High Resolution 2k')::replace('1080p','Great Resolution 1080p')::replace('720p','Decent Resolution 720p')}"||\"\"]}\n{stream.quality::exists["🎥 "||""]}{stream.quality::exists::isfalse::and::stream.encode::exists["🎞️ "||""]}{stream.quality::exists["{stream.quality}"||""]}{stream.quality::exists::istrue::and::stream.encode::exists[" • "||""]}{stream.encode::exists["{stream.encode}"||""]}\n{stream.audioChannels::exists::or::stream.audioTags::exists["🔊 "||""]}{stream.audioChannels::exists["{stream.audioChannels::join(', ')}"||\"\"]}{stream.audioChannels::exists::and::stream.audioTags::exists[" • "||""]}{stream.audioTags::exists["{stream.audioTags::join(', ')}"||\"\"]}\n{stream.edition::exists["⭐️ {stream.edition}"||""]}\n{stream.size::exists["💾 {stream.size::bytes}"||""]} • ☁️ {stream.preloading}\n🏞️ {service.id} • {stream.type} • 📚 {stream.library}\n🗣️ {stream.uLanguages}`
+    d: `{service.cached::istrue["✅ Plays Fast"||""]} {service.cached::isfalse["❌ Uncached"||""]}{stream.nSeScore::exists::and::stream.nSeScore::>=75::istrue[" 🥇 Good Stream"||""]}\n{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEB-DL::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEBRip::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}\n{stream.resolution::exists["🖥️ {stream.resolution::replace('2160p', 'Highest Resolution 4k')::replace('1440p','High Resolution 2k')::replace('1080p','Great Resolution 1080p')::replace('720p','Decent Resolution 720p')}"||\"\"]}\n{stream.quality::exists["🎥 "||""]}{stream.quality::exists::isfalse::and::stream.encode::exists["🎞️ "||""]}{stream.quality::exists["{stream.quality}"||""]}{stream.quality::exists::istrue::and::stream.encode::exists[" • "||""]}{stream.encode::exists["{stream.encode}"||""]}{stream.visualTags::exists[" • "||""]}{stream.visualTags}\n{stream.audioChannels::exists::or::stream.audioTags::exists["🔊 "||""]}{stream.audioChannels::exists["{stream.audioChannels::join(', ')}"||\"\"]}{stream.audioChannels::exists::and::stream.audioTags::exists[" • "||""]}{stream.audioTags::exists["{stream.audioTags::join(', ')}"||\"\"]}\n{stream.edition::exists["⭐️ {stream.edition}"||""]}\n{stream.size::exists["💾 {stream.size::bytes}"||""]}{stream.preloading::istrue[" • ⏳ Preloading"||""]}\n🏞️ {service.id} • {stream.type}{stream.library::istrue[" • 📚 Library"||""]}\n🗣️ {stream.uLanguages}`
   },
   {
     id: 'ultra', label: 'Ultra', badge: 'Flagship', bc: '#e11d48',

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -714,7 +714,25 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .fmt-live-lines{flex:1;min-width:0;display:flex;flex-direction:column;gap:1px}
 .fmt-live-n{font-size:.73rem;color:#e2e8f0;line-height:1.55;word-break:break-word}
 .fmt-live-d{font-size:.7rem;color:#6b7280;line-height:1.55;word-break:break-word}
-/* Formatter dropdown picker */
+/* Formatter horizontal scroll picker */
+.fmt-scroll{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:4px 2px 12px;scrollbar-width:thin;scrollbar-color:rgba(0,212,255,.25) transparent}
+.fmt-scroll::-webkit-scrollbar{height:4px}
+.fmt-scroll::-webkit-scrollbar-track{background:transparent}
+.fmt-scroll::-webkit-scrollbar-thumb{background:rgba(0,212,255,.25);border-radius:4px}
+.fmt-scroll-card{scroll-snap-align:start;flex:0 0 260px;border:1.5px solid rgba(255,255,255,.1);border-radius:12px;background:rgba(8,12,18,.9);cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;padding:12px 14px;display:flex;flex-direction:column;gap:6px}
+.fmt-scroll-card:hover{border-color:rgba(255,255,255,.2);background:rgba(255,255,255,.03)}
+.fmt-scroll-card[data-active="true"]{border-color:rgba(0,212,255,.6);background:rgba(0,212,255,.06);box-shadow:0 0 12px rgba(0,212,255,.1)}
+.fmt-scroll-head{display:flex;align-items:center;gap:8px}
+.fmt-scroll-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.fmt-scroll-label{font-weight:700;font-size:.8rem;color:#9ca3af;white-space:nowrap}
+.fmt-scroll-card[data-active="true"] .fmt-scroll-label{color:#00d4ff}
+.fmt-scroll-badge{font-size:.58rem;font-weight:700;padding:1px 6px;border-radius:4px;white-space:nowrap}
+.fmt-scroll-desc{font-size:.66rem;color:#6b7280;line-height:1.35;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.fmt-scroll-card .fmt-live-preview{margin-top:2px;background:rgba(0,0,0,.2);border-color:rgba(255,255,255,.05)}
+.fmt-scroll-card .fmt-live-n{font-size:.65rem}
+.fmt-scroll-card .fmt-live-d{font-size:.6rem}
+.fmt-scroll-card .fmt-live-poster{width:28px;height:40px;font-size:1rem}
+/* Keep dropdown styles for fallback/import custom formatter */
 .fmt-select-wrap{position:relative}
 .fmt-select{width:100%;padding:11px 40px 11px 14px;border-radius:10px;border:1.5px solid rgba(255,255,255,.13);background:#0d1117;color:#e6edf3;font-size:.85rem;font-weight:600;cursor:pointer;appearance:none;-webkit-appearance:none;outline:none;transition:border-color .2s}
 .fmt-select:focus{border-color:rgba(0,212,255,.5)}
@@ -729,6 +747,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .fmt-select:focus{border-color:#0969da}
 [data-theme="light"] .fmt-featured{border-color:rgba(9,105,218,.3);background:rgba(9,105,218,.04)}
 [data-theme="light"] .fmt-featured-label{color:#0969da}
+[data-theme="light"] .fmt-scroll-card{background:#fff;border-color:#d0d7de}
+[data-theme="light"] .fmt-scroll-card:hover{border-color:#afb8c1;background:#f6f8fa}
+[data-theme="light"] .fmt-scroll-card[data-active="true"]{border-color:rgba(9,105,218,.6);background:rgba(9,105,218,.04)}
+[data-theme="light"] .fmt-scroll-card[data-active="true"] .fmt-scroll-label{color:#0969da}
+[data-theme="light"] .fmt-scroll-card .fmt-live-preview{background:rgba(0,0,0,.03)}
+[data-theme="light"] .fmt-scroll-label{color:#1f2328}
 /* Animated logo */
 @keyframes corePulse{0%,100%{transform:scale(1);opacity:.95}50%{transform:scale(1.07);opacity:1}}
 @keyframes coreGlowPulse{0%,100%{transform:scale(1);opacity:.38}50%{transform:scale(1.24);opacity:.84}}
@@ -1374,7 +1398,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.65';
+const CONFIGURATOR_VERSION = '2.66';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1428,6 +1452,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.66', date:'Jul 18 2026', items:[
+    'Formatter picker — replaced dropdown menu with horizontal scroll carousel showing live previews of all formatters',
+  ]},
   { v:'2.65', date:'Jul 18 2026', items:[
     'Mobile UX — grids (test drive tiles, hero sections, compare table) now collapse to single column on extra-small screens (≤360px)',
     'Family v3 preview card updated to reflect fixed formatter (removed raw boolean values, added visual tags)',
@@ -2531,36 +2558,37 @@ function fmtPreviewHtml(fmtId) {
 }
 
 function fmtDropdownHtml() {
-  const cur = FORMATTERS.find(f => f.id === S.formatter) || FORMATTERS[0];
   const isCustom = S.formatter === 'custom' && S.customFormatter;
-  const opts = FORMATTERS.map(f => `<option value="${f.id}"${f.id === S.formatter && !isCustom ? ' selected' : ''}>${f.label} — ${f.badge}</option>`).join('');
-  const customOpt = S.customFormatter ? `<option value="custom"${isCustom ? ' selected' : ''}>${S.customFormatter.label || 'Custom'} — Imported</option>` : '';
-  const display = isCustom ? { bc:'#a78bfa', label:S.customFormatter.label||'Custom', badge:'Imported', desc:'Your imported formatter' } : cur;
-  return `<div>
-    <div class="fmt-select-wrap">
-      <select class="fmt-select" data-action="fmt-dropdown-change">${opts}${customOpt}</select>
-      <span class="fmt-select-arrow">▾</span>
-    </div>
-    <div class="fmt-featured" id="fmtFeaturedCard">
-      <div class="fmt-featured-head">
-        <div class="fmt-featured-dot" style="background:${display.bc};box-shadow:0 0 8px ${display.bc}88"></div>
-        <span class="fmt-featured-label" id="fmtFeaturedLabel">${display.label}</span>
-        <span class="fmt-featured-badge" id="fmtFeaturedBadge" style="background:${display.bc}22;color:${display.bc}">${display.badge}</span>
+  const allFmts = [...FORMATTERS];
+  if (S.customFormatter) allFmts.push({ id:'custom', label:S.customFormatter.label||'Custom', badge:'Imported', bc:'#a78bfa', desc:'Your imported formatter' });
+  const cards = allFmts.map(f => {
+    const active = (isCustom && f.id === 'custom') || (!isCustom && f.id === S.formatter);
+    const p = FMT_PREVIEWS[f.id] || FMT_PREVIEWS['family-v3'];
+    return `<div class="fmt-scroll-card" data-active="${active}" data-action="fmt-scroll-pick" data-fmt="${f.id}">
+      <div class="fmt-scroll-head">
+        <div class="fmt-scroll-dot" style="background:${f.bc}"></div>
+        <span class="fmt-scroll-label">${f.label}</span>
+        <span class="fmt-scroll-badge" style="background:${f.bc}22;color:${f.bc}">${f.badge}</span>
       </div>
-      <div class="fmt-featured-desc" id="fmtFeaturedDesc">${display.desc}</div>
-      <div id="fmtFeaturedPreview">${fmtPreviewHtml(isCustom ? 'family-v3' : cur.id)}</div>
-    </div>
-  </div>`;
+      <div class="fmt-scroll-desc">${f.desc}</div>
+      <div class="fmt-live-preview">
+        <div class="fmt-live-poster">${ICO.film(14,'#6b7280')}</div>
+        <div class="fmt-live-lines">
+          <div class="fmt-live-n">${p.n}</div>
+          ${p.d.map(l=>`<div class="fmt-live-d">${l}</div>`).join('')}
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+  return `<div class="fmt-scroll" id="fmtScroll">${cards}</div>`;
 }
 
 function updateFmtFeatured() {
-  const isCustom = S.formatter === 'custom' && S.customFormatter;
-  const cur = isCustom ? { bc:'#a78bfa', label:S.customFormatter.label||'Custom', badge:'Imported', desc:'Your imported formatter', id:'custom' } : (FORMATTERS.find(f => f.id === S.formatter) || FORMATTERS[0]);
-  document.querySelectorAll('#fmtFeaturedLabel').forEach(el => { el.textContent = cur.label; });
-  document.querySelectorAll('#fmtFeaturedBadge').forEach(el => { el.textContent = cur.badge; el.style.background = cur.bc + '22'; el.style.color = cur.bc; });
-  document.querySelectorAll('#fmtFeaturedDesc').forEach(el => { el.textContent = cur.desc; });
-  document.querySelectorAll('.fmt-featured-dot').forEach(el => { el.style.background = cur.bc; el.style.boxShadow = '0 0 8px ' + cur.bc + '88'; });
-  document.querySelectorAll('#fmtFeaturedPreview').forEach(el => { el.innerHTML = fmtPreviewHtml(isCustom ? 'family-v3' : cur.id); });
+  document.querySelectorAll('.fmt-scroll-card').forEach(card => {
+    const isSel = card.dataset.fmt === S.formatter;
+    card.dataset.active = isSel ? 'true' : 'false';
+    if (isSel) card.scrollIntoView({ behavior:'smooth', block:'nearest', inline:'center' });
+  });
 }
 function updateFmtReceiptRow() {
   const fmtLbl = label('formatter', S.formatter);
@@ -3863,6 +3891,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;
+
+    if (action === 'fmt-scroll-pick') {
+      S.formatter = el.dataset.fmt;
+      saveState();
+      updateFmtFeatured();
+      updateFmtReceiptRow();
+      return;
+    }
 
     if (action === 'nav-next') {
       if (step === 1 && S.multiServices.length === 0) return;

--- a/configurator/index.html
+++ b/configurator/index.html
@@ -1370,7 +1370,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.61';
+const CONFIGURATOR_VERSION = '2.62';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1424,6 +1424,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.62', date:'Jul 18 2026', items:[
+    'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
+    'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
+  ]},
   { v:'2.61', date:'Jul 17 2026', items:[
     'Onboarding Tutorial — interactive coach-mark walkthrough for first-time visitors with spotlight cutouts on key UI elements',
     'Tutorial auto-launches on first visit (skipped for returning users with saved state); accessible via the Tutorial preset on the splash screen',
@@ -2718,7 +2722,7 @@ function renderAdvancedPanel() {
         </div>
         ${(S.service !== 'http' && S.service !== 'p2p') ? `<div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px;margin-top:8px">
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
-            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what\\'s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
+            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what&apos;s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
           </div>
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">How stream quality tiers are built. Standard uses simple resolution/quality filters. Apex IQR uses statistical bitrate analysis matching the flagship Apex template.</div>
           <div style="display:flex;gap:5px">
@@ -2728,7 +2732,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it\\'s arranged. You can import custom formatters for different visual styles.')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it&apos;s arranged. You can import custom formatters for different visual styles.')}</div>
         ${fmtDropdownHtml()}
         <button data-action="import-formatter" style="margin-top:10px;width:100%;padding:10px;border-radius:8px;border:1.5px dashed rgba(167,139,250,.3);background:transparent;color:#a78bfa;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s" onmouseover="this.style.borderColor='rgba(167,139,250,.6)'" onmouseout="this.style.borderColor='rgba(167,139,250,.3)'">${S.customFormatter ? '⟳ Replace Custom Formatter' : ICO.folder(14,'#a78bfa')+' Import Custom Formatter'}</button>
       </div>
@@ -2775,7 +2779,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don\\'t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don&apos;t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
         <div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px">
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">Add browse catalogs to your Stremio home screen for discovering content.</div>
           <div style="display:flex;flex-direction:column;gap:5px">

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -1368,7 +1368,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.61';
+const CONFIGURATOR_VERSION = '2.62';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1422,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.62', date:'Jul 18 2026', items:[
+    'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
+    'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
+  ]},
   { v:'2.61', date:'Jul 17 2026', items:[
     'Onboarding Tutorial — interactive coach-mark walkthrough for first-time visitors with spotlight cutouts on key UI elements',
     'Tutorial auto-launches on first visit (skipped for returning users with saved state); accessible via the Tutorial preset on the splash screen',
@@ -2716,7 +2720,7 @@ function renderAdvancedPanel() {
         </div>
         ${(S.service !== 'http' && S.service !== 'p2p') ? `<div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px;margin-top:8px">
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
-            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what\\'s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
+            <span style="font-size:.78rem;font-weight:600;color:#6b7280">PSE Quality Architecture</span> ${ftTip('<strong>Standard</strong> uses simple resolution/quality tiers to rank streams. <strong>Apex IQR</strong> uses statistical bitrate analysis (interquartile range) to detect outliers &mdash; it adapts to what&apos;s actually available, filtering out suspiciously low or high bitrates. Apex IQR matches the flagship 4K Apex template.')}
           </div>
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">How stream quality tiers are built. Standard uses simple resolution/quality filters. Apex IQR uses statistical bitrate analysis matching the flagship Apex template.</div>
           <div style="display:flex;gap:5px">
@@ -2726,7 +2730,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it\\'s arranged. You can import custom formatters for different visual styles.')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.palette(16,'#a78bfa')} Stream Layout (Formatter) ${ftTip('Controls how streams appear in Stremio. The <strong>formatter</strong> defines the layout of each stream result &mdash; what info is shown (codec, resolution, size, etc.) and how it&apos;s arranged. You can import custom formatters for different visual styles.')}</div>
         ${fmtDropdownHtml()}
         <button data-action="import-formatter" style="margin-top:10px;width:100%;padding:10px;border-radius:8px;border:1.5px dashed rgba(167,139,250,.3);background:transparent;color:#a78bfa;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s" onmouseover="this.style.borderColor='rgba(167,139,250,.6)'" onmouseout="this.style.borderColor='rgba(167,139,250,.3)'">${S.customFormatter ? '⟳ Replace Custom Formatter' : ICO.folder(14,'#a78bfa')+' Import Custom Formatter'}</button>
       </div>
@@ -2773,7 +2777,7 @@ function renderAdvancedPanel() {
       </div>
 
       <div>
-        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don\\'t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
+        <div style="font-size:.72rem;font-weight:700;color:#4b5563;letter-spacing:.06em;text-transform:uppercase;margin-bottom:10px;display:flex;align-items:center;gap:6px">${ICO.compass(16,'#f97316')} Catalogs & Discovery ${ftTip('Adds <strong>browse catalogs</strong> to your Stremio home screen for discovering content. These don&apos;t affect stream quality &mdash; they just add new ways to find movies and shows (trending, by streaming service, anime databases, etc).')}</div>
         <div style="background:#111720;border:1.5px solid rgba(255,255,255,.08);border-radius:10px;padding:14px 16px">
           <div style="font-size:.65rem;color:#4b5563;margin-bottom:10px;line-height:1.4">Add browse catalogs to your Stremio home screen for discovering content.</div>
           <div style="display:flex;flex-direction:column;gap:5px">

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -714,7 +714,25 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 .fmt-live-lines{flex:1;min-width:0;display:flex;flex-direction:column;gap:1px}
 .fmt-live-n{font-size:.73rem;color:#e2e8f0;line-height:1.55;word-break:break-word}
 .fmt-live-d{font-size:.7rem;color:#6b7280;line-height:1.55;word-break:break-word}
-/* Formatter dropdown picker */
+/* Formatter horizontal scroll picker */
+.fmt-scroll{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:4px 2px 12px;scrollbar-width:thin;scrollbar-color:rgba(0,212,255,.25) transparent}
+.fmt-scroll::-webkit-scrollbar{height:4px}
+.fmt-scroll::-webkit-scrollbar-track{background:transparent}
+.fmt-scroll::-webkit-scrollbar-thumb{background:rgba(0,212,255,.25);border-radius:4px}
+.fmt-scroll-card{scroll-snap-align:start;flex:0 0 260px;border:1.5px solid rgba(255,255,255,.1);border-radius:12px;background:rgba(8,12,18,.9);cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;padding:12px 14px;display:flex;flex-direction:column;gap:6px}
+.fmt-scroll-card:hover{border-color:rgba(255,255,255,.2);background:rgba(255,255,255,.03)}
+.fmt-scroll-card[data-active="true"]{border-color:rgba(0,212,255,.6);background:rgba(0,212,255,.06);box-shadow:0 0 12px rgba(0,212,255,.1)}
+.fmt-scroll-head{display:flex;align-items:center;gap:8px}
+.fmt-scroll-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.fmt-scroll-label{font-weight:700;font-size:.8rem;color:#9ca3af;white-space:nowrap}
+.fmt-scroll-card[data-active="true"] .fmt-scroll-label{color:#00d4ff}
+.fmt-scroll-badge{font-size:.58rem;font-weight:700;padding:1px 6px;border-radius:4px;white-space:nowrap}
+.fmt-scroll-desc{font-size:.66rem;color:#6b7280;line-height:1.35;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.fmt-scroll-card .fmt-live-preview{margin-top:2px;background:rgba(0,0,0,.2);border-color:rgba(255,255,255,.05)}
+.fmt-scroll-card .fmt-live-n{font-size:.65rem}
+.fmt-scroll-card .fmt-live-d{font-size:.6rem}
+.fmt-scroll-card .fmt-live-poster{width:28px;height:40px;font-size:1rem}
+/* Keep dropdown styles for fallback/import custom formatter */
 .fmt-select-wrap{position:relative}
 .fmt-select{width:100%;padding:11px 40px 11px 14px;border-radius:10px;border:1.5px solid rgba(255,255,255,.13);background:#0d1117;color:#e6edf3;font-size:.85rem;font-weight:600;cursor:pointer;appearance:none;-webkit-appearance:none;outline:none;transition:border-color .2s}
 .fmt-select:focus{border-color:rgba(0,212,255,.5)}
@@ -729,6 +747,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 [data-theme="light"] .fmt-select:focus{border-color:#0969da}
 [data-theme="light"] .fmt-featured{border-color:rgba(9,105,218,.3);background:rgba(9,105,218,.04)}
 [data-theme="light"] .fmt-featured-label{color:#0969da}
+[data-theme="light"] .fmt-scroll-card{background:#fff;border-color:#d0d7de}
+[data-theme="light"] .fmt-scroll-card:hover{border-color:#afb8c1;background:#f6f8fa}
+[data-theme="light"] .fmt-scroll-card[data-active="true"]{border-color:rgba(9,105,218,.6);background:rgba(9,105,218,.04)}
+[data-theme="light"] .fmt-scroll-card[data-active="true"] .fmt-scroll-label{color:#0969da}
+[data-theme="light"] .fmt-scroll-card .fmt-live-preview{background:rgba(0,0,0,.03)}
+[data-theme="light"] .fmt-scroll-label{color:#1f2328}
 /* Animated logo */
 @keyframes corePulse{0%,100%{transform:scale(1);opacity:.95}50%{transform:scale(1.07);opacity:1}}
 @keyframes coreGlowPulse{0%,100%{transform:scale(1);opacity:.38}50%{transform:scale(1.24);opacity:.84}}
@@ -1372,7 +1396,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.65';
+const CONFIGURATOR_VERSION = '2.66';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1426,6 +1450,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.66', date:'Jul 18 2026', items:[
+    'Formatter picker — replaced dropdown menu with horizontal scroll carousel showing live previews of all formatters',
+  ]},
   { v:'2.65', date:'Jul 18 2026', items:[
     'Mobile UX — grids (test drive tiles, hero sections, compare table) now collapse to single column on extra-small screens (≤360px)',
     'Family v3 preview card updated to reflect fixed formatter (removed raw boolean values, added visual tags)',
@@ -2529,36 +2556,37 @@ function fmtPreviewHtml(fmtId) {
 }
 
 function fmtDropdownHtml() {
-  const cur = FORMATTERS.find(f => f.id === S.formatter) || FORMATTERS[0];
   const isCustom = S.formatter === 'custom' && S.customFormatter;
-  const opts = FORMATTERS.map(f => `<option value="${f.id}"${f.id === S.formatter && !isCustom ? ' selected' : ''}>${f.label} — ${f.badge}</option>`).join('');
-  const customOpt = S.customFormatter ? `<option value="custom"${isCustom ? ' selected' : ''}>${S.customFormatter.label || 'Custom'} — Imported</option>` : '';
-  const display = isCustom ? { bc:'#a78bfa', label:S.customFormatter.label||'Custom', badge:'Imported', desc:'Your imported formatter' } : cur;
-  return `<div>
-    <div class="fmt-select-wrap">
-      <select class="fmt-select" data-action="fmt-dropdown-change">${opts}${customOpt}</select>
-      <span class="fmt-select-arrow">▾</span>
-    </div>
-    <div class="fmt-featured" id="fmtFeaturedCard">
-      <div class="fmt-featured-head">
-        <div class="fmt-featured-dot" style="background:${display.bc};box-shadow:0 0 8px ${display.bc}88"></div>
-        <span class="fmt-featured-label" id="fmtFeaturedLabel">${display.label}</span>
-        <span class="fmt-featured-badge" id="fmtFeaturedBadge" style="background:${display.bc}22;color:${display.bc}">${display.badge}</span>
+  const allFmts = [...FORMATTERS];
+  if (S.customFormatter) allFmts.push({ id:'custom', label:S.customFormatter.label||'Custom', badge:'Imported', bc:'#a78bfa', desc:'Your imported formatter' });
+  const cards = allFmts.map(f => {
+    const active = (isCustom && f.id === 'custom') || (!isCustom && f.id === S.formatter);
+    const p = FMT_PREVIEWS[f.id] || FMT_PREVIEWS['family-v3'];
+    return `<div class="fmt-scroll-card" data-active="${active}" data-action="fmt-scroll-pick" data-fmt="${f.id}">
+      <div class="fmt-scroll-head">
+        <div class="fmt-scroll-dot" style="background:${f.bc}"></div>
+        <span class="fmt-scroll-label">${f.label}</span>
+        <span class="fmt-scroll-badge" style="background:${f.bc}22;color:${f.bc}">${f.badge}</span>
       </div>
-      <div class="fmt-featured-desc" id="fmtFeaturedDesc">${display.desc}</div>
-      <div id="fmtFeaturedPreview">${fmtPreviewHtml(isCustom ? 'family-v3' : cur.id)}</div>
-    </div>
-  </div>`;
+      <div class="fmt-scroll-desc">${f.desc}</div>
+      <div class="fmt-live-preview">
+        <div class="fmt-live-poster">${ICO.film(14,'#6b7280')}</div>
+        <div class="fmt-live-lines">
+          <div class="fmt-live-n">${p.n}</div>
+          ${p.d.map(l=>`<div class="fmt-live-d">${l}</div>`).join('')}
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+  return `<div class="fmt-scroll" id="fmtScroll">${cards}</div>`;
 }
 
 function updateFmtFeatured() {
-  const isCustom = S.formatter === 'custom' && S.customFormatter;
-  const cur = isCustom ? { bc:'#a78bfa', label:S.customFormatter.label||'Custom', badge:'Imported', desc:'Your imported formatter', id:'custom' } : (FORMATTERS.find(f => f.id === S.formatter) || FORMATTERS[0]);
-  document.querySelectorAll('#fmtFeaturedLabel').forEach(el => { el.textContent = cur.label; });
-  document.querySelectorAll('#fmtFeaturedBadge').forEach(el => { el.textContent = cur.badge; el.style.background = cur.bc + '22'; el.style.color = cur.bc; });
-  document.querySelectorAll('#fmtFeaturedDesc').forEach(el => { el.textContent = cur.desc; });
-  document.querySelectorAll('.fmt-featured-dot').forEach(el => { el.style.background = cur.bc; el.style.boxShadow = '0 0 8px ' + cur.bc + '88'; });
-  document.querySelectorAll('#fmtFeaturedPreview').forEach(el => { el.innerHTML = fmtPreviewHtml(isCustom ? 'family-v3' : cur.id); });
+  document.querySelectorAll('.fmt-scroll-card').forEach(card => {
+    const isSel = card.dataset.fmt === S.formatter;
+    card.dataset.active = isSel ? 'true' : 'false';
+    if (isSel) card.scrollIntoView({ behavior:'smooth', block:'nearest', inline:'center' });
+  });
 }
 function updateFmtReceiptRow() {
   const fmtLbl = label('formatter', S.formatter);
@@ -3861,6 +3889,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;
+
+    if (action === 'fmt-scroll-pick') {
+      S.formatter = el.dataset.fmt;
+      saveState();
+      updateFmtFeatured();
+      updateFmtReceiptRow();
+      return;
+    }
 
     if (action === 'nav-next') {
       if (step === 1 && S.multiServices.length === 0) return;

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -301,7 +301,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 /* ── Fine-Tune Info Tooltips ── */
 .ft-info{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);color:#6b7280;font-size:.6rem;font-weight:800;cursor:pointer;transition:all .15s;user-select:none;flex-shrink:0;font-style:normal;line-height:1}
 .ft-info:hover{background:rgba(0,212,255,.1);border-color:rgba(0,212,255,.3);color:#00d4ff}
-.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0}
+.ft-popup{display:none;position:absolute;z-index:999;width:280px;max-width:calc(100vw - 40px);background:#0f1820;border:1.5px solid rgba(0,212,255,.2);border-radius:12px;padding:14px 16px;box-shadow:0 12px 40px rgba(0,0,0,.5),0 0 20px rgba(0,212,255,.06);font-size:.75rem;color:#9ca3af;line-height:1.6;margin-top:8px;left:0;right:auto}
 .ft-popup.active{display:block}
 .ft-popup strong{color:#e6edf3;font-weight:600}
 .ft-popup .hl{color:#00d4ff;font-weight:600}
@@ -1368,7 +1368,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.62';
+const CONFIGURATOR_VERSION = '2.63';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1422,9 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.63', date:'Jul 18 2026', items:[
+    'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
+  ]},
   { v:'2.62', date:'Jul 18 2026', items:[
     'Fix — configurator blank page caused by syntax error in Fine-Tune tooltip text (escaped apostrophes breaking template literals)',
     'Fine-Tune tooltips now use HTML entities for apostrophes to avoid string termination inside template literals',
@@ -3827,12 +3830,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const popup = ftInfo.parentElement.querySelector('.ft-popup');
       if (popup) {
         const wasActive = popup.classList.contains('active');
-        document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
-        if (!wasActive) popup.classList.add('active');
+        document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
+        if (!wasActive) {
+          popup.style.left = '0'; popup.style.right = 'auto';
+          popup.classList.add('active');
+          const rect = popup.getBoundingClientRect();
+          if (rect.right > window.innerWidth - 12) {
+            popup.style.left = 'auto'; popup.style.right = '0';
+            const r2 = popup.getBoundingClientRect();
+            if (r2.left < 12) { popup.style.left = '0'; popup.style.right = 'auto'; popup.style.left = (-rect.left + 12) + 'px'; }
+          }
+          if (rect.left < 12) { popup.style.left = (-rect.left + 12) + 'px'; popup.style.right = 'auto'; }
+        }
       }
       return;
     }
-    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => p.classList.remove('active'));
+    if (!e.target.closest('.ft-popup')) document.querySelectorAll('.ft-popup.active').forEach(p => { p.classList.remove('active'); p.style.left = ''; p.style.right = ''; });
     const el = e.target.dataset.action ? e.target : e.target.closest('[data-action]');
     const action = el?.dataset.action;
     if(!action) return;

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -1368,7 +1368,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.63';
+const CONFIGURATOR_VERSION = '2.64';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1422,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.64', date:'Jul 18 2026', items:[
+    'Fix — Family v3 formatter: preloading and library fields now use conditional formatting instead of showing raw true/false',
+    'Family v3 formatter: added uncached badge, visual tags line, and spacing fixes',
+  ]},
   { v:'2.63', date:'Jul 18 2026', items:[
     'Fix — Fine-Tune info popups now stay within viewport on mobile instead of overflowing off-screen',
   ]},
@@ -1879,7 +1883,7 @@ const FORMATTERS = [
     desc: 'Human-readable · ✅ Plays Fast · network source · edition badges · by RB3',
     img: 'https://raw.githubusercontent.com/brevityA/Core-Builds/refs/heads/main/Assets/Formatters/rb3-formatter-preview.svg',
     name: `{addon.name} | {stream.title::exists["\"{stream.title}\""||\"\"]}{stream.season::>=0[" S"||""]}{stream.season::<=9["0"||""]}{stream.season::>0["{stream.season}"||""]}{stream.episode::>=0[" • E"||""]}{stream.episode::<=9["0"||""]}{stream.episode::>0["{stream.episode}"||""]}`,
-    d: `{service.cached::istrue["✅ Plays Fast"||""]}{stream.nSeScore::exists::and::stream.nSeScore::>=75::istrue["🥇Good Stream"||""]}\n{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEB-DL::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEBRip::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}\n{stream.resolution::exists["🖥️ {stream.resolution::replace('2160p', 'Highest Resolution 4k')::replace('1440p','High Resolution 2k')::replace('1080p','Great Resolution 1080p')::replace('720p','Decent Resolution 720p')}"||\"\"]}\n{stream.quality::exists["🎥 "||""]}{stream.quality::exists::isfalse::and::stream.encode::exists["🎞️ "||""]}{stream.quality::exists["{stream.quality}"||""]}{stream.quality::exists::istrue::and::stream.encode::exists[" • "||""]}{stream.encode::exists["{stream.encode}"||""]}\n{stream.audioChannels::exists::or::stream.audioTags::exists["🔊 "||""]}{stream.audioChannels::exists["{stream.audioChannels::join(', ')}"||\"\"]}{stream.audioChannels::exists::and::stream.audioTags::exists[" • "||""]}{stream.audioTags::exists["{stream.audioTags::join(', ')}"||\"\"]}\n{stream.edition::exists["⭐️ {stream.edition}"||""]}\n{stream.size::exists["💾 {stream.size::bytes}"||""]} • ☁️ {stream.preloading}\n🏞️ {service.id} • {stream.type} • 📚 {stream.library}\n🗣️ {stream.uLanguages}`
+    d: `{service.cached::istrue["✅ Plays Fast"||""]} {service.cached::isfalse["❌ Uncached"||""]}{stream.nSeScore::exists::and::stream.nSeScore::>=75::istrue[" 🥇 Good Stream"||""]}\n{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEB-DL::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}{stream.network::exists::istrue::and::stream.quality::exists::istrue::and::stream.quality::~WEBRip::istrue["📺 From {stream.network::replace('iTunes','Apple TV')}"||\"\"]}\n{stream.resolution::exists["🖥️ {stream.resolution::replace('2160p', 'Highest Resolution 4k')::replace('1440p','High Resolution 2k')::replace('1080p','Great Resolution 1080p')::replace('720p','Decent Resolution 720p')}"||\"\"]}\n{stream.quality::exists["🎥 "||""]}{stream.quality::exists::isfalse::and::stream.encode::exists["🎞️ "||""]}{stream.quality::exists["{stream.quality}"||""]}{stream.quality::exists::istrue::and::stream.encode::exists[" • "||""]}{stream.encode::exists["{stream.encode}"||""]}{stream.visualTags::exists[" • "||""]}{stream.visualTags}\n{stream.audioChannels::exists::or::stream.audioTags::exists["🔊 "||""]}{stream.audioChannels::exists["{stream.audioChannels::join(', ')}"||\"\"]}{stream.audioChannels::exists::and::stream.audioTags::exists[" • "||""]}{stream.audioTags::exists["{stream.audioTags::join(', ')}"||\"\"]}\n{stream.edition::exists["⭐️ {stream.edition}"||""]}\n{stream.size::exists["💾 {stream.size::bytes}"||""]}{stream.preloading::istrue[" • ⏳ Preloading"||""]}\n🏞️ {service.id} • {stream.type}{stream.library::istrue[" • 📚 Library"||""]}\n🗣️ {stream.uLanguages}`
   },
   {
     id: 'ultra', label: 'Ultra', badge: 'Flagship', bc: '#e11d48',

--- a/configurator/index_src.html
+++ b/configurator/index_src.html
@@ -557,6 +557,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
   .srh-ring{width:40px;height:40px}
   .srh-num{font-size:.95rem}
   .summary{grid-template-columns:1fr}
+  .td-tiles{grid-template-columns:1fr}
+  .hero-sub{grid-template-columns:1fr}
+  .cmp-row{grid-template-columns:70px 1fr 1fr;font-size:.68rem}
+  .cmp-label,.cmp-val{padding:4px 6px}
 }
 /* Touch devices — larger tap targets */
 @media(pointer:coarse){
@@ -1368,7 +1372,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <script>
 function toggleTheme(){const html=document.documentElement;const t=html.getAttribute('data-theme')==='dark'?'light':'dark';html.setAttribute('data-theme',t);localStorage.setItem('cbTheme',t);}
 const STEPS = 6;
-const CONFIGURATOR_VERSION = '2.64';
+const CONFIGURATOR_VERSION = '2.65';
 // Set to a collector endpoint to enable the opt-in anonymous usage ping (service+device+resolution only).
 // Leave empty to keep the feature fully disabled and hidden.
 const USAGE_BEACON_URL = '';
@@ -1422,6 +1426,10 @@ const ICO = {
   eye:(s=20,c='currentColor')=>`<svg width="${s}" height="${s}" viewBox="0 0 44 44" fill="none" style="vertical-align:middle"><path d="M6 22s6-10 16-10 16 10 16 10-6 10-16 10S6 22 6 22z" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".04"/><circle cx="22" cy="22" r="5" stroke="${c}" stroke-width="1.5" fill="${c}" fill-opacity=".1"/><circle cx="22" cy="22" r="2" fill="${c}" fill-opacity=".5"/></svg>`,
 };
 const CHANGELOG = [
+  { v:'2.65', date:'Jul 18 2026', items:[
+    'Mobile UX — grids (test drive tiles, hero sections, compare table) now collapse to single column on extra-small screens (≤360px)',
+    'Family v3 preview card updated to reflect fixed formatter (removed raw boolean values, added visual tags)',
+  ]},
   { v:'2.64', date:'Jul 18 2026', items:[
     'Fix — Family v3 formatter: preloading and library fields now use conditional formatting instead of showing raw true/false',
     'Family v3 formatter: added uncached badge, visual tags line, and spacing fixes',
@@ -2437,7 +2445,7 @@ function renderOpts(def) {
 const FMT_PREVIEWS = {
   'family-v3': {
     n:'Torrentio | "Frankenstein" S01 • E05',
-    d:['✅ Plays Fast  🥇Good Stream','📺 From Apple TV','🖥️ Highest Resolution 4k','🎥 WEB-DL • HEVC','🔊 5.1 • Atmos, EAC3','💾 4.2 GB • ☁️ false','🏞️ torbox • debrid • 📚 false','🗣️ English']
+    d:['✅ Plays Fast 🥇 Good Stream','📺 From Apple TV','🖥️ Highest Resolution 4k','🎥 WEB-DL • HEVC • HDR10+','🔊 5.1 • Atmos, EAC3','💾 4.2 GB','🏞️ torbox • debrid','🗣️ English']
   },
   'ultra': {
     n:'4K · ⚡ TORBOX · REMUX · FRANKENSTEIN',


### PR DESCRIPTION
## Description
Replaces the formatter dropdown menu + featured card with a horizontal scrollable carousel of preview cards. Users can now visually compare all 18 formatters side-by-side, each showing:

- Formatter name + badge
- Description
- Live preview with mock stream data (title, quality, audio, size, etc.)

Clicking a card selects it, with the active card highlighted in cyan. The carousel supports smooth scroll-snap, touch scrolling, and auto-scrolls to the selected card.

**Before:** Dropdown menu → select blindly → see preview of one formatter
**After:** Scroll through all formatters → compare previews → click to select

## Type of Change
- [x] Template improvement (optimisation, new feature)

## Template Checklist
N/A — configurator UI only, no template JSON changes.

## Testing
- JS syntax verified via `new Function()` check
- All 186 pytest tests pass
- Light/dark theme CSS included
- Configurator version bumped to v2.66

## Related Issues
Follow-up to #512 (formatter fix) and #513 (mobile UX improvements).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_