### PR TITLE
Add Discord release announcement workflows

### DIFF
--- a/.github/workflows/all_releases.yml
+++ b/.github/workflows/all_releases.yml
@@ -1,0 +1,13 @@
+name: All Releases
+on:
+  release:
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post releases
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' -d '{"content":"Release: ${{ github.event.release.name }}"}' $WEBHOOK_URL

--- a/.github/workflows/all_releases.yml
+++ b/.github/workflows/all_releases.yml
@@ -1,13 +1,19 @@
 name: All Releases
 on:
   release:
+    types: [created, edited, deleted, unpublished, prereleased, released]
+
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Post releases
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_NAME: ${{ github.event.release.name }}
         run: |
-          curl -X POST -H 'Content-type: application/json' -d '{"content":"Release: ${{ github.event.release.name }}"}' $WEBHOOK_URL
+          jq -n --arg name "$RELEASE_NAME" '{"content": "Release: \($name)"}' \
+            | curl -X POST -H 'Content-type: application/json' -d @- \
+              --fail-with-body --silent --show-error "$WEBHOOK_URL"

--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -2,10 +2,17 @@ name: Announce
 on:
   release:
     types: [published]
+
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Post to Discord
-        run: curl -X POST -H 'Content-type: application/json' --data '{"content":"New release!"}' ${{ secrets.DISCORD_WEBHOOK_URL }}
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"content":"New release!"}' \
+            --fail-with-body --silent --show-error "$WEBHOOK_URL"

--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -1,0 +1,11 @@
+name: Announce
+on:
+  release:
+    types: [published]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post to Discord
+        run: curl -X POST -H 'Content-type: application/json' --data '{"content":"New release!"}' ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Description
Two GitHub Actions workflows for posting Discord notifications on GitHub releases:
- **`announce.yml`** — triggers on `published` releases, posts a "New release!" message
- **`all_releases.yml`** — triggers on all release events, posts the release name

Both use the `DISCORD_WEBHOOK_URL` repository secret.

## Type of Change
- [x] Workflow / infrastructure

## Template Checklist
N/A — no template changes.

## Testing
Workflow syntax validated. Requires `DISCORD_WEBHOOK_URL` to be configured as a GitHub repository secret.

## Related Issues
N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_