### PR TITLE
Add sync docs to Discord workflow

### DIFF
--- a/.github/workflows/sync-docs-discord.yml
+++ b/.github/workflows/sync-docs-discord.yml
@@ -1,0 +1,84 @@
+name: Sync Docs to Discord
+
+on:
+  workflow_dispatch:
+    inputs:
+      group:
+        description: 'Post a specific group only (leave empty for all)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: docs
+
+      - name: Post docs to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GROUP_FILTER: ${{ inputs.group }}
+        run: |
+          BASE_URL="https://core-builds.mintlify.app"
+          COLOR=591103  # #00d4ff in decimal
+
+          # Parse navigation groups and pages from docs.json
+          groups=$(jq -c '.navigation.tabs[0].groups[]' docs/docs.json)
+
+          total=0
+          echo "$groups" | while read -r group; do
+            group_name=$(echo "$group" | jq -r '.group')
+
+            # Skip if filter is set and doesn't match
+            if [ -n "$GROUP_FILTER" ] && [ "$group_name" != "$GROUP_FILTER" ]; then
+              continue
+            fi
+
+            pages=$(echo "$group" | jq -r '.pages[]')
+
+            # Build embed fields from pages in this group
+            fields="[]"
+            for slug in $pages; do
+              mdx_file="docs/${slug}.mdx"
+              if [ -f "$mdx_file" ]; then
+                title=$(grep -m1 '^title:' "$mdx_file" | sed 's/^title: *"\{0,1\}\([^"]*\)"\{0,1\}/\1/')
+                desc=$(grep -m1 '^description:' "$mdx_file" | sed 's/^description: *"\{0,1\}\([^"]*\)"\{0,1\}/\1/' | head -c 100)
+              fi
+              title="${title:-$slug}"
+              desc="${desc:-}"
+
+              fields=$(echo "$fields" | jq \
+                --arg name "$title" \
+                --arg value "[Read →](${BASE_URL}/${slug})$(if [ -n "$desc" ]; then echo " — ${desc}"; fi)" \
+                '. + [{ name: $name, value: $value, inline: false }]')
+            done
+
+            # Post one embed per group
+            jq -n \
+              --arg group_name "$group_name" \
+              --argjson fields "$fields" \
+              --argjson color "$COLOR" \
+              '{
+                embeds: [{
+                  title: ("📚 " + $group_name),
+                  description: "Documentation pages",
+                  color: $color,
+                  fields: $fields,
+                  footer: { text: "Core Builds Docs" }
+                }]
+              }' | curl -X POST -H 'Content-type: application/json' -d @- \
+                --fail-with-body --silent --show-error "$WEBHOOK_URL"
+
+            page_count=$(echo "$fields" | jq 'length')
+            total=$((total + page_count))
+            echo "Posted group: $group_name ($page_count pages)"
+            sleep 1
+          done
+
+          echo "Synced docs to Discord."

--- a/.github/workflows/sync-docs-discord.yml
+++ b/.github/workflows/sync-docs-discord.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Post docs to Discord
         env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_DOCS_WEBHOOK_URL }}
           GROUP_FILTER: ${{ inputs.group }}
         run: |
           BASE_URL="https://core-builds.mintlify.app"


### PR DESCRIPTION
## Summary
- Adds `sync-docs-discord.yml` — a manual workflow that posts all Mintlify docs pages to Discord as rich embeds
- Groups pages by navigation section (Getting Started, Configurator, Services & Devices, etc.)
- Each embed shows page titles with direct links and descriptions
- Optional `group` input to post only a specific section (e.g. "Formatters")
- Uses the existing `DISCORD_WEBHOOK_URL` secret with 1s rate-limit delay between posts

## Test plan
- [ ] Trigger workflow manually with no group filter — verify all 7 groups post as embeds
- [ ] Trigger with a specific group (e.g. "Support") — verify only that group posts
- [ ] Verify embed fields show correct page titles and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_