### PR TITLE
feat(account-tools): read-only Account Manager foundation

### DIFF
--- a/account-tools/package.json
+++ b/account-tools/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "core-builds-account-tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test 'tests/**/*.test.mjs'"
+  }
+}

--- a/account-tools/src/addon-model.js
+++ b/account-tools/src/addon-model.js
@@ -1,0 +1,95 @@
+const CREDENTIAL_FIELDS = /apiKey|password|secret|auth.*key|token/i;
+
+export function parseAddon(raw) {
+  return {
+    name: raw.manifest?.name || raw.transportName || 'Unknown Addon',
+    version: raw.manifest?.version || null,
+    description: raw.manifest?.description || null,
+    types: raw.manifest?.types || [],
+    catalogs: raw.manifest?.catalogs || [],
+    resources: raw.manifest?.resources || [],
+    transportUrl: raw.transportUrl || '',
+    flags: raw.flags || {},
+    id: raw.manifest?.id || null,
+  };
+}
+
+export function parseCollection(addons) {
+  return addons.map(parseAddon);
+}
+
+export function searchAddons(addons, query) {
+  if (!query) return addons;
+  const q = query.toLowerCase();
+  return addons.filter(a =>
+    a.name.toLowerCase().includes(q) ||
+    (a.description || '').toLowerCase().includes(q) ||
+    a.transportUrl.toLowerCase().includes(q) ||
+    (a.id || '').toLowerCase().includes(q)
+  );
+}
+
+export function filterByType(addons, type) {
+  if (!type) return addons;
+  return addons.filter(a => a.types.includes(type));
+}
+
+export function hasCredentialRisk(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    const path = decodeURIComponent(parsed.pathname + parsed.search);
+    const segments = path.split(/[/&?=]/);
+    return segments.some(s => s.length >= 16 && /^[a-zA-Z0-9+/=_-]+$/.test(s));
+  } catch {
+    return false;
+  }
+}
+
+export function getCredentialWarnings(addons) {
+  const warnings = [];
+  for (const addon of addons) {
+    if (hasCredentialRisk(addon.transportUrl)) {
+      warnings.push({
+        addon: addon.name,
+        url: redactUrl(addon.transportUrl),
+        message: 'Transport URL may contain embedded credentials',
+      });
+    }
+  }
+  return warnings;
+}
+
+export function redactUrl(url) {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split('/');
+    const redacted = segments.map(s =>
+      s.length >= 16 && /^[a-zA-Z0-9+/=_-]+$/.test(s) ? '[REDACTED]' : s
+    );
+    parsed.pathname = redacted.join('/');
+    for (const [k, v] of parsed.searchParams) {
+      if (CREDENTIAL_FIELDS.test(k) || (v.length >= 16 && /^[a-zA-Z0-9+/=_-]+$/.test(v))) {
+        parsed.searchParams.set(k, '[REDACTED]');
+      }
+    }
+    return parsed.toString();
+  } catch {
+    return url.replace(/[a-zA-Z0-9+/=_-]{16,}/g, '[REDACTED]');
+  }
+}
+
+export function inspectManifest(addon) {
+  return {
+    name: addon.name,
+    version: addon.version,
+    description: addon.description,
+    id: addon.id,
+    types: addon.types,
+    catalogs: addon.catalogs.length,
+    resources: addon.resources.length,
+    transportUrl: redactUrl(addon.transportUrl),
+    hasCredentialRisk: hasCredentialRisk(addon.transportUrl),
+  };
+}

