### PR TITLE
fix: update tools page design and add deploy build validation

### DIFF
--- a/.github/workflows/deploy-configurator.yml
+++ b/.github/workflows/deploy-configurator.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'configurator/**'
+      - 'tools/**'
+      - 'account-tools/**'
+      - 'Formatters/**'
   workflow_dispatch:
 
 permissions:
@@ -14,7 +17,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -46,6 +49,18 @@ jobs:
       - name: Build
         working-directory: configurator
         run: npm run build
+
+      - name: Validate build output
+        working-directory: configurator
+        run: |
+          test -f dist/web/index.html || { echo "ERROR: dist/web/index.html missing"; exit 1; }
+          test -f dist/web/assets/app.js || { echo "ERROR: dist/web/assets/app.js missing"; exit 1; }
+          test -f dist/web/assets/app.css || { echo "ERROR: dist/web/assets/app.css missing"; exit 1; }
+          JS_SIZE=$(wc -c < dist/web/assets/app.js)
+          CSS_SIZE=$(wc -c < dist/web/assets/app.css)
+          echo "app.js: ${JS_SIZE} bytes | app.css: ${CSS_SIZE} bytes"
+          test "$JS_SIZE" -gt 100000 || { echo "ERROR: app.js too small (${JS_SIZE} bytes, expected 500KB+)"; exit 1; }
+          echo "Build output validated"
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/tools/index.html
+++ b/tools/index.html
@@ -3,31 +3,166 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-<title>Core Builds — Utility Deck</title>
+<title>Core Builds — Core Tools</title>
 <style>
