### PR TITLE
fix: correct worker name to core-builds-cors-proxy

### DIFF
--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "core-builds-counter"
+name = "core-builds-cors-proxy"
 main = "worker.js"
 compatibility_date = "2024-09-25"
 


### PR DESCRIPTION
## Summary

- `wrangler.toml` had `name = "core-builds-counter"` but the contact widget and all proxy routes target `core-builds-cors-proxy.tlorenzato26.workers.dev`
- Changed to `name = "core-builds-cors-proxy"` so the deploy workflow pushes to the correct worker

## Test plan

- [ ] Merge → deploy workflow runs → worker deployed to `core-builds-cors-proxy`
- [ ] Contact widget sends successfully (no more "Failed to send")
- [ ] Existing proxy/paste routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_