### PR TITLE
fix(configurator): convert device picker to responsive grid

### DIFF
--- a/configurator/src/js/app.js
+++ b/configurator/src/js/app.js
@@ -365,20 +365,25 @@ function renderOpts(def) {
   const std = (o, cls='') => `<div class="opt${cls}">${inp(o)}<label for="o_${o.v}" tabindex="0"><div class="opt-icon">${o.icon}</div>${body(o)}</label></div>`;
 
   if (def.layout === 'device-hybrid') {
+    // Responsive grid of equal-height device cards + a single contextual
+    // explanation banner for the currently selected device (neat + consistent
+    // with the vertical list steps, instead of a sideways-scrolling carousel).
+    const activeOpt = def.opts.find(o => o.v === S[key]);
     const cards = def.opts.map(o => {
       const active = (S[key] === o.v);
-      return `<div class="fmt-scroll-card" data-active="${active}" data-action="device-scroll-pick" data-val="${o.v}" style="flex:0 0 280px;height:auto">
-        <div class="fmt-scroll-head">
-          <div class="opt-icon" style="flex-shrink:0;margin-right:2px">${o.icon}</div>
-          <div style="min-width:0">
-            <span class="fmt-scroll-label" style="font-size:.84rem;color:${active?'#00d4ff':'#c9d1d9'}">${o.name}</span>${POPULAR_DEVICE_IDS.has(o.v)?'<span style="display:inline-block;margin-left:6px;padding:1px 6px;border-radius:4px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.18);color:#67e8f9;font-size:.5rem;font-weight:900;letter-spacing:.06em;text-transform:uppercase">Popular</span>':''}
-          </div>
+      return `<div class="device-card" data-active="${active}" data-action="device-scroll-pick" data-val="${o.v}" role="radio" aria-checked="${active}" tabindex="0">
+        <div class="device-card-head">
+          <div class="device-card-icon">${o.icon}</div>
+          <span class="device-card-check">${active ? ICO.check(15,'#00d4ff') : ''}</span>
         </div>
-        <div style="font-size:.65rem;color:#8b949e;line-height:1.45;margin-top:2px">${o.desc}</div>
-        ${o.help ? `<div style="font-size:.62rem;color:#4b5563;line-height:1.4;margin-top:6px;border-top:1px dashed rgba(255,255,255,.05);padding-top:6px;display:${active?'block':'none'}">${o.help}</div>` : ''}
+        <div class="device-card-name">${o.name}${POPULAR_DEVICE_IDS.has(o.v) ? '<span class="device-card-pop">Popular</span>' : ''}</div>
+        <div class="device-card-desc">${o.desc}</div>
       </div>`;
     }).join('');
-    return `<div class="scroll-fade-wrap" data-scroll-start="true" data-scroll-end="false"><div class="fmt-scroll" id="devScroll" style="padding-bottom:14px">${cards}</div></div>`;
+    const banner = activeOpt && activeOpt.help
+      ? `<div class="device-help-banner"><div class="device-help-banner-ico"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#00d4ff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="11" x2="12" y2="16"/><circle cx="12" cy="7.8" r="0.4" fill="#00d4ff"/></svg></div><div class="device-help-banner-text"><div class="device-help-banner-title">${activeOpt.name}</div><div class="device-help-banner-body">${activeOpt.help}</div></div></div>`
+      : '';
+    return `<div class="device-grid" role="radiogroup" aria-label="Your device">${cards}</div>${banner}`;
   }
   if (def.layout === 'formatter-picker') return fmtDropdownHtml() +
     `<button data-action="import-formatter" style="margin-top:10px;width:100%;padding:10px;border-radius:8px;border:1.5px dashed rgba(167,139,250,.3);background:transparent;color:#a78bfa;font-size:.78rem;font-weight:600;cursor:pointer;transition:all .15s" onmouseover="this.style.borderColor='rgba(167,139,250,.6)'" onmouseout="this.style.borderColor='rgba(167,139,250,.3)'">${S.customFormatter ? '⟳ Replace Custom Formatter' : ICO.folder(14,'#a78bfa')+' Import Custom Formatter'}</button>` +
@@ -660,14 +665,11 @@ function updateFmtFeatured() {
 }
 
 function updateDeviceScroll() {
-  document.querySelectorAll('.fmt-scroll-card[data-action="device-scroll-pick"]').forEach(card => {
-    const isSel = card.dataset.val === S.device;
-    card.dataset.active = isSel ? 'true' : 'false';
-    const helpPanel = card.querySelector('div[style*="line-height:1.4"]');
-    if (helpPanel) helpPanel.style.display = isSel ? 'block' : 'none';
-    const label = card.querySelector('.fmt-scroll-label');
-    if (label) label.style.color = isSel ? '#00d4ff' : '#c9d1d9';
-    if (isSel) card.scrollIntoView({ behavior:'smooth', block:'nearest', inline:'center' });
+  // The device picker is now a responsive grid rebuilt from state on every
+  // render, so there are no carousel snaps or inline help panels to sync.
+  // Just bring the selected card gently into view (vertical only).
+  document.querySelectorAll('.device-card[data-action="device-scroll-pick"]').forEach(card => {
+    if (card.dataset.val === S.device) card.scrollIntoView({ behavior:'smooth', block:'nearest' });
   });
 }
 function updateFmtReceiptRow() {
@@ -1997,6 +1999,12 @@ document.addEventListener('DOMContentLoaded', () => {
         if (S.device && !document.querySelector('input[name="device"]:checked')) render();
       }
     }
+  });
+  // Keyboard support for the device grid cards (Enter / Space activates them).
+  document.addEventListener('keydown', (e) => {
+    const card = e.target.closest && e.target.closest('.device-card');
+    if (!card) return;
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); card.click(); }
   });
   document.addEventListener('click', (e) => {
     const flashBtn = e.target.closest('button:not(:disabled):not(.btn-manifest):not(.btn-dl)');

--- a/configurator/src/styles/03-enhancements.css
+++ b/configurator/src/styles/03-enhancements.css
@@ -98,6 +98,47 @@
 [data-theme="light"] .svc-list-row input:checked+label .svc-row-ck{background:#0969da}
 [data-theme="light"] .btn-next,[data-theme="light"] .btn-dl{color:#04202b}
 [data-theme="light"] .btn-next:disabled{background:#f6f8fa;color:#8c959f;border:1px solid #d0d7de}
+/* ===== Device picker grid (Advanced Builder > Your Device) =====
+   Replaces the old sideways-scrolling carousel with a neat, responsive grid
+   of equal-height cards plus a single contextual explanation banner. */
+.device-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(152px,1fr));gap:9px;padding:2px}
+.device-card{position:relative;display:flex;flex-direction:column;gap:6px;padding:12px 12px 13px;border:1px solid rgba(255,255,255,.085);border-radius:14px;background:linear-gradient(145deg,#111b27,#0d151f);cursor:pointer;transition:border-color .18s,background .18s,transform .18s,box-shadow .18s;outline:none}
+.device-card:hover{border-color:rgba(0,212,255,.26);background:linear-gradient(145deg,#152331,#101923);transform:translateY(-1px)}
+.device-card:focus-visible{outline:2px solid rgba(0,212,255,.5);outline-offset:2px}
+.device-card[data-active="true"]{border-color:rgba(0,212,255,.43);background:radial-gradient(circle at 100% 0,rgba(0,212,255,.13),transparent 42%),linear-gradient(145deg,#102431,#0e1823);box-shadow:inset 3px 0 #00d4ff}
+.device-card-head{display:flex;align-items:flex-start;justify-content:space-between;gap:6px;min-height:32px}
+.device-card-icon{width:32px;height:32px;display:flex;align-items:center;justify-content:center;flex-shrink:0}
+.device-card-icon svg{width:32px;height:32px;display:block}
+.device-card-check{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;flex-shrink:0}
+.device-card-name{font-size:.82rem;font-weight:700;color:#dce6ed;line-height:1.25;display:flex;align-items:center;flex-wrap:wrap;gap:5px}
+.device-card[data-active="true"] .device-card-name{color:#67e8f9}
+.device-card-pop{display:inline-block;padding:1px 6px;border-radius:4px;background:rgba(0,212,255,.08);border:1px solid rgba(0,212,255,.18);color:#67e8f9;font-size:.5rem;font-weight:900;letter-spacing:.06em;text-transform:uppercase;line-height:1.4}
+.device-card-desc{font-size:.64rem;color:#718093;line-height:1.45}
+/* Contextual explanation banner for the currently selected device */
+.device-help-banner{display:flex;gap:11px;align-items:flex-start;margin-top:12px;padding:12px 14px;border:1px solid rgba(0,212,255,.16);border-radius:12px;background:radial-gradient(circle at 0% 0%,rgba(0,212,255,.06),transparent 55%),rgba(255,255,255,.02)}
+.device-help-banner-ico{flex-shrink:0;width:24px;height:24px;display:flex;align-items:center;justify-content:center;margin-top:1px}
+.device-help-banner-title{font-size:.78rem;font-weight:800;color:#67e8f9;letter-spacing:.02em;margin-bottom:4px}
+.device-help-banner-body{font-size:.71rem;color:#9aa6b2;line-height:1.55}
+.device-help-banner-body b{color:#cfe6ef;font-weight:700}
+/* Light theme */
+[data-theme="light"] .device-card{background:#f8fafc;border-color:#d7dee5}
+[data-theme="light"] .device-card:hover{background:#f2f6f9;border-color:rgba(9,105,218,.28)}
+[data-theme="light"] .device-card[data-active="true"]{background:rgba(9,105,218,.06);border-color:rgba(9,105,218,.4);box-shadow:inset 3px 0 #0969da}
+[data-theme="light"] .device-card-name{color:#1f2933}
+[data-theme="light"] .device-card[data-active="true"] .device-card-name{color:#0969da}
+[data-theme="light"] .device-card-pop{background:rgba(9,105,218,.08);border-color:rgba(9,105,218,.2);color:#0a6fcd}
+[data-theme="light"] .device-card-desc{color:#5f6c78}
+[data-theme="light"] .device-help-banner{background:rgba(9,105,218,.04);border-color:rgba(9,105,218,.2)}
+[data-theme="light"] .device-help-banner-title{color:#0969da}
+[data-theme="light"] .device-help-banner-body{color:#4a5663}
+[data-theme="light"] .device-help-banner-body b{color:#27323b}
+[data-theme="light"] .device-help-banner-ico svg{stroke:#0969da}
+/* Mobile: keep two tidy columns on narrow screens */
+@media(max-width:599px){
+  .device-grid{grid-template-columns:repeat(2,1fr);gap:9px}
+  .device-card{padding:11px 11px 12px}
+  .device-card-name{font-size:.8rem}
+}
 /* Theme toggle: dock bottom-right when the sidebar rail is visible (was overlapping the brand) */
 @media(min-width:1000px){
   .cb-sidebar:not(.sb-hidden)~#themeToggle{top:auto;left:auto;bottom:14px;right:14px}


### PR DESCRIPTION
## Description

Converts the Advanced Builder "Your Device" step from a sideways-scrolling carousel into a responsive grid of equal-height cards with a contextual explanation banner.

- **Grid layout:** `auto-fill` grid (`minmax(152px,1fr)`) — ~5 cols desktop, ~4 cols tablet, 2 cols mobile
- **Equal-height cards** with accent left-bar on selection
- **Explanation banner** below the grid shows selected device details
- **Dark + light themes** supported
- **Keyboard activation** via Enter/Space
- **Skip button** retained unchanged

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)
- [x] Template improvement (optimisation, new feature)

## Template Checklist
N/A — configurator-only changes, no template JSON modified.

## Testing
- 22 Node tests passed
- 21 static configurator validation checks passed
- 195 pytest tests passed
- 715 template checks passed, 0 errors, 0 warnings
- Standalone and web builds passed

## Related Issues
Follows PR #542 (`063e000`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_