-:root{color-scheme:dark;--bg:#070b11;--panel:#0d151f;--line:rgba(255,255,255,.085);--tx:#e8eef3;--muted:#758493;--cyan:#00d4ff;--violet:#a78bfa;--orange:#ff7a45;--green:#34d399}*{box-sizing:border-box}body{margin:0;min-height:100vh;padding:max(18px,env(safe-area-inset-top)) max(18px,env(safe-area-inset-right)) max(24px,env(safe-area-inset-bottom)) max(18px,env(safe-area-inset-left));background:radial-gradient(800px 420px at 14% -8%,rgba(0,212,255,.11),transparent 65%),radial-gradient(700px 360px at 92% 8%,rgba(167,139,250,.09),transparent 64%),var(--bg);color:var(--tx);font-family:Inter,ui-sans-serif,system-ui,sans-serif}.shell{width:min(1080px,100%);margin:auto}.mast{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:14px;padding:8px 2px 26px;border-bottom:1px solid var(--line)}.mark{width:44px;height:44px;display:grid;place-items:center}.mark svg{filter:drop-shadow(0 0 10px rgba(0,212,255,.35))}.brand{font:900 .92rem/1 ui-monospace,SFMono-Regular,monospace;letter-spacing:.12em;text-transform:uppercase}.brand span{color:var(--cyan)}.version{font:700 .58rem/1 ui-monospace,monospace;color:#526270;margin-top:7px;letter-spacing:.1em}.return{color:#9aa8b4;text-decoration:none;font:800 .68rem/1 ui-monospace,monospace;letter-spacing:.06em;text-transform:uppercase;padding:9px 11px;border:1px solid var(--line);border-radius:8px}.return:hover,.return:focus-visible{color:var(--cyan);border-color:rgba(0,212,255,.35);outline:none}.hero{display:grid;grid-template-columns:minmax(0,1.5fr) minmax(260px,.7fr);gap:34px;align-items:end;padding:52px 0 38px}.kicker{font:800 .62rem/1 ui-monospace,monospace;color:var(--cyan);letter-spacing:.16em;text-transform:uppercase;margin-bottom:13px}.hero h1{font:500 clamp(2.55rem,7vw,5.75rem)/.92 Georgia,'Times New Roman',serif;letter-spacing:-.055em;margin:0}.hero h1 em{font-style:normal;color:var(--cyan)}.hero-copy{border-left:1px solid rgba(0,212,255,.25);padding-left:18px;color:#8d9ba7;font-size:.82rem;line-height:1.65}.hero-copy strong{display:block;color:#dce6ed;margin-bottom:7px;font-size:.9rem}.deck-label{display:flex;align-items:center;gap:12px;margin:8px 0 14px;font:800 .62rem/1 ui-monospace,monospace;letter-spacing:.14em;text-transform:uppercase;color:#667582}.deck-label:after{content:'';height:1px;flex:1;background:var(--line)}.deck{display:grid;grid-template-columns:1.25fr .75fr;grid-template-areas:'builder backup' 'builder inspector' 'manager inspector';gap:12px}.unit{position:relative;overflow:hidden;min-height:210px;padding:22px;border:1px solid var(--line);border-radius:17px;background:linear-gradient(145deg,rgba(17,27,39,.96),rgba(10,16,24,.96));text-decoration:none;color:inherit;display:flex;flex-direction:column;transition:transform .18s,border-color .18s,background .18s}.unit:before{content:'';position:absolute;inset:13px;border:1px dashed rgba(255,255,255,.025);border-radius:12px;pointer-events:none}.unit:hover{transform:translateY(-2px);border-color:rgba(0,212,255,.3);background:linear-gradient(145deg,#132331,#0c1722)}.builder{grid-area:builder;min-height:432px}.backup{grid-area:backup}.inspector{grid-area:inspector}.manager{grid-area:manager}.unit-index{font:800 .58rem/1 ui-monospace,monospace;color:#52616e;letter-spacing:.13em}.unit-symbol{margin:auto 0;align-self:center;width:92px;height:92px;display:grid;place-items:center;border-radius:28px;transform:rotate(45deg);border:1px solid rgba(0,212,255,.3);background:radial-gradient(circle,rgba(0,212,255,.12),transparent 68%);box-shadow:0 0 36px rgba(0,212,255,.07)}.unit-symbol span{transform:rotate(-45deg);font:500 2.1rem Georgia,serif;color:var(--cyan)}.unit h2{font:500 1.45rem/1.05 Georgia,serif;margin:18px 0 7px}.builder h2{font-size:2.2rem}.unit p{color:var(--muted);font-size:.74rem;line-height:1.55;margin:0;max-width:52ch}.unit-foot{display:flex;justify-content:space-between;align-items:center;margin-top:auto;padding-top:20px;font:800 .58rem/1 ui-monospace,monospace;letter-spacing:.09em;text-transform:uppercase}.live{color:var(--green)}.open{color:var(--cyan)}.soon{color:#647382}.backup .unit-foot{color:var(--green)}.inspector{background:linear-gradient(160deg,rgba(27,20,42,.92),rgba(12,15,24,.97))}.inspector h2{color:#c7b8ff}.manager{background:linear-gradient(145deg,rgba(37,21,17,.82),rgba(12,16,23,.97))}.manager h2{color:#ffad89}.disabled{pointer-events:none}.rule{margin:38px 0 18px;height:1px;background:linear-gradient(90deg,transparent,var(--line),transparent)}.foot{display:flex;justify-content:space-between;gap:15px;flex-wrap:wrap;color:#53616d;font:700 .58rem/1.5 ui-monospace,monospace;letter-spacing:.06em;text-transform:uppercase}.foot a{color:#7e8d99;text-decoration:none}.foot a:hover{color:var(--cyan)}@media(max-width:760px){.hero{grid-template-columns:1fr;gap:20px;padding-top:38px}.hero-copy{max-width:500px}.deck{grid-template-columns:1fr;grid-template-areas:'builder' 'backup' 'inspector' 'manager'}.builder{min-height:340px}.unit{min-height:190px}.mast{grid-template-columns:auto 1fr}.return{grid-column:1/-1;text-align:center}.hero h1{font-size:clamp(3rem,16vw,4.7rem)}}@media(prefers-reduced-motion:reduce){.unit{transition:none}}
+:root{--th-bg:#0d1017;--th-card:#151923;--th-card-alt:#111720;--th-border:rgba(255,255,255,.06);--th-border-strong:rgba(255,255,255,.12);--th-tx:#e4e7ed;--th-tx2:#8b949e;--th-tx3:#6b7280;--th-tx4:#4b5563;--th-tx5:#374151;--th-accent:#00d4ff;--th-accent-bg:rgba(0,212,255,.08);--th-accent-border:rgba(0,212,255,.18);--th-green:#34d399;--th-green-bg:rgba(52,211,153,.06);--th-green-border:rgba(52,211,153,.2);--th-yellow:#fbbf24;--th-yellow-bg:rgba(251,191,36,.04);--th-yellow-border:rgba(245,158,11,.12);--th-red:#f87171;--th-red-bg:rgba(239,68,68,.04);--th-red-border:rgba(239,68,68,.15);--th-purple:#a78bfa;--th-purple-bg:rgba(168,85,247,.04);--th-purple-border:rgba(168,85,247,.18)}
+[data-theme="light"]{--th-bg:#f6f8fa;--th-card:#ffffff;--th-card-alt:#f6f8fa;--th-border:rgba(0,0,0,.09);--th-border-strong:rgba(0,0,0,.18);--th-tx:#1c2128;--th-tx2:#57606a;--th-tx3:#6b7280;--th-tx4:#8c959f;--th-tx5:#9ca3af;--th-accent:#0969da;--th-accent-bg:rgba(9,105,218,.06);--th-accent-border:rgba(9,105,218,.25);--th-green:#059669;--th-green-bg:rgba(5,150,105,.06);--th-green-border:rgba(5,150,105,.2);--th-yellow:#a16207;--th-yellow-bg:rgba(161,98,7,.04);--th-yellow-border:rgba(161,98,7,.15);--th-red:#dc2626;--th-red-bg:rgba(220,38,38,.04);--th-red-border:rgba(220,38,38,.12);--th-purple:#7c3aed;--th-purple-bg:rgba(124,58,237,.04);--th-purple-border:rgba(124,58,237,.18)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--th-bg);background-image:radial-gradient(ellipse at 15% 15%,rgba(0,212,255,0.06) 0%,transparent 45%),radial-gradient(ellipse at 85% 85%,rgba(168,85,247,0.05) 0%,transparent 45%);background-attachment:fixed;color:var(--th-tx);min-height:100dvh;display:flex;flex-direction:column;align-items:center;padding:24px 16px 20px}
+.wrap{width:100%;max-width:700px;flex:1;display:flex;flex-direction:column}
+.hdr-banner{display:flex;align-items:center;gap:14px;background:var(--th-card);border:1px solid var(--th-border);border-radius:14px;padding:16px 20px;margin-bottom:16px;position:relative;overflow:hidden}
+.hdr-banner::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,rgba(0,212,255,.3),transparent);pointer-events:none}
+.hdr-icon{width:46px;height:46px;flex-shrink:0;filter:drop-shadow(0 0 8px rgba(0,212,255,.4))}
+.hdr-divider{width:1px;height:44px;background:linear-gradient(to bottom,transparent,rgba(0,212,255,.35),transparent);flex-shrink:0}
+.hdr-text{display:flex;flex-direction:column;gap:1px}
+.hdr-title{font-size:1.55rem;font-weight:900;letter-spacing:-.02em;line-height:1;margin-bottom:2px}
+.hdr-core{color:var(--th-tx)}
+.hdr-builds{color:var(--th-accent)}
+.hdr-underline{height:1.5px;width:96px;background:linear-gradient(90deg,rgba(0,212,255,.55),transparent);border-radius:1px;margin-bottom:3px}
+.hdr-by{font-size:.63rem;letter-spacing:.16em;color:var(--th-tx4);margin-bottom:2px}
+.hdr-sub{font-size:.78rem;color:var(--th-tx3);line-height:1.3}
+.hdr-right{margin-left:auto;display:flex;align-items:center;gap:10px}
+.theme-toggle{background:none;border:1px solid var(--th-border);border-radius:8px;padding:8px 10px;cursor:pointer;color:var(--th-tx2);font-size:1rem;transition:all .15s;line-height:1}
+.theme-toggle:hover{border-color:var(--th-accent-border);color:var(--th-accent)}
+.back-link{color:var(--th-tx2);text-decoration:none;font-size:.78rem;font-weight:600;padding:8px 14px;border:1px solid var(--th-border);border-radius:8px;transition:all .15s;white-space:nowrap}
+.back-link:hover{color:var(--th-accent);border-color:var(--th-accent-border)}
+.section-label{display:flex;align-items:center;gap:10px;margin:24px 0 14px}
+.section-line{flex:1;height:1px;background:var(--th-border)}
+.section-title{font-size:.6rem;color:var(--th-tx4);text-transform:uppercase;letter-spacing:1.5px;font-weight:600}
+.tool-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.tool-card{background:var(--th-card);border:1px solid var(--th-border);border-radius:14px;padding:22px 20px 18px;position:relative;overflow:hidden;display:flex;flex-direction:column;gap:10px;text-decoration:none;color:inherit;transition:all .2s;backdrop-filter:blur(12px) saturate(180%);-webkit-backdrop-filter:blur(12px) saturate(180%)}
+.tool-card::after{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,rgba(0,212,255,.2),transparent);pointer-events:none}
+.tool-card:hover{transform:translateY(-2px);border-color:var(--th-accent-border);background:var(--th-card-alt)}
+.tool-card.disabled{pointer-events:none;opacity:.6}
+.tool-card-icon{width:40px;height:40px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;background:var(--th-accent-bg);border:1px solid var(--th-accent-border)}
+.tool-card-icon.purple{background:var(--th-purple-bg);border-color:var(--th-purple-border)}
+.tool-card-icon.yellow{background:var(--th-yellow-bg);border-color:var(--th-yellow-border)}
+.tool-card-icon.green{background:var(--th-green-bg);border-color:var(--th-green-border)}
+.tool-card h3{font-size:1rem;font-weight:800;color:var(--th-tx);line-height:1.2}
+.tool-card p{font-size:.76rem;color:var(--th-tx2);line-height:1.55;margin:0;flex:1}
+.tool-card-foot{display:flex;justify-content:space-between;align-items:center;margin-top:auto;padding-top:10px}
+.badge{display:inline-flex;align-items:center;gap:4px;font-size:.6rem;font-weight:700;padding:3px 9px;border-radius:6px;text-transform:uppercase;letter-spacing:.5px}
+.badge-green{color:var(--th-green);background:var(--th-green-bg);border:1px solid var(--th-green-border)}
+.badge-yellow{color:var(--th-yellow);background:var(--th-yellow-bg);border:1px solid var(--th-yellow-border)}
+.badge-purple{color:var(--th-purple);background:var(--th-purple-bg);border:1px solid var(--th-purple-border)}
+.badge-muted{color:var(--th-tx4);background:rgba(255,255,255,.02);border:1px solid var(--th-border)}
+.arrow{font-size:.72rem;font-weight:700;color:var(--th-accent)}
+.news-card{background:var(--th-card);border:1px solid var(--th-border);border-radius:14px;padding:22px 20px;position:relative;overflow:hidden;backdrop-filter:blur(12px) saturate(180%);-webkit-backdrop-filter:blur(12px) saturate(180%)}
+.news-card::after{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,rgba(0,212,255,.2),transparent);pointer-events:none}
+.news-card h3{font-size:.92rem;font-weight:800;color:var(--th-tx);margin-bottom:12px}
+.news-list{list-style:none;display:flex;flex-direction:column;gap:8px}
+.news-list li{font-size:.76rem;color:var(--th-tx2);line-height:1.55;padding-left:16px;position:relative}
+.news-list li::before{content:'';position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--th-accent);opacity:.5}
+.footer{margin-top:28px;padding-top:16px;border-top:1px solid var(--th-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-size:.68rem;color:var(--th-tx4)}
+.footer a{color:var(--th-tx3);text-decoration:none;transition:color .15s}
+.footer a:hover{color:var(--th-accent)}
+@media(max-width:560px){.tool-grid{grid-template-columns:1fr}.hdr-right{flex-direction:column;gap:6px}.hdr-banner{flex-wrap:wrap}}
+@media(prefers-reduced-motion:reduce){.tool-card{transition:none}}
 </style>
 </head>
 <body>
-<main class="shell">
-<header class="mast">
-  <div class="mark" aria-hidden="true"><svg width="42" height="42" viewBox="0 0 64 64" fill="none"><path d="M32 4 56 18v28L32 60 8 46V18L32 4Z" stroke="url(#g)" stroke-width="3"/><path d="m32 20 12 12-12 12-12-12 12-12Z" fill="url(#g)" opacity=".9"/><defs><linearGradient id="g" x1="9" y1="8" x2="55" y2="57"><stop stop-color="#00e5ff"/><stop offset=".55" stop-color="#a78bfa"/><stop offset="1" stop-color="#ff7043"/></linearGradient></defs></svg></div>
-  <div><div class="brand">Core <span>Builds</span></div><div class="version">Utility Deck · v0.1</div></div>
-  <a class="return" href="../">Return to Configurator</a>
-</header>
-<section class="hero">
-  <div><div class="kicker">Build / Maintain / Recover</div><h1>Your Core.<br><em>Your tools.</em></h1></div>
-  <div class="hero-copy"><strong>A focused workspace—not another setup wizard.</strong>Build configurations, protect existing accounts, and inspect problems without mixing credentials or destructive operations between tools.</div>
-</section>
-<div class="deck-label">Tool directory</div>
-<section class="deck">
-  <a class="unit builder" href="../"><span class="unit-index">01 / BUILD</span><div class="unit-symbol"><span>CB</span></div><h2>Template Builder</h2><p>Quick Install, Advanced Builder, device-aware profiles, existing-setup updates, partial exports, and protected manifest deployment.</p><div class="unit-foot"><span class="live">Operational</span><span class="open">Launch →</span></div></a>
-  <a class="unit backup" href="../account-tools/"><span class="unit-index">02 / SAFETY</span><h2>Addon Backup</h2><p>Read and download your current Stremio addon collection. No account changes.</p><div class="unit-foot"><span>Read-only</span><span>Open →</span></div></a>
-  <div class="unit inspector disabled" aria-disabled="true"><span class="unit-index">03 / VERIFY</span><h2>Template Inspector</h2><p>Local schema checks, plain-English findings, safe repairs, and compatibility reports.</p><div class="unit-foot"><span class="soon">In development</span><span>Local-first</span></div></div>
-  <div class="unit manager disabled" aria-disabled="true"><span class="unit-index">04 / ACCOUNT</span><h2>Account Manager</h2><p>Future restore, ordering, cloning, Cinemeta controls, exact diffs, and rollback.</p><div class="unit-foot"><span class="soon">Security review</span><span>Locked</span></div></div>
-</section>
-<div class="rule"></div>
-<footer class="foot"><span>Core Builds by Brevity</span><span><a href="https://github.com/brevityA/Core-Builds">GitHub</a> · <a href="https://www.reddit.com/r/CoreBuilds/">Core Crew</a> · <a href="https://core-builds.mintlify.app/">Documentation</a></span></footer>
+<main class="wrap">
+  <header class="hdr-banner">
+    <svg class="hdr-icon" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs><linearGradient id="cg" x1="10" y1="10" x2="90" y2="90"><stop stop-color="#00e5ff"/><stop offset=".5" stop-color="#a78bfa"/><stop offset="1" stop-color="#ff7043"/></linearGradient></defs>
+      <path d="M50 5 L93.3 30 L93.3 70 L50 95 L6.7 70 L6.7 30 Z" stroke="url(#cg)" stroke-width="3" fill="none" opacity=".7"/>
+      <path d="M50 25 L75 50 L50 75 L25 50 Z" fill="url(#cg)" opacity=".85"/>
+    </svg>
+    <div class="hdr-divider"></div>
+    <div class="hdr-text">
+      <div class="hdr-title"><span class="hdr-core">Core </span><span class="hdr-builds">Tools</span></div>
+      <div class="hdr-underline"></div>
+      <div class="hdr-by">by Brevity</div>
+      <div class="hdr-sub">Build, verify, back up, and manage</div>
+    </div>
+    <div class="hdr-right">
+      <button class="theme-toggle" id="themeToggle" title="Toggle light/dark theme" aria-label="Toggle theme">🌙</button>
+      <a class="back-link" href="../">← Configurator</a>
+    </div>
+  </header>
+
+  <div class="section-label">
+    <span class="section-title">Tools</span>
+    <div class="section-line"></div>
+  </div>
+
+  <section class="tool-grid">
+    <a class="tool-card" href="../">
+      <div class="tool-card-icon">🔧</div>
+      <h3>Template Builder</h3>
+      <p>Quick Install, Advanced Builder, device profiles, partial exports, and manifest deployment.</p>
+      <div class="tool-card-foot">
+        <span class="badge badge-green">Live</span>
+        <span class="arrow">Open →</span>
+      </div>
+    </a>
+    <a class="tool-card" href="../account-tools/">
+      <div class="tool-card-icon green">🛡️</div>
+      <h3>Addon Backup</h3>
+      <p>Read and download your current Stremio addon collection. No account changes — read-only.</p>
+      <div class="tool-card-foot">
+        <span class="badge badge-green">Live</span>
+        <span class="arrow">Open →</span>
+      </div>
+    </a>
+    <a class="tool-card" href="./inspector/">
+      <div class="tool-card-icon purple">🔍</div>
+      <h3>Template Inspector</h3>
+      <p>Paste a template JSON to get schema checks, plain-English findings, and compatibility reports.</p>
+      <div class="tool-card-foot">
+        <span class="badge badge-green">Live</span>
+        <span class="arrow">Open →</span>
+      </div>
+    </a>
+    <div class="tool-card disabled">
+      <div class="tool-card-icon yellow">📋</div>
+      <h3>Account Manager</h3>
+      <p>Restore, ordering, cloning, Cinemeta controls, diffs, and rollback — coming soon.</p>
+      <div class="tool-card-foot">
+        <span class="badge badge-muted">Planned</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-label">
+    <span class="section-title">What's New</span>
+    <div class="section-line"></div>
+  </div>
+
+  <div class="news-card">
+    <h3>Latest Updates — v2.81</h3>
+    <ul class="news-list">
+      <li>Health Score ring with letter grade on the Review step</li>
+      <li>Template Versioning — coreBuildsVersion and generatedAt metadata</li>
+      <li>Full Stack Install — one-click AIOMetadata + Cinemeta patch</li>
+      <li>family-v4 default formatter with bitrate, release group, and seeders</li>
+      <li>Template Inspector now live — paste JSON for instant validation</li>
+      <li>Debug modules — error boundary, state guard, network resilience</li>
+    </ul>
+  </div>
+
+  <footer class="footer">
+    <span>Core Builds by Brevity</span>
+    <span>
+      <a href="https://github.com/brevityA/Core-Builds">GitHub</a> ·
+      <a href="https://www.reddit.com/r/CoreBuilds/">Core Crew</a> ·
+      <a href="https://core-builds.mintlify.app/">Docs</a>
+    </span>
+  </footer>
 </main>
+<script>
+(function(){
+  const btn = document.getElementById('themeToggle');
+  const root = document.documentElement;
+  const stored = localStorage.getItem('cb-theme');
+  if (stored === 'light') { root.dataset.theme = 'light'; btn.textContent = '☀️'; }
+  btn.addEventListener('click', function(){
+    const next = root.dataset.theme === 'light' ? 'dark' : 'light';
+    root.dataset.theme = next;
+    btn.textContent = next === 'light' ? '☀️' : '🌙';
+    localStorage.setItem('cb-theme', next);
+  });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Tools page redesigned** — replaced the old "Utility Deck" design (Georgia serif, diamond symbols, v0.1) with the configurator-matched design system (`--th-bg`, `--th-card`, `--th-accent` CSS variables, glassmorphic cards, badge system, light/dark theme toggle)
- **Template Inspector now linked as live** — card links to `./inspector/` with a green "Live" badge instead of the old disabled "In development" state
- **Deploy workflow hardened** — added a build output validation step that checks `dist/web/index.html`, `app.js`, and `app.css` exist and that `app.js` exceeds 100KB (prevents deploying empty/broken builds)
- **Deploy triggers expanded** — workflow now also triggers on changes to `tools/**`, `account-tools/**`, `Formatters/**` (was only `configurator/**`)
- **Concurrency** — changed `cancel-in-progress` from `false` to `true`

## Test plan

- [ ] Verify tools page renders correctly in both light and dark themes
- [ ] Verify all 4 tool cards display (Builder → `../`, Backup → `../account-tools/`, Inspector → `./inspector/`, Account Manager → disabled/planned)
- [ ] Verify "What's New" section shows v2.81 features
- [ ] Verify deploy workflow YAML is valid and contains the build validation step
- [ ] After merge, manually trigger deploy via GitHub Actions → "Run workflow" on `main`
- [ ] Confirm live site shows v2.81 configurator after deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_