--- a/account-tools/src/app.js
+++ b/account-tools/src/app.js
@@ -1,0 +1,89 @@
+import { login, loginWithAuthKey, getAddonCollection } from './stremio-api.js';
+import { setSession, clearSession, getAuthKey, getEmail, isAuthenticated, onSessionChange } from './auth-session.js';
+import { parseCollection, searchAddons, filterByType, getCredentialWarnings, inspectManifest } from './addon-model.js';
+import { createBackup, parseBackup, downloadBackup } from './backup.js';
+import { diffSnapshots, formatDiff } from './diff.js';
+
+let _addons = [];
+let _parsedAddons = [];
+let _lastBackup = null;
+
+export async function loginWithEmail(email, password) {
+  const authKey = await login(email, password);
+  setSession(authKey, email);
+  await loadAddons();
+  return _parsedAddons;
+}
+
+export async function loginWithKey(authKey) {
+  await loginWithAuthKey(authKey);
+  setSession(authKey);
+  await loadAddons();
+  return _parsedAddons;
+}
+
+export async function loadAddons() {
+  const authKey = getAuthKey();
+  if (!authKey) throw new Error('Not authenticated');
+  _addons = await getAddonCollection(authKey);
+  _parsedAddons = parseCollection(_addons);
+  return _parsedAddons;
+}
+
+export function getAddons() {
+  return _parsedAddons;
+}
+
+export function search(query) {
+  return searchAddons(_parsedAddons, query);
+}
+
+export function filterType(type) {
+  return filterByType(_parsedAddons, type);
+}
+
+export function inspect(index) {
+  const addon = _parsedAddons[index];
+  if (!addon) throw new Error(`No addon at index ${index}`);
+  return inspectManifest(addon);
+}
+
+export function getWarnings() {
+  return getCredentialWarnings(_parsedAddons);
+}
+
+export function exportBackup() {
+  if (_addons.length === 0) throw new Error('No addons loaded');
+  _lastBackup = createBackup(_addons, { email: getEmail(), source: 'account-tools' });
+  return _lastBackup;
+}
+
+export function exportAndDownload() {
+  const backup = exportBackup();
+  downloadBackup(backup);
+  return backup;
+}
+
+export function importBackup(jsonOrString) {
+  const backup = parseBackup(jsonOrString);
+  return {
+    backup,
+    parsed: parseCollection(backup.addons),
+  };
+}
+
+export function compareSnapshots(backupA, backupB) {
+  const a = parseBackup(backupA);
+  const b = parseBackup(backupB);
+  const result = diffSnapshots(a, b);
+  return { ...result, formatted: formatDiff(result) };
+}
+
+export function logout() {
+  _addons = [];
+  _parsedAddons = [];
+  _lastBackup = null;
+  clearSession();
+}
+
+export { isAuthenticated, onSessionChange };

--- a/account-tools/src/auth-session.js
+++ b/account-tools/src/auth-session.js
@@ -1,0 +1,38 @@
+let _authKey = null;
+let _email = null;
+const _listeners = new Set();
+
+export function setSession(authKey, email = null) {
+  _authKey = authKey;
+  _email = email;
+  _notify();
+}
+
+export function clearSession() {
+  _authKey = null;
+  _email = null;
+  _notify();
+}
+
+export function getAuthKey() {
+  return _authKey;
+}
+
+export function getEmail() {
+  return _email;
+}
+
+export function isAuthenticated() {
+  return _authKey !== null;
+}
+
+export function onSessionChange(fn) {
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}
+
+function _notify() {
+  for (const fn of _listeners) {
+    try { fn({ authKey: _authKey, email: _email }); } catch {}
+  }
+}

