### PR TITLE
fix(ci): downgrade drift-watch workflow to actions v4 and Node 22

### DIFF
--- a/.github/workflows/upstream-drift-watch.yml
+++ b/.github/workflows/upstream-drift-watch.yml
@@ -21,11 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: configurator/package-lock.json
 
       - name: Compare live upstream against pinned snapshots
         id: drift


### PR DESCRIPTION
## Summary
- Downgrades `actions/checkout` and `actions/setup-node` from v7 → v4 in `upstream-drift-watch.yml` (v7 doesn't exist)
- Changes Node.js from 24 → 22 (current LTS)
- Adds npm cache with `cache-dependency-path` for faster workflow runs

Same fix pattern as #600 applied to the remaining broken workflow.

## Test plan
- [ ] Verify drift-watch workflow runs successfully on next scheduled cron or manual trigger
- [ ] Confirm Node 22 + npm cache speeds up the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_