### PR TITLE
feat: filtering SEL v2 — new PSEs, ESEs, ISEs

### DIFF
--- a/Filtering/core-builds-eses.json
+++ b/Filtering/core-builds-eses.json
@@ -870,7 +870,7 @@
     ]
   },
   {
-    "expression": "/*Low SEL Score*/ count(streamExpressionScore(negate(merge(library(streams), seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),-50))<10?[]:streamExpressionScore(negate(merge(library(streams),seadex(streams)),streams),-1000000,-50)",
+    "expression": "/* Adaptive Score Floor */ count(streamExpressionScore(negate(merge(library(streams),seadex(streams)),merge(cached(streams),type(streams,'p2p','http'))),-50+min(30,daysSinceRelease*0.1)))<5?[]:streamExpressionScore(negate(merge(library(streams),seadex(streams)),streams),-1000000,-50+min(30,daysSinceRelease*0.1))",
     "enabled": true,
     "templates": [
       "4K AllDebrid",
@@ -1581,5 +1581,9 @@
     "templates": [
       "Samsung RU7100 4K"
     ]
+  },
+  {
+    "expression": "/* Low Seeder Cull */ count(seeders(merge(type(streams,'p2p'),type(uncached(streams),'debrid')),2))<=3?[]:seeders(merge(type(streams,'p2p'),type(uncached(streams),'debrid')),0,0)",
+    "enabled": true
   }
 ]

--- a/Filtering/core-builds-ises.json
+++ b/Filtering/core-builds-ises.json
@@ -312,5 +312,17 @@
     "templates": [
       "Apple TV 4K"
     ]
+  },
+  {
+    "expression": "/* Protect Library & SeaDex */ passthrough(merge(library(streams), seadex(streams)), 'excluded')",
+    "enabled": true
+  },
+  {
+    "expression": "/* ID-Matched Trust */ passthrough(idMatched(streams), 'title', 'year', 'episode')",
+    "enabled": true
+  },
+  {
+    "expression": "/* Smart Play Pin */ pin(message(streams, 'includes', '\ud83c\udfaf'), 'top')",
+    "enabled": true
   }
 ]

--- a/Filtering/core-builds-pses.json
+++ b/Filtering/core-builds-pses.json
@@ -1589,5 +1589,21 @@
       "Anime 4K",
       "Anime 4K Lite"
     ]
+  },
+  {
+    "expression": "/* QR Balance — HQ */ perGroup(quality(streams,'Bluray REMUX','Bluray','WEB-DL'),'resolution',3,'2160p','1080p','720p')",
+    "enabled": true
+  },
+  {
+    "expression": "/* QR Balance — LQ */ perGroup(quality(streams,'WEBRip','HDTV','HDRip'),'resolution',2,'1080p','720p','480p')",
+    "enabled": true
+  },
+  {
+    "expression": "/* Addon Diversity */ perGroup(cached(streams),'indexer',2)",
+    "enabled": true
+  },
+  {
+    "expression": "/* Bitrate Anomaly Pin */ count(values(resolution(quality(streams,'Bluray REMUX'),'2160p'),'bitrate'))>=4?pin(bitrate(resolution(quality(streams,'Bluray REMUX'),'2160p'),0,q1(values(resolution(quality(streams,'Bluray REMUX'),'2160p'),'bitrate'))-1.5*iqr(values(resolution(quality(streams,'Bluray REMUX'),'2160p'),'bitrate'))),'bottom'):[]",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
- **PSEs (4 new):** QR Balance HQ/LQ (perGroup quality+resolution caps), Addon Diversity (perGroup indexer cap), Bitrate Anomaly Pin (IQR-based bottom-pin for 4K REMUX outliers)
- **ESEs:** Adaptive Score Floor replaces Low SEL Score — uses `daysSinceRelease`-aware threshold (`-50+min(30,daysSinceRelease*0.1)`) so older titles relax the floor; Low Seeder Cull (zero-seeder kill when pool has 3+ seeded streams)
- **ISEs (3 new):** Protect Library & SeaDex passthrough, ID-Matched Trust passthrough, Smart Play Pin

## Test plan
- [ ] Verify all 3 JSON files parse correctly (validated locally)
- [ ] Confirm PSE count increased from 166 to 170
- [ ] Confirm ESE count increased from 83 to 84 (one replaced, one added)
- [ ] Confirm ISE count increased from 8 to 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_