--- a/account-tools/src/backup.js
+++ b/account-tools/src/backup.js
@@ -1,0 +1,44 @@
+const BACKUP_VERSION = 1;
+
+export function createBackup(addons, meta = {}) {
+  return {
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    source: meta.source || 'account-tools',
+    email: meta.email || null,
+    addonCount: addons.length,
+    addons,
+  };
+}
+
+export function parseBackup(json) {
+  if (typeof json === 'string') json = JSON.parse(json);
+  if (json.version === BACKUP_VERSION && Array.isArray(json.addons)) return json;
+  if (json?.result?.addons) {
+    return createBackup(json.result.addons, { source: 'api-import' });
+  }
+  if (Array.isArray(json?.addons)) {
+    return createBackup(json.addons, { source: 'legacy-import' });
+  }
+  throw new Error('Unrecognized backup format');
+}
+
+export function downloadBackup(backup) {
+  const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  a.href = url;
+  a.download = `stremio-backup-${ts}.json`;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 200);
+}
+
+export function isValidBackup(data) {
+  try {
+    parseBackup(data);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/account-tools/src/diff.js
+++ b/account-tools/src/diff.js
@@ -1,0 +1,60 @@
+export function diffSnapshots(snapshotA, snapshotB) {
+  const addonsA = snapshotA.addons || [];
+  const addonsB = snapshotB.addons || [];
+
+  const urlsA = new Map(addonsA.map(a => [a.transportUrl, a]));
+  const urlsB = new Map(addonsB.map(a => [a.transportUrl, a]));
+
+  const added = [];
+  const removed = [];
+  const moved = [];
+
+  for (const [url, addon] of urlsB) {
+    if (!urlsA.has(url)) added.push(addon);
+  }
+  for (const [url, addon] of urlsA) {
+    if (!urlsB.has(url)) removed.push(addon);
+  }
+
+  const shared = addonsA.filter(a => urlsB.has(a.transportUrl));
+  for (const addon of shared) {
+    const idxA = addonsA.findIndex(a => a.transportUrl === addon.transportUrl);
+    const idxB = addonsB.findIndex(a => a.transportUrl === addon.transportUrl);
+    if (idxA !== idxB) {
+      moved.push({ addon, from: idxA, to: idxB });
+    }
+  }
+
+  return {
+    added,
+    removed,
+    moved,
+    unchanged: shared.length - moved.length,
+    totalA: addonsA.length,
+    totalB: addonsB.length,
+    hasDifferences: added.length > 0 || removed.length > 0 || moved.length > 0,
+  };
+}
+
+export function formatDiff(diff) {
+  const lines = [];
+  lines.push(`Snapshot A: ${diff.totalA} addons`);
+  lines.push(`Snapshot B: ${diff.totalB} addons`);
+  lines.push('');
+
+  if (diff.added.length > 0) {
+    lines.push(`Added (${diff.added.length}):`);
+    for (const a of diff.added) lines.push(`  + ${a.name || a.manifest?.name || a.transportUrl}`);
+  }
+  if (diff.removed.length > 0) {
+    lines.push(`Removed (${diff.removed.length}):`);
+    for (const a of diff.removed) lines.push(`  - ${a.name || a.manifest?.name || a.transportUrl}`);
+  }
+  if (diff.moved.length > 0) {
+    lines.push(`Reordered (${diff.moved.length}):`);
+    for (const m of diff.moved) lines.push(`  ~ ${m.addon.name || m.addon.manifest?.name}: ${m.from + 1} → ${m.to + 1}`);
+  }
+  if (!diff.hasDifferences) lines.push('No differences found.');
+
+  return lines.join('\n');
+}

--- a/account-tools/src/stremio-api.js
+++ b/account-tools/src/stremio-api.js
@@ -1,0 +1,32 @@
+const API_BASE = 'https://api.strem.io/api/';
+
+export async function post(path, body) {
+  const res = await fetch(API_BASE + path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Stremio API error ${res.status}`);
+  const data = await res.json();
+  if (data.error) throw new Error(data.error);
+  return data;
+}
+
+export async function login(email, password) {
+  const data = await post('login', { type: 'Login', email, password, facebook: false });
+  const authKey = data?.result?.authKey;
+  if (!authKey) throw new Error('Login failed — no auth key returned');
+  return authKey;
+}
+
+export async function loginWithAuthKey(authKey) {
+  const data = await post('addonCollectionGet', { type: 'AddonCollectionGet', authKey, update: true });
+  if (!data?.result?.addons) throw new Error('Invalid auth key — could not load addons');
+  return data;
+}
+
+export async function getAddonCollection(authKey) {
+  const data = await post('addonCollectionGet', { type: 'AddonCollectionGet', authKey, update: true });
+  if (!data?.result?.addons) throw new Error('Failed to load addon collection');
+  return data.result.addons;
+}

--- a/account-tools/tests/addon-model.test.mjs
+++ b/account-tools/tests/addon-model.test.mjs
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseAddon,
+  parseCollection,
+  searchAddons,
+  filterByType,
+  hasCredentialRisk,
+  getCredentialWarnings,
+  redactUrl,
+  inspectManifest,
+} from '../src/addon-model.js';
+
+const ADDON_A = {
+  manifest: { name: 'Torrentio', version: '0.0.14', description: 'Torrent streaming', id: 'torrentio', types: ['movie', 'series'], catalogs: [], resources: ['stream'] },
+  transportUrl: 'https://torrentio.strem.fun/manifest.json',
+  flags: {},
+};
+
+const ADDON_B = {
+  manifest: { name: 'Comet', version: '1.0', description: 'Comet addon', id: 'comet', types: ['movie'], catalogs: [{ type: 'movie' }], resources: ['stream'] },
+  transportUrl: 'https://comet.example.com/abc123def456ghi789jkl012mno345/manifest.json',
+  flags: {},
+};
+
+const ADDON_BARE = { transportName: 'Legacy', transportUrl: 'https://x.com/m.json' };
+
+test('parseAddon: extracts manifest fields', () => {
+  const p = parseAddon(ADDON_A);
+  assert.equal(p.name, 'Torrentio');
+  assert.equal(p.version, '0.0.14');
+  assert.equal(p.id, 'torrentio');
+  assert.deepEqual(p.types, ['movie', 'series']);
+});
+
+test('parseAddon: handles missing manifest', () => {
+  const p = parseAddon(ADDON_BARE);
+  assert.equal(p.name, 'Legacy');
+  assert.equal(p.version, null);
+});
+
+test('parseCollection: maps array', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  assert.equal(coll.length, 2);
+  assert.equal(coll[0].name, 'Torrentio');
+  assert.equal(coll[1].name, 'Comet');
+});
+
+test('searchAddons: filters by name', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  const results = searchAddons(coll, 'torrent');
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, 'Torrentio');
+});
+
+test('searchAddons: filters by description', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  const results = searchAddons(coll, 'comet addon');
+  assert.equal(results.length, 1);
+});
+
+test('searchAddons: empty query returns all', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  assert.equal(searchAddons(coll, '').length, 2);
+  assert.equal(searchAddons(coll, null).length, 2);
+});
+
+test('filterByType: filters by type', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  const movies = filterByType(coll, 'movie');
+  assert.equal(movies.length, 2);
+  const series = filterByType(coll, 'series');
+  assert.equal(series.length, 1);
+  assert.equal(series[0].name, 'Torrentio');
+});
+
+test('filterByType: null returns all', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  assert.equal(filterByType(coll, null).length, 2);
+});
+
+test('hasCredentialRisk: detects long tokens in URL path', () => {
+  assert.ok(hasCredentialRisk('https://x.com/abc123def456ghi789jkl012mno345/manifest.json'));
+});
+
+test('hasCredentialRisk: safe URL returns false', () => {
+  assert.ok(!hasCredentialRisk('https://torrentio.strem.fun/manifest.json'));
+});
+
+test('hasCredentialRisk: handles null', () => {
+  assert.ok(!hasCredentialRisk(null));
+  assert.ok(!hasCredentialRisk(''));
+});
+
+test('getCredentialWarnings: returns warnings for risky URLs', () => {
+  const coll = parseCollection([ADDON_A, ADDON_B]);
+  const warnings = getCredentialWarnings(coll);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].addon, 'Comet');
+  assert.ok(!warnings[0].url.includes('abc123def456ghi789jkl012mno345'));
+});
+
+test('redactUrl: redacts long path segments', () => {
+  const r = redactUrl('https://comet.example.com/abc123def456ghi789jkl012mno345/manifest.json');
+  assert.ok(r.includes('[REDACTED]'));
+  assert.ok(!r.includes('abc123def456ghi789jkl012mno345'));
+});
+
+test('redactUrl: preserves short segments', () => {
+  const r = redactUrl('https://example.com/short/manifest.json');
+  assert.ok(r.includes('short'));
+});
+
+test('redactUrl: handles query params with credential names', () => {
+  const r = redactUrl('https://x.com/m.json?apiKey=secretvalue12345678');
+  assert.ok(!r.includes('secretvalue12345678'));
+  assert.ok(r.includes('REDACTED'));
+});
+
+test('inspectManifest: returns redacted summary', () => {
+  const p = parseAddon(ADDON_B);
+  const info = inspectManifest(p);
+  assert.equal(info.name, 'Comet');
+  assert.ok(!info.transportUrl.includes('abc123def456ghi789jkl012mno345'));
+  assert.ok(info.hasCredentialRisk);
+});

--- a/account-tools/tests/auth-session.test.mjs
+++ b/account-tools/tests/auth-session.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  setSession,
+  clearSession,
+  getAuthKey,
+  getEmail,
+  isAuthenticated,
+  onSessionChange,
+} from '../src/auth-session.js';
+
+test('session: starts unauthenticated', () => {
+  clearSession();
+  assert.ok(!isAuthenticated());
+  assert.equal(getAuthKey(), null);
+  assert.equal(getEmail(), null);
+});
+
+test('session: setSession stores auth key and email', () => {
+  setSession('test-key-123', 'user@example.com');
+  assert.ok(isAuthenticated());
+  assert.equal(getAuthKey(), 'test-key-123');
+  assert.equal(getEmail(), 'user@example.com');
+});
+
+test('session: clearSession removes credentials', () => {
+  setSession('key', 'email');
+  clearSession();
+  assert.ok(!isAuthenticated());
+  assert.equal(getAuthKey(), null);
+  assert.equal(getEmail(), null);
+});
+
+test('session: onSessionChange fires on set', () => {
+  clearSession();
+  let called = false;
+  const unsub = onSessionChange(({ authKey, email }) => {
+    called = true;
+    assert.equal(authKey, 'new-key');
+    assert.equal(email, 'new@test.com');
+  });
+  setSession('new-key', 'new@test.com');
+  assert.ok(called);
+  unsub();
+  clearSession();
+});
+
+test('session: onSessionChange fires on clear', () => {
+  setSession('key', 'email');
+  let called = false;
+  const unsub = onSessionChange(({ authKey }) => {
+    called = true;
+    assert.equal(authKey, null);
+  });
+  clearSession();
+  assert.ok(called);
+  unsub();
+});
+
+test('session: unsubscribe stops notifications', () => {
+  clearSession();
+  let count = 0;
+  const unsub = onSessionChange(() => count++);
+  setSession('a', 'b');
+  unsub();
+  setSession('c', 'd');
+  assert.equal(count, 1);
+  clearSession();
+});
+
+test('session: auth key without email', () => {
+  clearSession();
+  setSession('auth-key-only');
+  assert.ok(isAuthenticated());
+  assert.equal(getEmail(), null);
+  clearSession();
+});

--- a/account-tools/tests/backup.test.mjs
+++ b/account-tools/tests/backup.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBackup, parseBackup, isValidBackup } from '../src/backup.js';
+
+const ADDONS = [
+  { manifest: { name: 'Addon1' }, transportUrl: 'https://a.com/m.json' },
+  { manifest: { name: 'Addon2' }, transportUrl: 'https://b.com/m.json' },
+];
+
+test('createBackup: creates versioned backup', () => {
+  const b = createBackup(ADDONS, { email: 'test@test.com', source: 'test' });
+  assert.equal(b.version, 1);
+  assert.equal(b.addonCount, 2);
+  assert.equal(b.email, 'test@test.com');
+  assert.equal(b.source, 'test');
+  assert.ok(b.exportedAt);
+  assert.equal(b.addons.length, 2);
+});
+
+test('parseBackup: parses own format', () => {
+  const b = createBackup(ADDONS);
+  const parsed = parseBackup(b);
+  assert.equal(parsed.addonCount, 2);
+});
+
+test('parseBackup: parses from JSON string', () => {
+  const b = createBackup(ADDONS);
+  const parsed = parseBackup(JSON.stringify(b));
+  assert.equal(parsed.addonCount, 2);
+});
+
+test('parseBackup: handles API response format', () => {
+  const apiRes = { result: { addons: ADDONS } };
+  const parsed = parseBackup(apiRes);
+  assert.equal(parsed.addonCount, 2);
+  assert.equal(parsed.source, 'api-import');
+});
+
+test('parseBackup: handles legacy format', () => {
+  const legacy = { addons: ADDONS };
+  const parsed = parseBackup(legacy);
+  assert.equal(parsed.addonCount, 2);
+  assert.equal(parsed.source, 'legacy-import');
+});
+
+test('parseBackup: rejects invalid format', () => {
+  assert.throws(() => parseBackup({ bad: true }), /Unrecognized backup format/);
+});
+
+test('isValidBackup: true for valid', () => {
+  assert.ok(isValidBackup(createBackup(ADDONS)));
+});
+
+test('isValidBackup: false for invalid', () => {
+  assert.ok(!isValidBackup({ bad: true }));
+});

--- a/account-tools/tests/diff.test.mjs
+++ b/account-tools/tests/diff.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { diffSnapshots, formatDiff } from '../src/diff.js';
+
+const SNAPSHOT_A = {
+  addons: [
+    { name: 'Torrentio', transportUrl: 'https://torrentio.strem.fun/manifest.json' },
+    { name: 'Comet', transportUrl: 'https://comet.example.com/manifest.json' },
+    { name: 'Cinemeta', transportUrl: 'https://cinemeta.strem.io/manifest.json' },
+  ],
+};
+
+const SNAPSHOT_B = {
+  addons: [
+    { name: 'Torrentio', transportUrl: 'https://torrentio.strem.fun/manifest.json' },
+    { name: 'Cinemeta', transportUrl: 'https://cinemeta.strem.io/manifest.json' },
+    { name: 'NewAddon', transportUrl: 'https://new.example.com/manifest.json' },
+  ],
+};
+
+test('diffSnapshots: detects added addons', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_B);
+  assert.equal(d.added.length, 1);
+  assert.equal(d.added[0].name, 'NewAddon');
+});
+
+test('diffSnapshots: detects removed addons', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_B);
+  assert.equal(d.removed.length, 1);
+  assert.equal(d.removed[0].name, 'Comet');
+});
+
+test('diffSnapshots: detects reordered addons', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_B);
+  assert.equal(d.moved.length, 1);
+  assert.equal(d.moved[0].addon.name, 'Cinemeta');
+  assert.equal(d.moved[0].from, 2);
+  assert.equal(d.moved[0].to, 1);
+});
+
+test('diffSnapshots: identical snapshots', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_A);
+  assert.equal(d.added.length, 0);
+  assert.equal(d.removed.length, 0);
+  assert.equal(d.moved.length, 0);
+  assert.ok(!d.hasDifferences);
+});
+
+test('diffSnapshots: reports counts', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_B);
+  assert.equal(d.totalA, 3);
+  assert.equal(d.totalB, 3);
+  assert.ok(d.hasDifferences);
+});
+
+test('diffSnapshots: handles empty snapshots', () => {
+  const d = diffSnapshots({ addons: [] }, SNAPSHOT_A);
+  assert.equal(d.added.length, 3);
+  assert.equal(d.removed.length, 0);
+});
+
+test('formatDiff: produces readable output', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_B);
+  const text = formatDiff(d);
+  assert.ok(text.includes('Added (1)'));
+  assert.ok(text.includes('Removed (1)'));
+  assert.ok(text.includes('Reordered (1)'));
+  assert.ok(text.includes('NewAddon'));
+  assert.ok(text.includes('Comet'));
+});
+
+test('formatDiff: no differences message', () => {
+  const d = diffSnapshots(SNAPSHOT_A, SNAPSHOT_A);
+  const text = formatDiff(d);
+  assert.ok(text.includes('No differences found'));
+});


### PR DESCRIPTION
## Description

Adds the modular read-only Account Manager foundation per post-PR #623 Phase 6. All operations are read-only — no mutation endpoints, no addon install/uninstall/reorder in this PR.

### Modules

| File | Purpose |
|------|---------|
| `src/stremio-api.js` | Stremio API client (email/password login, auth-key login, addon collection fetch) |
| `src/auth-session.js` | In-memory session with change-subscription pattern |
| `src/addon-model.js` | Addon parsing, search/filter by name/type, credential-risk detection, URL redaction, manifest inspection |
| `src/backup.js` | Versioned backup export/import with auto-detection (own format, API response, legacy) |
| `src/diff.js` | Snapshot comparison — detects added, removed, and reordered addons |
| `src/app.js` | Orchestrator exposing the public API surface |

### Features
- Email/password login
- Auth-key login
- Load addon collection
- Manifest inspection (with redacted URLs)
- Search by name/description/URL/ID
- Filter by content type
- Versioned backup export
- Backup import (3 format variants)
- Snapshot comparison (added/removed/reordered)
- Credential-risk warnings (detects embedded tokens in transport URLs)
- Clear session

### Security
- No passwords or auth keys stored to disk (in-memory only)
- No account data sent to analytics
- No raw API values inserted into HTML
- No credentials in logs, diagnostics, or diffs
- URL redaction for long path segments and credential-named query params
- No mutation in this PR

## Type of Change
- [x] Workflow / infrastructure

## Testing
- 39 unit tests covering all modules (addon-model, auth-session, backup, diff)
- All existing suites pass: 64 CLI, 230 Configurator, 241 pytest


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_