### PR TITLE
ci: Vidhin05 upstream drift watch + tracking issue

### DIFF
--- a/.github/workflows/upstream-drift-watch.yml
+++ b/.github/workflows/upstream-drift-watch.yml
@@ -1,0 +1,85 @@
+name: Upstream Drift Watch
+
+# Compares the live Vidhin05/Releases-Regex files (which all active templates
+# live-sync) against the pinned snapshots in Filtering/upstream/. Opens a single
+# tracking issue on drift so the change becomes a reviewed event.
+#
+# Soft-fails on upstream outage (script exit 0 with warning) so network blips
+# never spam issues.
+
+on:
+  schedule:
+    - cron: '17 18 * * *'   # daily, off-the-hour
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Compare live upstream against pinned snapshots
+        id: drift
+        run: |
+          set +e
+          node scripts/check_upstream_drift.mjs 2>&1 | tee /tmp/drift_report.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Open or refresh drift issue
+        if: steps.drift.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="upstream-drift"
+          gh label create "$LABEL" --color "D29922" --description "Vidhin05 upstream changed — review snapshots" 2>/dev/null || true
+
+          REPORT=$(head -c 4000 /tmp/drift_report.txt)
+          BODY="## ⚠️ Vidhin05 upstream drift detected
+
+The ranked regex / ranked expression files that all active templates live-sync have
+changed relative to our pinned snapshots in \`Filtering/upstream/\`.
+
+Template behaviour changes immediately whether we act or not — this issue exists so
+the change is reviewed.
+
+\`\`\`
+${REPORT}
+\`\`\`
+
+**Response checklist**
+- [ ] Review the diff upstream (linked in the report)
+- [ ] Re-pin snapshots: \`node scripts/check_upstream_drift.mjs --update\` and commit
+- [ ] Check \`Filtering/ranked-regex-patterns.json\` still matches the elfhosted whitelist (drifted pattern strings cause import rejections)
+- [ ] Re-generate affected templates if scoring changed materially
+- [ ] Close this issue once snapshots are re-pinned"
+
+          EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Drift still present as of $(date -u +%Y-%m-%dT%H:%M:%SZ):
+
+\`\`\`
+${REPORT}
+\`\`\`"
+          else
+            gh issue create --title "Upstream drift: Vidhin05 Releases-Regex changed" --label "$LABEL" --body "$BODY"
+          fi
+
+      - name: Close stale drift issue if back in sync
+        if: steps.drift.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "upstream-drift" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Upstream is back in sync with the pinned snapshots (verified $(date -u +%Y-%m-%dT%H:%M:%SZ))."
+          fi

--- a/Filtering/upstream/README.md
+++ b/Filtering/upstream/README.md
@@ -1,0 +1,34 @@
+# Upstream snapshots — Vidhin05/Releases-Regex
+
+These files are **pinned snapshots of third-party upstream**, not Core Builds content:
+
+| Snapshot | Upstream |
+|---|---|
+| `vidhin05-regexes.snapshot.json` | [`Vidhin05/Releases-Regex@main/English/regexes.json`](https://github.com/Vidhin05/Releases-Regex/blob/main/English/regexes.json) |
+| `vidhin05-expressions.snapshot.json` | [`Vidhin05/Releases-Regex@main/English/expressions.json`](https://github.com/Vidhin05/Releases-Regex/blob/main/English/expressions.json) |
+
+## Why they exist
+
+41/48 active templates — and every configurator-generated template — live-sync ranked
+regex and ranked stream expressions from these upstream URLs, and elfhosted validates
+regex patterns against `regexes.json` by **exact string equality**. Any push upstream
+changes ranking for every Core Builds user immediately.
+
+The templates sync `@main` regardless of what we do here, so these snapshots don't
+*pin* behaviour — they make upstream changes a **reviewed event**: the
+`upstream-drift-watch.yml` workflow compares live upstream against these files daily
+and opens an issue on drift, so we can review changes, re-generate affected templates,
+and update `Filtering/ranked-regex-patterns.json` (the inline Core Builds subset that
+must keep matching the whitelist) instead of finding out from user reports.
+
+## Checking and updating
+
+```bash
+node scripts/check_upstream_drift.mjs            # compare live upstream vs snapshots
+node scripts/check_upstream_drift.mjs --update   # re-pin after reviewing the drift
+```
+
+After `--update`: review `git diff`, commit the snapshots, and check whether
+`Filtering/ranked-regex-patterns.json` needs re-syncing with any renamed/changed
+whitelist patterns (drifted pattern strings cause "X/183 regexes not allowed" import
+errors on elfhosted).

--- a/Filtering/upstream/vidhin05-expressions.snapshot.json
+++ b/Filtering/upstream/vidhin05-expressions.snapshot.json
@@ -1,0 +1,1217 @@
+[
+  {
+    "expression": "/*#𝚅𝚒𝚍𝚑𝚒𝚗'𝚜 𝙴𝚗𝚐𝚕𝚒𝚜𝚑 𝚁𝚊𝚗𝚔𝚎𝚍 𝚂𝚝𝚛𝚎𝚊𝚖 𝙴𝚡𝚙𝚛𝚎𝚜𝚜𝚒𝚘𝚗𝚜 (𝚜𝚢𝚗𝚌𝚎𝚍)*/ []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Remux T1*/ queryType=='movie' ? regexMatched(streams, 'Radarr Remux T1') : []",
+    "score": 1950,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Remux T1*/ queryType=='series' ? regexMatched(streams, 'Sonarr Remux T1') : []",
+    "score": 1900,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Remux T2*/ queryType=='movie' ? regexMatched(streams, 'Radarr Remux T2') : []",
+    "score": 1900,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Remux T2*/ queryType=='series' ? regexMatched(streams, 'Sonarr Remux T2') : []",
+    "score": 1850,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Remux T3*/ queryType=='movie' ? regexMatched(streams, 'Radarr Remux T3') : []",
+    "score": 1850,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*UHD Bluray T1*/ queryType=='movie' ? regexMatched(resolution(streams, '2160p'), 'Radarr UHD Bluray T1') : []",
+    "score": 1800,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*HD Bluray T1*/ queryType=='movie' ? regexMatched(negate(resolution(streams, '2160p'), streams), 'Radarr HD Bluray T1') : []",
+    "score": 1800,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*UHD Bluray T2*/ queryType=='movie' ? regexMatched(resolution(streams, '2160p'), 'Radarr UHD Bluray T2') : []",
+    "score": 1750,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*HD Bluray T2*/ queryType=='movie' ? regexMatched(negate(resolution(streams, '2160p'), streams), 'Radarr HD Bluray T2') : []",
+    "score": 1750,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*UHD Bluray T3*/ queryType=='movie' ? regexMatched(resolution(streams, '2160p'), 'Radarr UHD Bluray T3') : []",
+    "score": 1700,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*HD Bluray T3*/ queryType=='movie' ? regexMatched(negate(resolution(streams, '2160p'), streams), 'Radarr HD Bluray T3') : []",
+    "score": 1700,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*HD Bluray T1*/ queryType=='series' ? regexMatched(negate(resolution(streams, '2160p'), streams), 'Sonarr HD Bluray T1') : []",
+    "score": 1800,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*HD Bluray T2*/ queryType=='series' ? regexMatched(negate(resolution(streams, '2160p'), streams), 'Sonarr HD Bluray T2') : []",
+    "score": 1750,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Web T1*/ queryType=='movie' ? regexMatched(streams, 'Radarr Web T1', 'Web T1') : []",
+    "score": 1700,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Web T1*/ queryType=='series' ? regexMatched(streams, 'Sonarr Web T1', 'Web T1') : []",
+    "score": 1700,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Web T2*/ queryType=='movie' ? regexMatched(streams, 'Radarr Web T2') : []",
+    "score": 1650,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Web T2*/ queryType=='series' ? regexMatched(streams, 'Sonarr Web T2') : []",
+    "score": 1650,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Web T3*/ queryType=='movie' ? regexMatched(streams, 'Radarr Web T3') : []",
+    "score": 1600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Web T3*/ queryType=='series' ? regexMatched(streams, 'Sonarr Web T3') : []",
+    "score": 1600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Web Scene*/ queryType=='series' ? regexMatched(streams, 'Web Scene') : []",
+    "score": 1600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Asian T1*/ queryType=='movie' ? regexMatched(streams, 'Asian Tier 01') : []",
+    "score": 1650,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Asian T1*/ queryType=='series' ? regexMatched(streams, 'Asian Tier 01') : []",
+    "score": 1650,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Asian T2*/ queryType=='movie' ? regexMatched(streams, 'Asian Tier 02') : []",
+    "score": 1600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Asian T2*/ queryType=='series' ? regexMatched(streams, 'Asian Tier 02') : []",
+    "score": 1600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Asian T3*/ queryType=='movie' ? regexMatched(streams, 'Asian Tier 03') : []",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Asian T3*/ queryType=='series' ? regexMatched(streams, 'Asian Tier 03') : []",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*SeaDex Best*/ isAnime ? seadex(streams, 'best') : []",
+    "score": 2000,
+    "enabled": true
+  },
+  {
+    "expression": "/*SeaDex Alt*/ isAnime ? negate(seadex(streams, 'best'), seadex(streams)) : []",
+    "score": 1750,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T1*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T1')) : []",
+    "score": 1400,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T2*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T2')) : []",
+    "score": 1300,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T3*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T3')) : []",
+    "score": 1200,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T4*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T4')) : []",
+    "score": 1100,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Remux T1*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'Radarr Remux T1')) : []",
+    "score": 975,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*Remux T1*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'Sonarr Remux T1')) : []",
+    "score": 975,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Remux T2*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'Radarr Remux T2')) : []",
+    "score": 950,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*Remux T2*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'Sonarr Remux T2')) : []",
+    "score": 950,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T5*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T5')) : []",
+    "score": 1000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Remux T3*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'Radarr Remux T3')) : []",
+    "score": 925,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T6*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T6')) : []",
+    "score": 900,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T7*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T7')) : []",
+    "score": 800,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*BD T8*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime BD T8')) : []",
+    "score": 700,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T1*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T1')) : []",
+    "score": 600,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T2*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T2')) : []",
+    "score": 500,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T3*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T3')) : []",
+    "score": 400,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T4*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T4')) : []",
+    "score": 300,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T5*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T5')) : []",
+    "score": 200,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Web T6*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Web T6')) : []",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*Repack*/ isAnime ? [] : regexMatched(negate(regexMatched(streams, 'Repack2', 'Repack3'), streams), 'Repack/Proper')",
+    "score": 5,
+    "enabled": true
+  },
+  {
+    "expression": "/*Repack2*/ isAnime ? [] : regexMatched(negate(regexMatched(streams, 'Repack3'),streams), 'Repack2')",
+    "score": 6,
+    "enabled": true
+  },
+  {
+    "expression": "/*Repack3*/ isAnime ? [] : regexMatched(streams, 'Repack3')",
+    "score": 7,
+    "enabled": true
+  },
+  {
+    "expression": "/*v0*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'v0')) : []",
+    "score": -51,
+    "enabled": true
+  },
+  {
+    "expression": "/*v1*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'v1')) : []",
+    "score": 1,
+    "enabled": true
+  },
+  {
+    "expression": "/*v2*/ isAnime ? negate(seadex(streams), negate(regexMatched(streams, 'v3', 'v4', 'Repack2', 'Repack3'), regexMatched(streams, 'v2', 'Repack/Proper'))) : []",
+    "score": 2,
+    "enabled": true
+  },
+  {
+    "expression": "/*v3*/ isAnime ? negate(seadex(streams), negate(regexMatched(streams, 'v4', 'Repack3'), regexMatched(streams, 'v3', 'Repack2'))) : []",
+    "score": 3,
+    "enabled": true
+  },
+  {
+    "expression": "/*v4*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'v4', 'Repack3')) : []",
+    "score": 4,
+    "enabled": true
+  },
+  {
+    "expression": "/*HD*/ isAnime ? [] : resolution(streams, '720p')",
+    "score": 5,
+    "enabled": true
+  },
+  {
+    "expression": "/*FHD*/ isAnime ? [] : resolution(streams, '1080p')",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*4K*/ isAnime ? [] : resolution(streams, '2160p')",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*126811*/ queryType=='movie' ? regexMatched(streams, '126811') : []",
+    "score": 51,
+    "enabled": true
+  },
+  {
+    "expression": "/*FLUX*/ isAnime ? [] : regexMatched(streams, 'FLUX')",
+    "score": 51,
+    "enabled": false
+  },
+  {
+    "expression": "/*#Radarr*/ /*SiC*/ queryType=='movie' ? regexMatched(streams, 'SiC') : []",
+    "score": 51,
+    "enabled": false
+  },
+  {
+    "expression": "/*#Radarr*/ /*FraMeSToR*/ queryType=='movie' ? regexMatched(streams, 'FraMeSToR') : []",
+    "score": 101,
+    "enabled": false
+  },
+  {
+    "expression": "/*#Radarr*/ /*TheFarm*/ queryType=='movie' ? regexMatched(streams, 'TheFarm') : []",
+    "score": 231,
+    "enabled": false
+  },
+  {
+    "expression": "/*#Radarr*/ /*hallowed*/ queryType=='movie' ? regexMatched(streams, 'hallowed') : []",
+    "score": 600,
+    "enabled": false
+  },
+  {
+    "expression": "/*#Radarr*/ /*BHDStudio*/ queryType=='movie' ? regexMatched(streams, 'BHDStudio') : []",
+    "score": 1000,
+    "enabled": false
+  },
+  {
+    "expression": "/*HDR*/ isAnime ? [] : merge(regexMatched(streams, 'HDR'), visualTag(streams, 'HDR', 'HDR10', 'HDR10+'))",
+    "score": 500,
+    "enabled": true
+  },
+  {
+    "expression": "/*DV*/ isAnime ? [] : visualTag(streams, 'DV')",
+    "score": 1000,
+    "enabled": true
+  },
+  {
+    "expression": "/*HDR10+ Boost*/ isAnime ? [] : visualTag(streams, 'HDR10+')",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*DV (Disk)*/ queryType=='movie' ? negate(releaseGroup(streams, 'HYBRID'), regexMatched(streams, 'DV (Disk)')) : []",
+    "score": 101,
+    "enabled": true
+  },
+  {
+    "expression": "/*INTERNAL*/ isAnime ? [] : regexMatched(streams, 'INTERNAL')",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*TrueHD ATMOS*/ queryType=='movie' ? merge(audioTag(audioTag(streams, 'Atmos'), 'TrueHD'), negate(audioTag(streams, 'DD', 'DD+', 'DTS', 'DTS:X', 'FLAC'), merge(regexMatched(audioTag(streams, 'Atmos'), 'Atmos Exclude Groups'), regexMatched(audioTag(streams, 'TrueHD'), 'TrueHD Exclude Groups'), regexMatched(regexMatched(streams, 'TrueHD Exclude Groups'), 'Atmos Exclude Groups')))) : []",
+    "score": 5000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*TrueHD ATMOS*/ queryType=='series' ? audioTag(audioTag(streams, 'Atmos'), 'TrueHD') : []",
+    "score": 5000,
+    "enabled": true
+  },
+  {
+    "expression": "/*DTS X*/ isAnime ? [] : audioTag(streams, 'DTS:X')",
+    "score": 4500,
+    "enabled": true
+  },
+  {
+    "expression": "/*DD+ ATMOS*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD'), audioTag(audioTag(streams, 'DD+'), 'Atmos'))",
+    "score": 3000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*ATMOS*/ queryType=='movie' ? negate(merge(rseMatched(streams, 'DD+ ATMOS', 'TrueHD ATMOS'), regexMatched(streams, 'Atmos Exclude Groups')), audioTag(streams, 'Atmos')) : []",
+    "score": 3000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*ATMOS*/ queryType=='series' ? negate(rseMatched(streams, 'DD+ ATMOS', 'TrueHD ATMOS'), audioTag(streams, 'Atmos')) : []",
+    "score": 3000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*TrueHD*/ queryType=='movie' ? negate(merge(audioTag(streams, 'Atmos'), regexMatched(streams, 'TrueHD Exclude Groups')), audioTag(streams, 'TrueHD')) : []",
+    "score": 2750,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*TrueHD*/ queryType=='series' ? negate(audioTag(streams, 'Atmos'), audioTag(streams, 'TrueHD')) : []",
+    "score": 2750,
+    "enabled": true
+  },
+  {
+    "expression": "/*DTS-HD MA*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD', 'Atmos', 'DTS:X'), audioTag(streams, 'DTS-HD MA'))",
+    "score": 2500,
+    "enabled": true
+  },
+  {
+    "expression": "/*FLAC*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD', 'Atmos'), audioTag(streams, 'FLAC'))",
+    "score": 2250,
+    "enabled": true
+  },
+  {
+    "expression": "/*DTS-HD HRA*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD', 'Atmos', 'DTS:X', 'FLAC'), audioTag(streams, 'DTS-HD'))",
+    "score": 2000,
+    "enabled": true
+  },
+  {
+    "expression": "/*DD+*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD', 'Atmos', 'FLAC'), audioTag(streams, 'DD+'))",
+    "score": 1750,
+    "enabled": true
+  },
+  {
+    "expression": "/*DTS-ES*/ isAnime ? [] : negate(audioTag(streams, 'TrueHD', 'Atmos', 'DD+', 'DTS:X', 'FLAC'), audioTag(streams, 'DTS-ES'))",
+    "score": 1500,
+    "enabled": true
+  },
+  {
+    "expression": "/*DTS*/ isAnime ? [] : negate(audioTag(streams, 'DTS-HD MA', 'DTS-HD', 'DTS-ES', 'DD+', 'TrueHD', 'Atmos', 'DTS:X', 'FLAC'), audioTag(streams, 'DTS'))",
+    "score": 1250,
+    "enabled": true
+  },
+  {
+    "expression": "/*AAC*/ isAnime ? [] : negate(audioTag(streams, 'DTS', 'DD+', 'FLAC', 'TrueHD', 'Atmos'), audioTag(streams, 'AAC'))",
+    "score": 1000,
+    "enabled": true
+  },
+  {
+    "expression": "/*DD*/ isAnime ? [] : negate(audioTag(streams, 'DD+', 'TrueHD', 'Atmos', 'DTS', 'FLAC', 'AAC'), audioTag(streams, 'DD'))",
+    "score": 750,
+    "enabled": true
+  },
+  {
+    "expression": "/*Opus*/ isAnime ? [] : audioTag(streams, 'OPUS')",
+    "score": 250,
+    "enabled": true
+  },
+  {
+    "expression": "/*IMAX*/ queryType=='movie' ? negate(regexMatched(streams, 'IMAX Enhanced'),regexMatched(streams, 'IMAX')) : []",
+    "score": 800,
+    "enabled": true
+  },
+  {
+    "expression": "/*IMAX Enhanced*/ queryType=='movie' ? regexMatched(streams, 'IMAX Enhanced') : []",
+    "score": 800,
+    "enabled": true
+  },
+  {
+    "expression": "/*Criterion Collection*/ queryType=='movie' ? regexMatched(negate(releaseGroup(streams, 'Criterion'), quality(streams, 'BluRay', 'DVDRip')), 'Criterion Collection') : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*Masters of Cinema*/ queryType=='movie' ? regexMatched(streams, 'Masters of Cinema') : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*Open Matte*/ queryType=='movie' ? regexMatched(streams, 'Open Matte') : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*Remaster*/ queryType=='movie' ? negate(regexMatched(streams, '4K'), regexMatched(streams, 'Remaster')) : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*4K Remaster*/ queryType=='movie' ? regexMatched(regexMatched(negate(resolution(streams, '2160p'), streams), '4K'), 'Remaster') : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*Hybrid*/ queryType=='movie' ? regexMatched(negate(releaseGroup(streams, 'HYBRID'), streams), 'Hybrid') : []",
+    "score": 100,
+    "enabled": true
+  },
+  {
+    "expression": "/*Anniversary*/ queryType=='movie' ? regexMatched(streams, 'Anniversary Edition') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*DBOX*/ queryType=='movie' ? regexMatched(streams, 'Dragon Box') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Color Corrected*/ queryType=='movie' ? regexMatched(streams, 'Color Corrected') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Ultimate*/ queryType=='movie' ? regexMatched(streams, 'Ultimate Edition') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Extended*/ queryType=='movie' ? regexMatched(streams, 'Extended Edition') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Director's*/ queryType=='movie' ? regexMatched(streams, 'Director\\'s Cut') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Collector's*/ queryType=='movie' ? regexMatched(streams, 'Collector\\'s Edition') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Diamond*/ queryType=='movie' ? regexMatched(streams, 'Diamond Edition') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Special Edition*/ queryType=='movie' ? negate(regexMatched(streams, 'IMAX Edition', 'Open Matte', 'Theatrical Cut', 'Extended Clip', 'Anniversary Edition', 'Ultimate Edition', 'Extended Edition', 'Director\\'s Cut', 'Collector\\'s Edition', 'Diamond Edition'),regexMatched(streams, 'Special Edition')) : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Theatrical*/ queryType=='movie' ? regexMatched(streams, 'Theatrical Cut') : []",
+    "score": 125,
+    "enabled": true
+  },
+  {
+    "expression": "/*Vinegar Syndrome*/ queryType=='movie' ? regexMatched(streams, 'Vinegar Syndrome') : []",
+    "score": 25,
+    "enabled": true
+  },
+  {
+    "expression": "/*Season Pack*/ queryType=='series' ? negate(seadex(streams), seasonPack(streams, 'seasonPack')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*CR*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'CR')) : []",
+    "score": 6,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*CR*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'CR')) : []",
+    "score": 6,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*Disney+*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'DSNP')) : []",
+    "score": 5,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Disney+*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'DSNP')) : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*Netflix*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'NF')) : []",
+    "score": 4,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Netflix*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'NF')) : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*Amazon*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'AMZN')) : []",
+    "score": 3,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*Amazon*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'AMZN')) : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*VRV*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'VRV')) : []",
+    "score": 3,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*VRV*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'VRV')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*FUNi*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'FUNi')) : []",
+    "score": 2,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*FUNi*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'FUNi')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*ABEMA*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'ABEMA')) : []",
+    "score": 1,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*ABEMA*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'ABEMA')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Sonarr*/ /*ADN*/ queryType=='anime.series' ? negate(seadex(streams), regexMatched(streams, 'ADN')) : []",
+    "score": 1,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*#Radarr*/ /*ADN*/ queryType=='anime.movie' ? negate(seadex(streams), regexMatched(streams, 'ADN')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*Anime LQ*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime LQ Groups')) : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*Anime Raws*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Anime Raws')) : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#AV1*/ isAnime ? negate(seadex(streams), encode(streams, 'AV1')) : encode(streams, 'AV1')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Extras*/ queryType=='movie' ? regexMatched(streams, 'Extras (Radarr)') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Extras*/ queryType=='series' ? regexMatched(streams, 'Extras (Sonarr)') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*VOSTFR*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'VOSTFR')) : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*Generated DV/HDR10+*/ queryType=='movie' ? regexMatched(streams, 'Generated Dynamic HDR') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Asian LQ*/ queryType=='movie' ? regexMatched(streams, 'Asian LQ') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Asian LQ*/ queryType=='series' ? regexMatched(streams, 'Asian LQ') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*LQ*/ queryType=='movie' ? merge(regexMatched(streams, 'LQ (Radarr)'), releaseGroup(streams, 'E')) : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*LQ*/ queryType=='series' ? regexMatched(streams, 'LQ (Sonarr)') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*LQ Title*/ queryType=='movie' ? regexMatched(streams, 'LQ (Release Title) (Radarr)') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*LQ Title*/ queryType=='series' ? regexMatched(streams, 'LQ (Release Title) (Sonarr)') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*Sing-Along*/ queryType=='movie' ? regexMatched(streams, 'Sing-Along Versions') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*Upscaled*/ isAnime ? [] : regexMatched(streams, 'Upscaled')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*B&W*/ queryType=='movie' ? regexMatched(streams, 'Black and White Editions') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*B&W*/ queryType=='series' and (title != 'Spider-Noir' and title != 'Spider Noir' and title != 'Spider-noir' and title != 'Spider noir') ? regexMatched(streams, 'BW') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*B&W Boost*/ queryType=='series' and (title == 'Spider-Noir' or title == 'Spider Noir' or title == 'Spider-noir' or title == 'Spider noir') ? regexMatched(streams, 'BW') : []",
+    "score": 1500,
+    "enabled": true
+  },
+  {
+    "expression": "/*AD*/ isAnime ? [] : regexMatched(streams, 'WiTH AD')",
+    "score": 101,
+    "enabled": false
+  },
+  {
+    "expression": "/*ASL*/ isAnime ? [] : regexMatched(streams, 'WiTH ASL')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*BSL*/ isAnime ? [] : regexMatched(streams, 'WiTH BSL')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*BASL*/ isAnime ? [] : regexMatched(streams, 'WiTH BASL')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Amazon*/ queryType=='movie' ? regexMatched(streams, 'AMZN') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Apple TV*/ queryType=='movie' ? regexMatched(streams, 'ATV') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Apple TV+*/ queryType=='movie' ? regexMatched(streams, 'ATVP') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Bravia Core*/ queryType=='movie' ? regexMatched(streams, 'BCORE') : []",
+    "score": 15,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Criterion Channel*/ queryType=='movie' ? regexMatched(streams, 'CRiT') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Disney+*/ queryType=='movie' ? regexMatched(streams, 'DSNP') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*HBO*/ queryType=='movie' ? regexMatched(streams, 'HBO') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*HBO Max*/ queryType=='movie' ? regexMatched(streams, 'HMAX') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Hulu*/ queryType=='movie' ? regexMatched(streams, 'Hulu') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*iTunes*/ queryType=='movie' ? regexMatched(streams, 'iT') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Max*/ queryType=='movie' ? regexMatched(streams, 'MAX') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Movies Anywhere*/ queryType=='movie' ? regexMatched(streams, 'MA') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Netflix*/ queryType=='movie' ? regexMatched(streams, 'NF') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Paramount+*/ queryType=='movie' ? regexMatched(streams, 'PMTP') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Peacock*/ queryType=='movie' ? regexMatched(streams, 'PCOK') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Google Play*/ queryType=='movie' ? regexMatched(streams, 'PLAY') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Roku*/ queryType=='movie' ? regexMatched(streams, 'ROKU') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Stan*/ queryType=='movie' ? regexMatched(streams, 'STAN') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Coupang*/ queryType=='movie' ? regexMatched(streams, 'CPNG') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*FOD*/ queryType=='movie' ? regexMatched(streams, 'FOD') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*friDay*/ queryType=='movie' ? regexMatched(streams, 'friDay') : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Hami*/ queryType=='movie' ? regexMatched(streams, 'Hami') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Hotstar*/ queryType=='movie' ? regexMatched(streams, 'HTSR') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*iQIYI*/ queryType=='movie' ? regexMatched(streams, 'iQIY') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*KOCOWA*/ queryType=='movie' ? regexMatched(streams, 'KCW') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*KKTV*/ queryType=='movie' ? regexMatched(streams, 'KKTV') : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*LINE TV*/ queryType=='movie' ? regexMatched(streams, 'LINETV') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*myTV*/ queryType=='movie' ? regexMatched(streams, 'MyTVSuper') : []",
+    "score": 40,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*TVer*/ queryType=='movie' ? regexMatched(streams, 'TVer') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*TVING*/ queryType=='movie' ? regexMatched(streams, 'TVING') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*U-NEXT*/ queryType=='movie' ? regexMatched(streams, 'U-NEXT') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Viki*/ queryType=='movie' ? regexMatched(streams, 'Viki') : []",
+    "score": 49,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Viu*/ queryType=='movie' ? regexMatched(streams, 'VIU') : []",
+    "score": 0,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Wavve*/ queryType=='movie' ? regexMatched(streams, 'WAVVE') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*WeTV*/ queryType=='movie' ? regexMatched(streams, 'WETV') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Youku*/ queryType=='movie' ? regexMatched(streams, 'YOUKU') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Amazon*/ queryType=='series' ? regexMatched(streams, 'AMZN') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Apple TV*/ queryType=='series' ? regexMatched(streams, 'ATV') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Apple TV+*/ queryType=='series' ? regexMatched(streams, 'ATVP') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Comedy Central*/ queryType=='series' ? regexMatched(streams, 'CC') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*DC Universe*/ queryType=='series' ? regexMatched(streams, 'DCU') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Disney+*/ queryType=='series' ? regexMatched(streams, 'DSNP') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*HBO Max*/ queryType=='series' ? regexMatched(streams, 'HMAX') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*HBO*/ queryType=='series' ? regexMatched(streams, 'HBO') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Hulu*/ queryType=='series' ? regexMatched(streams, 'Hulu') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*iTunes*/ queryType=='series' ? regexMatched(streams, 'iT') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Max*/ queryType=='series' ? regexMatched(streams, 'MAX') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Netflix*/ queryType=='series' ? regexMatched(streams, 'NF') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Paramount+*/ queryType=='series' ? regexMatched(streams, 'PMTP') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Peacock*/ queryType=='series' ? regexMatched(streams, 'PCOK') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Google Play*/ queryType=='series' ? regexMatched(streams, 'PLAY') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Roku*/ queryType=='series' ? regexMatched(streams, 'ROKU') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Showtime*/ queryType=='series' ? regexMatched(streams, 'SHO') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Stan*/ queryType=='series' ? regexMatched(streams, 'STAN') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Coupang*/ queryType=='series' ? regexMatched(streams, 'CPNG') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*DMM TV*/ queryType=='series' ? regexMatched(streams, 'DMM-TV') : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*FOD*/ queryType=='series' ? regexMatched(streams, 'FOD') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*friDay*/ queryType=='series' ? regexMatched(streams, 'friDay') : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Hami*/ queryType=='series' ? regexMatched(streams, 'Hami') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Hotstar*/ queryType=='series' ? regexMatched(streams, 'HTSR') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*iQIYI*/ queryType=='series' ? regexMatched(streams, 'iQIY') : []",
+    "score": 50,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*KOCOWA*/ queryType=='series' ? regexMatched(streams, 'KCW') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*KKTV*/ queryType=='series' ? regexMatched(streams, 'KKTV') : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*LINE TV*/ queryType=='series' ? regexMatched(streams, 'LINETV') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*myTV*/ queryType=='series' ? regexMatched(streams, 'MyTVSuper') : []",
+    "score": 40,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*TVer*/ queryType=='series' ? regexMatched(streams, 'TVer') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*TVING*/ queryType=='series' ? regexMatched(streams, 'TVING') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*U-NEXT*/ queryType=='series' ? regexMatched(streams, 'U-NEXT') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Viki*/ queryType=='series' ? regexMatched(streams, 'Viki') : []",
+    "score": 49,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Viu*/ queryType=='series' ? regexMatched(streams, 'VIU') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Wavve*/ queryType=='series' ? regexMatched(streams, 'WAVVE') : []",
+    "score": 20,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*WeTV*/ queryType=='series' ? regexMatched(streams, 'WETV') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Youku*/ queryType=='series' ? regexMatched(streams, 'YOUKU') : []",
+    "score": 30,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Syfy*/ queryType=='series' ? regexMatched(streams, 'SYFY') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*UHD Streaming Boost*/ queryType=='series' ? regexMatched(resolution(streams, '2160p'), 'DSNP', 'HMAX', 'NF') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*HD Streaming Boost*/ queryType=='series' ? regexMatched(resolution(streams, '1080p'), 'DSNP') : []",
+    "score": 75,
+    "enabled": true
+  },
+  {
+    "expression": "/*BR-DISK*/ isAnime ? [] : regexMatched(streams, 'BR-DISK')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*x265*/ isAnime ? [] : negate(merge(visualTag(streams, 'HDR', 'HDR10', 'HDR10+'), visualTag(streams, 'DV')), encode(negate(resolution(streams, '2160p'), streams), 'HEVC'))",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*x264*/ isAnime ? [] : negate(quality(streams, 'Bluray REMUX'), regexMatched(streams, 'x264'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*x266*/ isAnime ? [] : negate(quality(streams, 'Bluray REMUX'), regexMatched(streams, 'x266'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*SDR*/ isAnime ? [] : negate(merge(visualTag(streams, 'HDR', 'HDR10', 'HDR10+'), visualTag(streams, 'DV')), regexMatched(resolution(streams, '2160p'), 'SDR'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*SDR (no WEBDL)*/ isAnime ? [] : negate(merge(visualTag(streams, 'HDR', 'HDR10', 'HDR10+'), visualTag(streams, 'DV'), quality(streams, 'WEBDL', 'WEBRIP')), regexMatched(negate(quality(streams, 'WEBDL', 'WEBRIP'), resolution(streams, '2160p')), 'SDR'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*3D*/ isAnime ? [] : regexMatched(streams, '3D')",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Bad Dual*/ queryType=='movie' ? regexMatched(streams, 'Radarr Bad Dual Groups') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Bad Dual*/ queryType=='series' ? regexMatched(streams, 'Sonarr Bad Dual Groups') : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Obfuscated*/ queryType=='movie' ? regexMatched(streams, 'Obfuscated (Radarr)') : []",
+    "score": -1,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Obfuscated*/ queryType=='series' ? regexMatched(streams, 'Obfuscated (Sonarr)') : []",
+    "score": -1,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Radarr*/ /*Retags*/ queryType=='movie' ? regexMatched(streams, 'Retags (Radarr)') : []",
+    "score": -1,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Sonarr*/ /*Retags*/ queryType=='series' ? regexMatched(streams, 'Retags (Sonarr)') : []",
+    "score": -1,
+    "enabled": true
+  },
+  {
+    "expression": "/*Dubs Only*/ isAnime and originalLanguage != 'English' ? negate(seadex(streams), regexMatched(streams, 'Dubs Only')) : []",
+    "score": -10000,
+    "enabled": true
+  },
+  {
+    "expression": "/*Uncensored*/ isAnime ? negate(seadex(streams), regexMatched(streams, 'Uncensored')) : []",
+    "score": 10,
+    "enabled": true
+  },
+  {
+    "expression": "/*#Anime*/ /*Dual Audio*/ isAnime and originalLanguage != 'English' ? language(streams, 'Dual Audio') : []",
+    "score": 0,
+    "enabled": false
+  },
+  {
+    "expression": "/*10bit*/ isAnime ? regexMatched(streams, '10bit') : []",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*H.264 10bit*/ isAnime ? regexMatched(streams, 'H.264 10bit') : []",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*DV w/o HDR*/ isAnime ? [] : negate(merge(releaseGroup(streams, 'Flights'), regexMatched(streams, 'Hulu'), visualTag(streams, 'HDR', 'HDR10', 'HDR10+')), quality(visualTag(streams, 'DV'), 'WEBDL', 'WEBRIP'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*DV P7*/ negate(rseMatched(streams, 'Hybrid'), quality(visualTag(resolution(streams, '2160p'), 'DV'), 'Bluray Remux', 'Bluray'))",
+    "score": -10000,
+    "enabled": false
+  },
+  {
+    "expression": "/*No-RlsGroup*/ isAnime ? [] : negate(releaseGroup(streams), streams)",
+    "score": -1,
+    "enabled": true
+  }
+]

--- a/Filtering/upstream/vidhin05-regexes.snapshot.json
+++ b/Filtering/upstream/vidhin05-regexes.snapshot.json
@@ -1,0 +1,872 @@
+[
+  {
+    "name": "𝚅𝚒𝚍𝚑𝚒𝚗'𝚜 𝙴𝚗𝚐𝚕𝚒𝚜𝚑 𝚁𝚊𝚗𝚔𝚎𝚍 𝚁𝚎𝚐𝚎𝚡𝚎𝚜 (𝚜𝚢𝚗𝚌𝚎𝚍)",
+    "pattern": "/^(?!𝚅𝚒𝚍𝚑𝚒𝚗'𝚜 𝙴𝚗𝚐𝚕𝚒𝚜𝚑 𝚁𝚊𝚗𝚔𝚎𝚍 𝚁𝚎𝚐𝚎𝚡𝚎𝚜 (𝚜𝚢𝚗𝚌𝚎𝚍))𝚅𝚒𝚍𝚑𝚒𝚗'𝚜 𝙴𝚗𝚐𝚕𝚒𝚜𝚑 𝚁𝚊𝚗𝚔𝚎𝚍 𝚁𝚎𝚐𝚎𝚡𝚎𝚜 (𝚜𝚢𝚗𝚌𝚎𝚍)$/",
+    "score": 0
+  },
+  {
+    "name": "Radarr Remux T1",
+    "pattern": "/^(?=.*(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p)(?=.*\\b(3L|BiZKiT|BLURANiUM|BMF|CiNEPHiLES|FraMeSToR|PiRAMiDHEAD|PmP|WiLDCAT|ZQ)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Remux T1",
+    "pattern": "/^(?=.*(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p)(?=.*\\b(BLURANiUM|BMF|FraMeSToR|PmP)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr Remux T2",
+    "pattern": "/^(?=.*(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p)(?=.*\\b(ATELiER|NCmt|playBD|SiCFoI|SURFINBIRD|TEPES)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Remux T2",
+    "pattern": "/^(?=.*(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p)(?=.*\\b(12GaugeShotgun|decibeL|EPSiLON|HiFi|KRaLiMaRKo|playBD|PTer|SiCFoI|TRiToN)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr Remux T3",
+    "pattern": "/^(?=.*(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p)(?=.*\\b(12GaugeShotgun|decibeL|EPSiLON|HiFi|iFT|KRaLiMaRKo|NTb|PTP|SumVision|TOA|TRiToN)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr UHD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|UHD|4K))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:CtrlHD|MainFrame|W4NK3R)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr UHD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|UHD|4K))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*(?:\\b(?:DON)\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr HD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:BBQ|BMF|c0kE|Chotab|CRiSC|CtrlHD|D-Z0N3|Dariush|decibeL|EbP|EDPH|LolHD|NCmt|PTer|TayTO|TDD|TnP|VietHD|ZQ|ZoroSenpai)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr HD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*(?:\\b(?:DON|Geek)\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "Sonarr HD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:Chotab|CtrlHD|EbP|NTb|PTer)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr HD Bluray T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*(?:\\b(?:DON)\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr UHD Bluray T2",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|UHD|4K))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:HQMUX)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr HD Bluray T2",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:ATELiER|EA|HiDt|HiSD|iFT|NTb|QOQ|SA89|sbR)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr HD Bluray T2",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:SA89|sbR)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr UHD Bluray T3",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|UHD|4K))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:BHDStudio|hallowed|HONE|PTer|SPHD|WEBDV)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr HD Bluray T3",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:BHDStudio|hallowed|HiFi|HONE|playHD|SPHD|W4NK3R)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr HD Bluray T3",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)))(?!.*(?:(?:[_. ]|\\d{4}p-|\\bHybrid-)(?:(?:BD|UHD)[-_. ]?)?Remux\\b|(?:(?:BD|UHD)[-_. ]?)?Remux[_. ]\\d{4}p))(?!.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)))(?!.*(WebRip|Web-Rip|WEBMux))(?=.*\\b(?:LoRD)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr Web T1",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:ABBIE|AJP69|BLUTONiUM|BYNDR|CMRG|CRFW|CRUD|GNOME|HONE|Kitsune|MADSKY|NOSiViD|NTb|NTG|PAXA|PEXA|RAWR|SiC|TEPES|TheFarm|XEPA|ZoroSenpai)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Web T1",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:ABBiE|AJP69|CasStudio|CRFW|CtrlHD|HONE|Kitsune|MADSKY|monkee|NOSiViD|NTb|NTG|PAXA|PEXA|QOQ|RAWR|RTN|SiC|T6D|ViSUM|XEPA)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Web T1",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:APEX|FLUX|KiNGS|TOMMY)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:dB|MiU|MZABI|playWEB|SbR|SMURF|XEBEC|4KBEC|CEBEX)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:TOMMY)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:Flights|PHOENiX)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:3cTWeB|4KBEC|BTW|BLUTONiUM|BYNDR|CEBEX|Chotab|Cinefeel|CiT|Coo7|dB|FC|iJP|iKA|iT00NZ|JETIX|KHN|MiU|MZABI|NPMS|NYH|orbitron|playWEB|PSiG|ROCCaT|RTFM|SA89|SbR|SDCC|TEPES|TVSmash|WELP|XEBEC)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:DEEP|END|ETHiCS|Flights|GNOME|KiMCHI|LAZY|PHOENiX|SIGMA|SiGMA|SMURF|SPiRiT)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Radarr Web T3",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:BLOOM|Dooky|GNOMiSSiON|HHWEB|NINJACENTRAL|NPMS|ROCCaT|SiGMA|SLiGNOME|SwAgLaNdEr)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Web T3",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:BLOOM|Dooky|HHWEB|NINJACENTRAL|SLiGNOME|SwAgLaNdEr|T4H)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Web T3",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:DRACULA|ViSiON)\\b).*/",
+    "score": 0
+  },
+  {
+    "name": "Asian Tier 01",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:ANDY|Archie|ECLiPSE|HBO|HeavenlyOppa|iTsOK|JKCT|LoveBug|MARK|MMR|MrHulk|Phanteam|SH3LBY|SYNFM|Wendy)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Asian Tier 02",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:PandaMoon)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Asian Tier 03",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:ADWeb|CHDWEB|HDCTV|HHWEB|OurTV|SHiNE)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Asian LQ",
+    "pattern": "/\\b(AppleTor|Luvmichelle|MagicStar|NEXT|Taengoo|unco@AvistaZ|unco)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Web Scene",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux))(?=.*\\b(?:DEFLATE|INFLATE)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(Moxie|smol|SoM)\\]|-(Moxie|smol|SoM)\\b|\\b(DemiHuman|FLE|Flugel|LYS1TH3A)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T1",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[sam\\]|-sam\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T2",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(Aergia|Arid|koala|Lulu|Vodes|YURI)\\]|-(Aergia(?!-raws)|Arid|koala|Lulu|YURI)\\b|\\b(Arg0|BlackRose|FateSucks|hchcsen|hydes|JOHNTiTOR|JySzE|Kulot|LostYears|Meakes|WAP|ZeroBuild)\\b|-Orphan\\b|(?<!Not)-Vodes\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T2",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[Orphan\\])).*/",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T3",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(ARC|cappybara|CRUCiBLE|Doc|fig|Headpatter|Legion|Mehul|Mysteria|RaiN|RUDY|Serendipity|sgt|uba)\\]|-(ARC|cappybara|CRUCiBLE|Doc|fig|Headpatter|Legion|Mehul|Mysteria|RaiN|RUDY|Serendipity|sgt|uba)\\b|\\b(BBT-RMX|ChucksMux|CUNNY|Cunnysseur|Inka-Subs|LaCroiX|MTBB|Netaro|Noiy|npz|NTRX|Okay-Subs|P9|RMX|Sekkon|SubsMix|Sylvar|ZR)\\b|(?<=remux).*\\b(NAN0)\\b|^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)|-ZR-)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T4",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(Afro|Chimera|derp|DIY|EXP|Foxtrot|Kawatare|Metal|Pizza|Smoke|Vanilla|VULCAN)\\]|-(Afro|Chimera|derp|DIY|EXP|Foxtrot|Kawatare|Metal|Pizza|Smoke|Vanilla|VULCAN)\\b|\\b(ABdex|aRMX|BiRJU|BKC|CBT|grimf|IK|Iznjie[ .-]Biznjie|Kaleido-subs|Kametsu|KH|LazyRemux|MK|neko-kBaraka|OZR|pog42|Quetzal|Reza|SCY|Shimatta|Spirale|UDF|UQW|Virtuality)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T5",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(Beatrice|Drag|Judgment|Thighs|Yuki)\\]|-(Beatrice(?!-raws)|Drag|Judgment|Thighs|Yuki)\\b|\\b(Animorphs|AOmundson|ASC|Baws|McBalls|B00BA|Cait-Sidhe|CsS|CTR|D4C|deanzel|eldon|Freehold|GHS|Hark0N|Holomux|MC|mottoj|NH|NTRM|o7|QM|TTGA|UltraRemux|WBDP|WSE)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T6",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(ANE|Tsundere|YURASUKA)\\]|-ANE$|-(Tsundere(?!-)|YURASUKA)\\b|\\b(Bunny-Apocalypse|CyC|Datte13|EJF|GetItTwisted|GSK[._-]kun|iKaos|karios|Pookie|RASETSU|Starbez|Yoghurt)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T7",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(Almighty|Asakura|Bolshevik|Chihiro|Crow|Dekinai|Senjou|Vivid|AC)\\]|-(Almighty|Asakura|Bolshevik|Chihiro|Crow|Dekinai|Senjou|Vivid)\\b|-AC$|\\b(9volt|Asenshi|BlurayDesuYo|Brrrrrrr|Commie|Dae|Dragon-Releases|DragsterPS|Exiled-Destiny|E-D|FFF|Final8|Geonope|GJM|iAHD|inid4c|Koten[ ._-]Gars|kuchikirukia|LCE|NTW|orz|RAI|REVO|SCP-2223|SEV|THORA)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime BD T8",
+    "pattern": "/^(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)|(?<=[-_. (\\[])bd(?=[-_. )\\]])|DVD|DVDRip|NTSC|PAL|xvidvd))(?=.*(\\[(EDGE|EMBER|GHOST|naiyas|Prof|Judas)\\]|-(EDGE|EMBER|GHOST|naiyas|Prof|Judas)\\b|\\b(AkihitoSubs|Arukoru|Nep[ ._-]Blanc|Shirσ)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T1",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[(Arid|smol|SoM|Vodes)\\]|-(Arid|smol|SoM)\\b|\\b(Arg0|Baws|FLE|LostYears|LYS1TH3A|McBalls|SCY|Setsugen|Z4ST1N|ZeroBuild)\\b|(?<!Not)-Vodes\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T1",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[sam\\]|-sam\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T2",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[(Asakura|Cyan|Dae|Foxtrot|Gao|Not-Vodes|Pizza|tenshi)\\]|-(Asakura|Cyan|Dae|Foxtrot|Gao|Not-Vodes|Pizza)\\b|-tenshi$|\\b(0x539|Cytox|GSK[._-]kun|Half-Baked|HatSubs|MALD|MTBB|Okay-Subs|Reza|Slyfox|SoLCE)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T3",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[Kitsune\\]|-Kitsune\\b|\\b(AnoZu|Dooky|SubsPlus\\+?|ZR)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T4",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(Erai-raws|ToonsHub|VARYG)\\b).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T5",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[(Lia|ZigZag)\\]|-(Lia|ZigZab)\\b|\\b(BlueLobster|GST|HorribleRips|HorribleSubs|KAN3D2M|KS|KiyoshiStar|NanDesuKa|PlayWeb|SobsPlease|Some-Stuffs|SubsPlease|URANIME)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Web T6",
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(\\[(Chihiro|Doki|Kantai|Tsundere)\\]|-(Chihiro|Doki|Kantai|Tsundere(?!-))\\b|\\b(9volt|Asenshi|Commie|DameDesuYo|GJM|Kaleido|KawaSubs)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "3D",
+    "pattern": "/(?<=\\b[12]\\d{3}\\b).*\\b(3d|sbs|half[ .-]ou|half[ .-]sbs|BluRay3D|BD3D)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Anime LQ Groups",
+    "pattern": "/\\b(\\$tore-Chill|0neshot|A-Destiny|AceAres|AhmadDev|Anime[ .-]?(Chap|Land|Time)|AnimeDynastyEN|AnimeKuro|AnimeRG|Animesubs|AnimeTR|Anitsu|AniVoid|ArataEnc|AREY|ASW|BJX|BlackLuster|bonkai77|CameEsp|Cat66|CBB|CuaP|DARKFLiX|DBArabic|Deadmau[ .-]?[ .-]?RAWS|DKB|DP|DsunS|ExREN|(Baked|Dead|Space)Fish|FunArts|GERMini|Hakata[ .-]?Ramen|Hall_of_C|HAV1T|HENiL|HollowRoxas|ICEBLUE|iPUNISHER|JacobSwaggedUp|Johnny-englishsubs|Kanjouteki|KEKMASTERS|Kirion|KQRM|KRP|LoliHouse|M@nI|mal[ .-]lu[ .-]zen|Man\\.K|mdcx|Metaljerk|MGD|Mini(Freeza|MTBB|sCuba|Theatre)|Mites|Modders[ .-]?Bay|Mr\\.Deadpool|NemDiggers|neoHEVC|Nokou|N[eo][wo]b[ ._-]?Subs|NS|Nyanpasu|OldCastle|phazer11|Plex[ .-]?Friendly|PnPSubs|Polarwindz|Project-gxs|PuyaSubs|QAS|QCE|Rando235|M2TS|BDMV|BDVD|Reaktor|RightShiftBy2|Rip[ .-]?Time|Salieri|Samir755|SanKyuu|sekkusu&ok|SHFS|shincaps|SLAX|SRW|SSA|StrayGods|TeamTurquoize|Tenrai[ .-]?Sensei|TnF|TOPKEK|U3-Web|Valenciano|VipapkStudios|WtF[ ._-]?Anime|xiao-av1|Yabai_Desu_NeRandomRemux|YakuboEncodes|youshikibi|YuiSubs)\\b|\\[224\\]|-224\\b|\\[(Ari|Cerberus|Cleo|Daddy(Subs)?|DB|Emmid|FAV|Hatsuyuki|Hitoku|HR|Kallango|Maximus|MD|Pantsu|Pao|Pixel|Ranger|Rapta|Raze|SAD|SEiN|Sokudo|Suki[ .-]?Desu|Trix|UNBIASED|uP|USD|Wardevil|Yun|zza)\\]|-(224|Ari|Cerberus|Cleo|Daddy(Subs)?|Emmid|FAV|Hatsuyuki|Hitoki|HR|Kallango|Maximus|MD|Pantsu|Pao|Pixel|Ranger|Rapta|Raze|SAD|SEiN|Sokudo|Suki[ .-]?Desu|Trix|UNBIASED|USD|Wardevil|Yun|zza)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Anime Raws",
+    "pattern": "/\\b(Asuka|Beatrice|Daddy|Fumi|Iriza|Kawaiika|Koi|Lilith|LowPower|Nanako|NC|neko|New|Ohys|Pandoratv|Scryous|Seicher|Shiniori)[ ._-]?(Raws)\\b|\\b(Moozzi2|Raws-Maji|ReinForce)\\b|\\[km\\]|-km\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Radarr Bad Dual Groups",
+    "pattern": "/\\b(alfaHD.*|BAT|BlackBit|BNd|C\\.A\\.A|C76|Cory|CYPHER|EniaHD|EXTREME|FF|FOXX|G4RiS|GUEIRA|LCD|MGE|MLH|N3G4N|ONLYMOViE|PD|PTHome|RiPER|RK|SiGLA|Tars|TM|tokar86a|TURG|TvR|vnlls|WTV|XiQUEXiQUE|Yatogam1|YusukeFLA|ZigZag|ZNM)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Sonarr Bad Dual Groups",
+    "pattern": "/\\b(alfaHD.*|BAT|BiOMA|BlackBit|BNd|C\\.A\\.A|C76|Cory|CYPHER|EniaHD|EXTREME|FF|FOXX|G4RiS|GUEIRA|LCD|MLH|N3G4N|PD|PTHome|RiPER|RK|SiGLA|Tars|tokar86a|TURG|vnlls|WTV|XiQUEXiQUE|Yatogam1|YusukeFLA|ZigZag|ZNM)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Dubs Only",
+    "pattern": "/\\b(Golumpa|KamiFS|torenter69)\\b|\\[Yameii\\]|-Yameii\\b|^(?!.*(Dual|Multi)[-_. ]?Audio).*((?<!multi-)\\b(dub(bed)?)\\b|(funi|eng(lish)?)_?dub)|^(?!.*(dual[ ._-]?audio|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO))).*\\b(KaiDubs|KS)\\b/i",
+    "score": 0
+  },
+  {
+    "pattern": "/(\\bAI[ ._-]?(Upscaled?|Enhanced|Remaster(ed)?)?\\b)|(\\b(AIUS|RW|GuyZo|BR-GuyZo)\\b)|(\\b((Upscale)?Re-?graded?)\\b)|(\\b(The[ ._-]?Upscaler)\\b)|(\\b(AI[ ._-]?Enhanced?|UPS(UHD)?|Upscaled?([ ._-]?UHD)?|UpRez)\\b)/i",
+    "name": "Upscaled",
+    "score": 0
+  },
+  {
+    "name": "Extras (Radarr)",
+    "pattern": "/(?<=\\b[12]\\d{3}\\b).*\\b(Extras|Bonus|Extended[ ._-]Clip)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Extras (Sonarr)",
+    "pattern": "/(?<=\\bS\\d+\\b).*\\b(Extras|Bonus|Extended[ ._-]Clip)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "BW",
+    "pattern": "/(?<=\\bS\\d+(E\\d+)?\\b).*\\b((B(lack)?[ ._-]?(out|(and|[n&])?[ ._-]?(W(hite)?|Chrome))))\\b(?!$)/",
+    "score": 0
+  },
+  {
+    "name": "VOSTFR",
+    "pattern": "/\\b(VOST.*?FR(E|A)?|SUBFR(A|ENCH)?)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Generated Dynamic HDR",
+    "pattern": "/^(?=.*\\b(BiTOR|DepraveD|SasukeducK|tarunk9c|VD0N|VECTOR|VisionXpert)\\b)(?=.*(?:\\bHDR10(\\+|P(lus)?)\\b|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)).*/i",
+    "score": 0
+  },
+  {
+    "name": "Generated Dynamic HDR",
+    "pattern": "/^(?=.*\\b(Flights|GuyZo|BR-GuyZo)\\b)(?=.*(?:\\bHDR10(\\+|P(lus)?)\\b|\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)).*/",
+    "score": 0
+  },
+  {
+    "name": "126811",
+    "pattern": "/\\b(126811)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "FLUX",
+    "pattern": "/\\b(FLUX)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "SiC",
+    "pattern": "/\\b(SiC)\\b/",
+    "score": 0
+  },
+  {
+    "name": "FraMeSToR",
+    "pattern": "/\\b(FraMeSToR)\\b/",
+    "score": 0
+  },
+  {
+    "name": "TheFarm",
+    "pattern": "/\\b(TheFarm)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "hallowed",
+    "pattern": "/\\b(hallowed)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "BHDStudio",
+    "pattern": "/\\b(BHDStudio)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "LQ (Radarr)",
+    "pattern": "/\\b(beAst|COLLECTiVE|EPiC|iVy|KiNGDOM|LUCY|Scene|SUNSCREEN)\\b/",
+    "score": 0
+  },
+  {
+    "name": "LQ (Radarr)",
+    "pattern": "/\\b(24xHD|41RGB|4K4U|AOC|AROMA|aXXo|AZAZE|BARC0DE|BAUCKLEY|BdC|BTM|C1NEM4|C4K|CDDHD|CHAOS|CHD|CHX|CiNE|CREATiVE24|CrEwSaDe|CTFOH|d3g|DDR|DepraveD|DNL|DRX|EuReKA|EVO|FaNGDiNG0|Feranki1980|FGT|FMD|FRDS|FZHD|GalaxyRG|GHD|GHOSTS|GPTHD|HDHUB4U|HDS|HDT|HDTime|HDWinG|HiQVE|iNTENSO|iPlanet|jennaortega(UHD)?|JFF|KC|KIRA|L0SERNIGHT|LAMA|Leffe|Liber8|LiGaS|MarkII|MeGusta|Mesc|mHD|mSD|MTeam|MT|MySiLU|nhanc3|NhaNc3|nHD|nikt0|nSD|OFT|PATOMiEL|PRODJi|PSA|PTNK|RARBG|RBB|RDN|Rifftrax|RU4HD|SANTi|SasukeducK|SHD|ShieldBearer|STUTTERSHIT|TBS|TEKNO3D|TG|Tigole|TIKO|VIDEOHOLE|VISIONPLUSHDR(-X|1000)?|WAF|WiKi|worldmkv|x0r|XLF|YIFY|YTS(.(MX|LT|AG))?|Zero00|Zeus)\\b|Pahe(\\.(ph|in))?\\b|\\bx265-E/i",
+    "score": 0
+  },
+  {
+    "name": "LQ (Sonarr)",
+    "pattern": "/\\b(iVy)\\b/",
+    "score": 0
+  },
+  {
+    "name": "LQ (Sonarr)",
+    "pattern": "/\\b(BRiNK|BTM|CHX|CTFOH|d3g|DepraveD|EVO|Feranki1980|FGT|FMD|GHOSTS|HiQVE|iNTENSO|JFF|KC|MeGusta|nhanc3|OFT|PSA|SasukeducK|SHD|ShieldBearer|TBS|TG|VIDEOHOLE|worldmkv|XLF|Zero00)\\b|Pahe(\\.(ph|in))?\\b/i",
+    "score": 0
+  },
+  {
+    "name": "LQ (Release Title) (Radarr)",
+    "pattern": "/\\b(1XBET|BEN[ ._-]THE[ ._-]MEN|Feranki1980|GalaxyRG|(?<!-)jennaortega(UHD)?|R&H|READ(\\s|\\.)+NOTE|SWTYBLZ|TeeWee|TEKNO3D|Will1869)\\b|(-D3US|D3US-)|(?<=\\b[12]\\d{3}\\b.*?)(?<!\\b(web[ ._-]?(dl|rip)?).*?)\\b(EVO|PiRaTeS)\\b|^(?!.*\\bMA\\b.*\\bWEB-?DL\\b).*\\b(HHWEB)\\b|(?<!\\b(remux).*?)\\b(unkn0wn)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "LQ (Release Title) (Sonarr)",
+    "pattern": "/\\b(BEN[ ._-]THE[ ._-]MEN|CREATiVE24|Feranki1980|R&H|TeeWee)\\b|(?=.*?(\\b2160p\\b))(?=.*?(\\bBiTOR\\b))/i",
+    "score": 0
+  },
+  {
+    "name": "Sing-Along Versions",
+    "pattern": "/(?<=\\b[12]\\d{3}\\b).*\\b(Sing[-_. ]Along)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "Hulu",
+    "pattern": "/\\b(hulu)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "v0",
+    "pattern": "/(\\b|\\d)(v0)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "v1",
+    "pattern": "/(\\b|\\d)(v1)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "v2",
+    "pattern": "/(\\b|\\d)(v2)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "v3",
+    "pattern": "/(\\b|\\d)(v3)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "v4",
+    "pattern": "/(\\b|\\d)(v4)\\b/i",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Repack|Proper|Rerip)\\b/i",
+    "name": "Repack/Proper",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b((repack|proper)2)\\b|\\b(REAL\\.(PROPER|REPACK))\\b/i",
+    "name": "Repack2",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b((repack|proper)3)\\b|\\b(REAL\\.REAL\\.(PROPER|REPACK))\\b/i",
+    "name": "Repack3",
+    "score": 0
+  },
+  {
+    "name": "HDR",
+    "pattern": "/(?:(?:^(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!(?=.*\\b(WEB[ ._-]?(DL|Rip)?)\\b)(?!.*\\b(hulu)\\b)))|\\b(HLG|PQ)\\b|^(?=.*\\b(FraMeSToR|HQMUX|SiCFoI)\\b)(?=.*\\b(2160p)\\b)(?!.*(?:HDR10(?:[+]|P(?:lus)?)|SDR)\\b).*)/i",
+    "score": 0
+  },
+  {
+    "pattern": "/-4P\\b|-4Planet\\b|-AsRequested\\b|-BUYMORE\\b|-Chamele0n\\b|-GEROV\\b|-iNC0GNiTO\\b|-NZBGeek\\b|-Obfuscated\\b|-postbot\\b|-Rakuv\\b|(?<=\\b[12]\\d{3}\\b).*(Scrambled)\\b|-WhiteRev\\b|-xpost\\b|-WRTEAM\\b|-CAPTCHA\\b|_nzb\\b/i",
+    "name": "Obfuscated (Radarr)",
+    "score": 0
+  },
+  {
+    "pattern": "/-4P\\b|-4Planet\\b|-AsRequested\\b|-BUYMORE\\b|-Chamele0n\\b|-GEROV\\b|-iNC0GNiTO\\b|-NZBGeek\\b|-Obfuscated\\b|-postbot\\b|-Rakuv\\b|(?<=\\bS\\d+\\b).*(Scrambled)\\b|-WhiteRev\\b|-xpost\\b|-WRTEAM\\b|-CAPTCHA\\b|_nzb\\b/i",
+    "name": "Obfuscated (Sonarr)",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|720p|MKV|XviD|WMV|d3g|(BD)?REMUX|^(?=.*1080p)(?=.*HEVC)|[xh][-_. ]?26[45]|German.*[DM]L|((?<=\\d{4}).*German.*([DM]L)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO)\\b))|^((?=.*\\b(((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*$/i",
+    "name": "BR-DISK",
+    "score": 0
+  },
+  {
+    "pattern": "/10[.-]?bit|hi10p?/i",
+    "name": "10bit",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bhi10p?\\b|(?=.*10[.-]?bit)(?=.*\\b[xh][-_. ]?264\\b)/i",
+    "name": "H.264 10bit",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Uncut|Unrated|Uncensored|AT[-_. ]?X)\\b/i",
+    "name": "Uncensored",
+    "score": 0
+  },
+  {
+    "pattern": "/[.]heb\\b|\\[eztvx?[ ._-]?(io|re|to)?\\]|\\[(rarbg|rartv|TGx)\\]|[.]VAV\\b|\\b(ORARBG)\\b/i",
+    "name": "Retags (Radarr)",
+    "score": 0
+  },
+  {
+    "pattern": "/[.]heb\\b|\\[eztvx?[ ._-]?(io|re|to)?\\]|\\[(rarbg|rartv|TGx)\\]/i",
+    "name": "Retags (Sonarr)",
+    "score": 0
+  },
+  {
+    "pattern": "/(?<=\\b[12]\\d{3}\\b).*\\b((B(lack)?[ ._-]?(out|(and|[n&])?[ ._-]?(W(hite)?|Chrome)))|Monochrome|Noir|Shush[ ._-]?Cut|(No|Minus)[ ._-]?Colou?r|Gr[ae]y([ ._-]?(scale))?|Darkness?[ ._-]?(and|&)[ ._-]?(Light))\\b(?!$)/i",
+    "name": "Black and White Editions",
+    "score": 0
+  },
+  {
+    "name": "WiTH AD",
+    "pattern": "/\\b((FRENCH|MULTi|WiTH|((BA?|A)SL[ ._-]and))[ ._-](AD|Audio[ ._-]Description))\\b/i",
+    "score": 0
+  },
+  {
+    "name": "WiTH ASL",
+    "pattern": "/\\b((WiTH)[ ._-](ASL))\\b/i",
+    "score": 0
+  },
+  {
+    "name": "WiTH BSL",
+    "pattern": "/\\b((WiTH)[ ._-](BSL))\\b/i",
+    "score": 0
+  },
+  {
+    "name": "WiTH BASL",
+    "pattern": "/\\b(BASL)\\b/i",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(W4NK3R|HQMUX)\\b/i",
+    "name": "Atmos Exclude Groups",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(CtrlHD|W4NK3R|DON)\\b/i",
+    "name": "TrueHD Exclude Groups",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b((?<!NON[ ._-])IMAX)\\b/i",
+    "name": "IMAX",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*\\b((DSNP|BC|B?CORE)\\b|Disney\\+)(?=.*\\bWEB[ ._-]?(DL|Rip)\\b))(?=.*\\b((?<!NON[ ._-])IMAX)\\b)|^(?=.*\\b(IMAX[ ._-]Enhanced)\\b)/i",
+    "name": "IMAX Enhanced",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Criterion|CC)\\b/i",
+    "name": "Criterion Collection",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Masters[ .-]?Of[ .-]?Cinema|MoC)(\\b|\\d)/i",
+    "name": "Masters of Cinema",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Open[ ._-]?Matte)\\b/i",
+    "name": "Open Matte",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Remaster)\\b/i",
+    "name": "Remaster",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(4k)\\b/i",
+    "name": "4K",
+    "score": 0
+  },
+  {
+    "pattern": "/(?=.*(BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$)|bd(?:720|1080|2160)))(?=.*(hybrid(\\b|\\d)))/i",
+    "name": "Hybrid",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b\\d{2,3}(?:th)?[.\\s\\-\\+_\\/(),]Anniversary[.\\s\\-\\+_\\/(),](?:Edition|Ed)?\\b/i",
+    "name": "Anniversary Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bDBOX\\b/i",
+    "name": "Dragon Box",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bCC\\b/",
+    "name": "Color Corrected",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bUltimate[.\\s\\-\\+_\\/(),]Edition\\b/i",
+    "name": "Ultimate Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(?:custom.?)?Extended\\b/i",
+    "name": "Extended Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bDirector'?s.?Cut\\b/i",
+    "name": "Director's Cut",
+    "score": 0
+  },
+  {
+    "pattern": "/\\bCollector'?s\\b/i",
+    "name": "Collector's Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b\\.Diamond\\.\\b/i",
+    "name": "Diamond Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/(?<!^)\\b(extended|uncut|directors|special|unrated|uncensored|cut|version|(?<!{)edition)(\\b|\\d)/i",
+    "name": "Special Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(IMAX[ ._-]Edition)\\b/i",
+    "name": "IMAX Edition",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Extended[ ._-]Clip)\\b/i",
+    "name": "Extended Clip",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Theatrical)\\b/i",
+    "name": "Theatrical Cut",
+    "score": 0
+  },
+  {
+    "pattern": "/\\b(Vinegar[ ._-]Syndrome|V-S|VinSyn)\\b/i",
+    "name": "Vinegar Syndrome",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(ABEMA[ ._-]?(TV)?)\\b).*/i",
+    "name": "ABEMA",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(amzn|amazon(hd)?)\\b).*/i",
+    "name": "AMZN",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(C(runchy)?[ .-]?R(oll)?)\\b).*/i",
+    "name": "CR",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(dsnp|dsny|disney|Disney\\+)\\b).*/i",
+    "name": "DSNP",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(ADN)\\b).*/i",
+    "name": "ADN",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(FUNi(mation)?)\\b).*/i",
+    "name": "FUNi",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(nf|netflix(u?hd)?)\\b).*/i",
+    "name": "NF",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(VRV)\\b).*/i",
+    "name": "VRV",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(ATV)\\b).*/i",
+    "name": "ATV",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(atvp|aptv|Apple TV\\+)\\b).*/i",
+    "name": "ATVP",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(BCORE)\\b|\\b(\\d{3,4}(p|i))\\b.*\\b(CORE)\\b).*/i",
+    "name": "BCORE",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(CC)\\b[ ._-]web[ ._-]?(dl|rip)?\\b|\\[(CC)\\b|\\b(CC)\\]).*/i",
+    "name": "CC",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(CRiT)\\b).*/i",
+    "name": "CRiT",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(dcu|DC Universe)\\b).*/i",
+    "name": "DCU",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\[(HBO)\\b|\\b(HBO)\\]).*/i",
+    "name": "HBO",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(hmax|hbom|hbo[ ._-]?max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\[(HMAX)\\b|\\b(HMAX)\\]).*/i",
+    "name": "HMAX",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(it|itunes)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\[(iT)\\b|\\b(iT)\\]).*/i",
+    "name": "iT",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\[(MAX)\\b|\\b(MAX)\\]).*/i",
+    "name": "MAX",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*(?<!dts[ .-]?hd[ .-]?)\\b(ma|ykw)\\b(?=.*\\bweb[ ._-]?(dl|rip)\\b)).*/i",
+    "name": "MA",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(pmtp|Paramount Plus)\\b).*/i",
+    "name": "PMTP",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(pcok|peacock)\\b).*/i",
+    "name": "PCOK",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(Play)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)|\\[(Play)\\b|\\b(Play)\\]).*/i",
+    "name": "PLAY",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(ROKU)\\b).*/i",
+    "name": "ROKU",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(sho|showtime)\\b[ ._-]web[ ._-]?(dl|rip)?\\b|\\[(SHO)\\b|\\b(SHO)\\]).*/i",
+    "name": "SHO",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(stan)\\b[ ._-]web[ ._-]?(dl|rip)?\\b|\\[(STAN)\\b|\\b(STAN)\\]).*/i",
+    "name": "STAN",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(SYFY)\\b).*/i",
+    "name": "SYFY",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(CPNG)\\b).*/i",
+    "name": "CPNG",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(fod)\\b).*/i",
+    "name": "FOD",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(friDay)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)).*/i",
+    "name": "friDay",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(hami|HamiVideo)\\b).*/i",
+    "name": "Hami",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(HTSR|DSNPHS|HS)\\b).*/i",
+    "name": "HTSR",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(IQIY|IQ|iQIYI)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)).*/i",
+    "name": "iQIY",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(KCW|KOCOWA)\\b).*/i",
+    "name": "KCW",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(KKTV)\\b).*/i",
+    "name": "KKTV",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(LINETV)\\b).*/i",
+    "name": "LINETV",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(MyTVSuper)\\b).*/i",
+    "name": "MyTVSuper",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(tver)\\b).*/i",
+    "name": "TVer",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(tving)\\b[ ._-]web[ ._-]?(dl|rip)?\\b|\\[(TVING)\\b|\\b(TVING)\\]).*/i",
+    "name": "TVING",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(u-next)\\b).*/i",
+    "name": "U-NEXT",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(Viki)\\b).*/i",
+    "name": "Viki",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(viu)\\b[ ._-]web[ ._-]?(dl|rip)?\\b|\\[(VIU)\\b|\\b(VIU)\\]).*/i",
+    "name": "VIU",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(WAVVE)\\b).*/i",
+    "name": "WAVVE",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(WETV)\\b).*/i",
+    "name": "WETV",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(YOUKU)\\b).*/i",
+    "name": "YOUKU",
+    "score": 0
+  },
+  {
+    "pattern": "/^(?=.*(WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip)|WebRip|Web-Rip|WEBMux|\\[WEB\\]|[\\[\\(]WEB[ .]))(?=.*\\b(DMM-TV)\\b).*/i",
+    "name": "DMM-TV",
+    "score": 0
+  },
+  {
+    "name": "SDR",
+    "pattern": "/\\bSDR\\b/i",
+    "score": 0
+  },
+  {
+    "name": "INTERNAL",
+    "pattern": "/\\b(INTERNAL)\\b/i",
+    "score": 0
+  },
+  {
+    "name": "DV (Disk)",
+    "pattern": "/^(?=.*\\b(FraMeSToR)\\b)(?=.*\\b(dv|dovi|dolby[ .]?v(ision)?)\\b)(?!.*\\b(FANRES)\\b)(?!.*\\bhybrid(\\b|\\d)).*/i",
+    "score": 0
+  },
+  {
+    "name": "x264",
+    "pattern": "/[xh][ ._-]?264|\\bAVC(\\b|\\d)/i",
+    "score": 0
+  },
+  {
+    "name": "x266",
+    "pattern": "/[xh][ ._-]?266|\\bVVC(\\b|\\d)/i",
+    "score": 0
+  }
+]

--- a/scripts/check_upstream_drift.mjs
+++ b/scripts/check_upstream_drift.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Vidhin05 upstream drift watch.
+//
+// 41/48 active templates — and every configurator-generated template — live-sync
+// ranked regex + ranked stream expressions from Vidhin05/Releases-Regex@main, and
+// elfhosted validates regex patterns against that file by exact string equality.
+// Any upstream push silently changes ranking for every Core Builds user.
+//
+// This script compares the live upstream files against the pinned snapshots in
+// Filtering/upstream/ and reports drift.
+//
+//   node scripts/check_upstream_drift.mjs            — check, exit 1 on drift
+//   node scripts/check_upstream_drift.mjs --update   — re-pin snapshots after review
+//
+// Exit codes: 0 = in sync (or upstream unreachable — soft pass, warns only),
+//             1 = drift detected, 2 = usage error.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TARGETS = [
+  {
+    label: 'ranked regex (elfhosted whitelist)',
+    url: 'https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/regexes.json',
+    snapshot: resolve(root, 'Filtering/upstream/vidhin05-regexes.snapshot.json'),
+    key: entry => entry.name || entry.pattern?.slice(0, 80) || JSON.stringify(entry).slice(0, 80),
+  },
+  {
+    label: 'ranked stream expressions',
+    url: 'https://raw.githubusercontent.com/Vidhin05/Releases-Regex/main/English/expressions.json',
+    snapshot: resolve(root, 'Filtering/upstream/vidhin05-expressions.snapshot.json'),
+    key: entry => `${(entry.expression || '').slice(0, 90)}@${entry.score}`,
+  },
+];
+
+const update = process.argv.includes('--update');
+
+async function fetchJson(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 20000);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { 'user-agent': 'core-builds-drift-watch' } });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function diff(live, pinned, key) {
+  const keyOf = e => key(e);
+  const liveKeys = live.map(keyOf);
+  const pinnedKeys = pinned.map(keyOf);
+  const liveSet = new Set(liveKeys);
+  const pinnedSet = new Set(pinnedKeys);
+  const added = liveKeys.filter(k => !pinnedSet.has(k));
+  const removed = pinnedKeys.filter(k => !liveSet.has(k));
+  const liveByKey = new Map(live.map(e => [keyOf(e), e]));
+  const pinnedByKey = new Map(pinned.map(e => [keyOf(e), e]));
+  const changed = [...liveByKey].filter(([k, e]) =>
+    pinnedByKey.has(k) && JSON.stringify(pinnedByKey.get(k)) !== JSON.stringify(e)).map(([k]) => k);
+  const reordered = added.length === 0 && removed.length === 0 &&
+    liveKeys.some((k, i) => pinnedKeys[i] !== k);
+  return { added, removed, changed, reordered };
+}
+
+let drifted = false;
+let unreachable = false;
+
+for (const t of TARGETS) {
+  let live;
+  try {
+    live = await fetchJson(t.url);
+  } catch (err) {
+    console.warn(`⚠ ${t.label}: upstream unreachable (${err.message}) — skipping (soft pass)`);
+    unreachable = true;
+    continue;
+  }
+  if (!Array.isArray(live)) {
+    console.warn(`⚠ ${t.label}: upstream is no longer a JSON array — manual review required`);
+    drifted = true;
+    continue;
+  }
+
+  if (update) {
+    writeFileSync(t.snapshot, JSON.stringify(live, null, 2) + '\n');
+    console.log(`✓ ${t.label}: snapshot updated (${live.length} entries)`);
+    continue;
+  }
+
+  const pinned = JSON.parse(readFileSync(t.snapshot, 'utf8'));
+  if (JSON.stringify(pinned) === JSON.stringify(live)) {
+    console.log(`✓ ${t.label}: in sync (${live.length} entries)`);
+    continue;
+  }
+
+  drifted = true;
+  const d = diff(live, pinned, t.key);
+  console.log(`✗ ${t.label}: DRIFT — upstream ${live.length} entries vs pinned ${pinned.length}`);
+  for (const k of d.added.slice(0, 15)) console.log(`    + added:   ${k}`);
+  if (d.added.length > 15) console.log(`    … +${d.added.length - 15} more added`);
+  for (const k of d.removed.slice(0, 15)) console.log(`    - removed: ${k}`);
+  if (d.removed.length > 15) console.log(`    … +${d.removed.length - 15} more removed`);
+  for (const k of d.changed.slice(0, 15)) console.log(`    ~ changed: ${k}`);
+  if (d.changed.length > 15) console.log(`    … +${d.changed.length - 15} more changed`);
+  if (d.reordered) console.log('    ⇅ entry order changed (scores unchanged)');
+}
+
+if (update) {
+  console.log('\nSnapshots re-pinned. Review `git diff Filtering/upstream/` before committing.');
+  process.exit(0);
+}
+if (drifted) {
+  console.log('\nDrift detected. Review, then re-pin with: node scripts/check_upstream_drift.mjs --update');
+  console.log('Templates live-sync upstream — behaviour changes immediately whether we pin or not;');
+  console.log('the snapshot exists so the change is a reviewed event, not a silent one.');
+  process.exit(1);
+}
+if (unreachable) {
+  console.log('\nCould not reach upstream — no drift conclusion this run.');
+}
+process.exit(0);


### PR DESCRIPTION
From the 2026-07-26 audit. Rationale: docs/AUDIT-2026-07-26.md (lands in the docs-auto-sync PR). Stack/merge order: see CODESPACES-APPLY-GUIDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_