### PR TITLE
fix: update wrangler.toml entry point to worker.js

### DIFF
--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,5 +1,5 @@
 name = "core-builds-counter"
-main = "counter.js"
+main = "worker.js"
 compatibility_date = "2024-09-25"
 
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary

- `wrangler.toml` still pointed to `counter.js` (the old filename) — updated to `worker.js` so `wrangler deploy` works

## Test plan

- [ ] Run `wrangler deploy` from `cloudflare-worker/` — should deploy successfully
- [ ] Test `/contact` endpoint after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_