### PR TITLE
feat(account-tools): reorder/restore mutations with rollback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ tools/                      — Tools hub
   inspector/                — Template Inspector (paste JSON for instant validation)
   debug/                    — Debug utilities
 account-tools/              — Addon Backup (read-only Stremio addon backup)
-cli/                        — CLI tool (planned)
+cli/                        — CLI tool (available)
 cloudflare-worker/          — CORS proxy (Cloudflare Worker for cross-origin requests)
 AIOMetadata/                — AIOMetadata configs (movies+TV, full)
 
@@ -121,8 +121,8 @@ The `build()` function (line ~3400) assembles the full AIOStreams config from cu
 | **Template Builder** | `configurator/` | Live — the configurator |
 | **Template Inspector** | `tools/inspector/` | Live — paste/upload/fetch JSON for instant validation, health score, host compatibility |
 | **Addon Backup** | `account-tools/` | Live — read-only Stremio addon backup |
-| **Account Manager** | planned | Locked |
-| **CLI** | `cli/` | Planned |
+| **Account Manager** | `account-tools/` | In development — addon reorder, restore, rollback |
+| **CLI** | `cli/` | Available |
 | **CORS Proxy** | `cloudflare-worker/` | Live — Cloudflare Worker for cross-origin config push |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ The `build()` function (line ~3400) assembles the full AIOStreams config from cu
 | **Template Builder** | `configurator/` | Live — the configurator |
 | **Template Inspector** | `tools/inspector/` | Live — paste/upload/fetch JSON for instant validation, health score, host compatibility |
 | **Addon Backup** | `account-tools/` | Live — read-only Stremio addon backup |
-| **Account Manager** | `account-tools/` | In development — addon reorder, restore, rollback |
+| **Account Manager** | `account-tools/` | In development — addon reorder, removal, restore, rollback |
 | **CLI** | `cli/` | Available |
 | **CORS Proxy** | `cloudflare-worker/` | Live — Cloudflare Worker for cross-origin config push |
 

--- a/account-tools/.gitignore
+++ b/account-tools/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+test-results/

--- a/account-tools/e2e/mutations.spec.mjs
+++ b/account-tools/e2e/mutations.spec.mjs
@@ -1,0 +1,250 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PAGE_PATH = 'file://' + path.resolve(__dirname, '..', 'index.html');
+
+const FIXTURE = [
+  { manifest: { id: 'torrentio', name: 'Torrentio', version: '1.0', types: ['movie'], resources: ['stream'] }, transportUrl: 'https://torrentio.example.com/manifest.json', flags: {} },
+  { manifest: { id: 'comet', name: 'Comet', version: '1.0', types: ['movie'], resources: ['stream'] }, transportUrl: 'https://comet.example.com/manifest.json', flags: {} },
+  { manifest: { id: 'cinemeta', name: 'Cinemeta', version: '1.0', types: ['movie'], resources: ['meta'] }, transportUrl: 'https://cinemeta.example.com/manifest.json', flags: {} },
+];
+
+function setupRoutes(page, options = {}) {
+  const setCalls = [];
+  let serverAddons = JSON.parse(JSON.stringify(options.addons || FIXTURE));
+  const shouldFailSet = options.failSet || false;
+
+  page.route('https://api.strem.io/api/**', async (route) => {
+    const url = route.request().url();
+    const body = route.request().postDataJSON();
+
+    if (url.includes('login')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ result: { authKey: 'TEST_AUTH_KEY' } }),
+      });
+    }
+
+    if (url.includes('addonCollectionGet')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ result: { addons: JSON.parse(JSON.stringify(serverAddons)) } }),
+      });
+    }
+
+    if (url.includes('addonCollectionSet')) {
+      if (shouldFailSet) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Server write failed' }),
+        });
+      }
+      setCalls.push(JSON.parse(JSON.stringify(body.addons)));
+      serverAddons = JSON.parse(JSON.stringify(body.addons));
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ result: true }),
+      });
+    }
+
+    return route.fulfill({ status: 404, body: 'Not found' });
+  });
+
+  return {
+    setCalls,
+    getServerAddons: () => serverAddons,
+    setServerAddons: (a) => { serverAddons = JSON.parse(JSON.stringify(a)); },
+  };
+}
+
+async function loginViaAuthKey(page) {
+  await page.click('.tab[data-tab="authkey-tab"]');
+  await page.fill('#authkey', 'TEST_AUTH_KEY');
+  await page.click('#loginKey');
+  await expect(page.locator('#addon-list .addon')).toHaveCount(3);
+}
+
+test.describe('mutations', () => {
+
+  test('reorder success — move first addon down', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    const moveDownBtn = page.locator('[data-move="down"][data-idx="0"]');
+    await moveDownBtn.click();
+
+    await expect(page.locator('#status')).toContainText(/moved|Undo/i, { timeout: 5000 });
+    expect(setCalls.length).toBeGreaterThanOrEqual(1);
+    expect(setCalls[0][0].manifest.id).toBe('comet');
+    expect(setCalls[0][1].manifest.id).toBe('torrentio');
+    expect(setCalls[0][2].manifest.id).toBe('cinemeta');
+  });
+
+  test('undo reorder restores original order', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    await page.locator('[data-move="down"][data-idx="0"]').click();
+    await expect(page.locator('#undo-card')).toBeVisible({ timeout: 5000 });
+
+    await page.click('#undoBtn');
+    await expect(page.locator('#status')).toContainText(/undo complete|restored/i, { timeout: 5000 });
+
+    expect(setCalls.length).toBeGreaterThanOrEqual(2);
+    const undoCall = setCalls[setCalls.length - 1];
+    expect(undoCall[0].manifest.id).toBe('torrentio');
+    expect(undoCall[1].manifest.id).toBe('comet');
+    expect(undoCall[2].manifest.id).toBe('cinemeta');
+  });
+
+  test('remove addon — confirm removal', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    const removeBtn = page.locator('[data-remove="1"]');
+    await removeBtn.click();
+
+    await expect(page.locator('#status')).toContainText(/removed|Undo/i, { timeout: 5000 });
+    expect(setCalls.length).toBeGreaterThanOrEqual(1);
+    const setCall = setCalls[0];
+    expect(setCall.length).toBe(2);
+    expect(setCall[0].manifest.id).toBe('torrentio');
+    expect(setCall[1].manifest.id).toBe('cinemeta');
+  });
+
+  test('cancel remove — dismiss confirm, no mutation', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.dismiss());
+
+    const removeBtn = page.locator('[data-remove="1"]');
+    await removeBtn.click();
+
+    // Give a moment for any potential call
+    await page.waitForTimeout(500);
+    expect(setCalls.length).toBe(0);
+  });
+
+  test('restore backup — upload and confirm', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    const backup = {
+      version: 1,
+      addons: [
+        { manifest: { id: 'newaddon', name: 'NewAddon', version: '1.0', types: ['movie'], resources: ['stream'] }, transportUrl: 'https://newaddon.example.com/manifest.json', flags: {} },
+      ],
+    };
+
+    const tmpFile = path.join(os.tmpdir(), 'test-backup-' + Date.now() + '.json');
+    fs.writeFileSync(tmpFile, JSON.stringify(backup));
+
+    try {
+      const fileInput = page.locator('#restoreFile');
+      await fileInput.setInputFiles(tmpFile);
+
+      await expect(page.locator('#status')).toContainText(/restored|Undo/i, { timeout: 5000 });
+      expect(setCalls.length).toBeGreaterThanOrEqual(1);
+      expect(setCalls[0].length).toBe(1);
+      expect(setCalls[0][0].manifest.id).toBe('newaddon');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('cancel restore — dismiss confirm, no mutation', async ({ page }) => {
+    const { setCalls } = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.dismiss());
+
+    const backup = {
+      version: 1,
+      addons: [
+        { manifest: { id: 'newaddon', name: 'NewAddon', version: '1.0', types: ['movie'], resources: ['stream'] }, transportUrl: 'https://newaddon.example.com/manifest.json', flags: {} },
+      ],
+    };
+
+    const tmpFile = path.join(os.tmpdir(), 'test-backup-cancel-' + Date.now() + '.json');
+    fs.writeFileSync(tmpFile, JSON.stringify(backup));
+
+    try {
+      const fileInput = page.locator('#restoreFile');
+      await fileInput.setInputFiles(tmpFile);
+
+      await page.waitForTimeout(500);
+      expect(setCalls.length).toBe(0);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('write failure — move shows error', async ({ page }) => {
+    setupRoutes(page, { failSet: true });
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    await page.locator('[data-move="down"][data-idx="0"]').click();
+
+    await expect(page.locator('#status')).toContainText(/failed|error/i, { timeout: 5000 });
+  });
+
+  test('reload verification — undo available after successful write', async ({ page }) => {
+    const ctx = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    page.on('dialog', async (d) => d.accept());
+
+    await page.locator('[data-move="down"][data-idx="0"]').click();
+
+    await expect(page.locator('#status')).toContainText(/moved|Undo/i, { timeout: 5000 });
+    await expect(page.locator('#undo-card')).toBeVisible();
+  });
+
+  test('stale-state protection — refuses move when server changed', async ({ page }) => {
+    const ctx = setupRoutes(page);
+    await page.goto(PAGE_PATH);
+    await loginViaAuthKey(page);
+
+    // After login, change server addons so they differ from the UI's currentSnapshot
+    const alteredAddons = [
+      { manifest: { id: 'changed', name: 'Changed', version: '1.0', types: ['movie'], resources: ['stream'] }, transportUrl: 'https://changed.example.com/manifest.json', flags: {} },
+    ];
+    ctx.setServerAddons(alteredAddons);
+
+    page.on('dialog', async (d) => d.accept());
+
+    await page.locator('[data-move="down"][data-idx="0"]').click();
+
+    await expect(page.locator('#status')).toContainText(/changed on server|reloading/i, { timeout: 5000 });
+    // setCalls should be empty — move was refused
+    expect(ctx.setCalls.length).toBe(0);
+  });
+
+});

--- a/account-tools/e2e/mutations.spec.mjs
+++ b/account-tools/e2e/mutations.spec.mjs
@@ -13,12 +13,12 @@ const FIXTURE = [
   { manifest: { id: 'cinemeta', name: 'Cinemeta', version: '1.0', types: ['movie'], resources: ['meta'] }, transportUrl: 'https://cinemeta.example.com/manifest.json', flags: {} },
 ];
 
-function setupRoutes(page, options = {}) {
+async function setupRoutes(page, options = {}) {
   const setCalls = [];
   let serverAddons = JSON.parse(JSON.stringify(options.addons || FIXTURE));
   const shouldFailSet = options.failSet || false;
 
-  page.route('https://api.strem.io/api/**', async (route) => {
+  await page.route('https://api.strem.io/api/**', async (route) => {
     const url = route.request().url();
     const body = route.request().postDataJSON();
 
@@ -75,7 +75,7 @@ async function loginViaAuthKey(page) {
 test.describe('mutations', () => {
 
   test('reorder success — move first addon down', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -92,7 +92,7 @@ test.describe('mutations', () => {
   });
 
   test('undo reorder restores original order', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -112,7 +112,7 @@ test.describe('mutations', () => {
   });
 
   test('remove addon — confirm removal', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -130,7 +130,7 @@ test.describe('mutations', () => {
   });
 
   test('cancel remove — dismiss confirm, no mutation', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -145,7 +145,7 @@ test.describe('mutations', () => {
   });
 
   test('restore backup — upload and confirm', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -175,7 +175,7 @@ test.describe('mutations', () => {
   });
 
   test('cancel restore — dismiss confirm, no mutation', async ({ page }) => {
-    const { setCalls } = setupRoutes(page);
+    const { setCalls } = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -203,7 +203,7 @@ test.describe('mutations', () => {
   });
 
   test('write failure — move shows error', async ({ page }) => {
-    setupRoutes(page, { failSet: true });
+    await setupRoutes(page, { failSet: true });
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -215,7 +215,7 @@ test.describe('mutations', () => {
   });
 
   test('reload verification — undo available after successful write', async ({ page }) => {
-    const ctx = setupRoutes(page);
+    const ctx = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 
@@ -228,7 +228,7 @@ test.describe('mutations', () => {
   });
 
   test('stale-state protection — refuses move when server changed', async ({ page }) => {
-    const ctx = setupRoutes(page);
+    const ctx = await setupRoutes(page);
     await page.goto(PAGE_PATH);
     await loginViaAuthKey(page);
 

--- a/account-tools/index.html
+++ b/account-tools/index.html
@@ -438,11 +438,10 @@ async function doMove(fromIdx,toIdx){
   try{
     $('status').textContent='Moving addon…';
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:reordered});
-    const ok=await reloadAddons();
-    if(!ok){$('status').textContent='Move saved but reload failed.';return}
     showUndo({addons:prev,label:'move'});
-    $('status').textContent='Addon moved. Undo available.';
+    const ok=await reloadAddons();
     $('undo-label').textContent='Last: moved '+esc(item.manifest?.name||'addon')+' — undo available';
+    $('status').textContent=ok?'Addon moved. Undo available.':'Move saved but reload failed. Undo available.';
   }catch(e){
     $('status').textContent='Move failed: '+e.message;
   }
@@ -460,6 +459,8 @@ $('addon-list').addEventListener('click',e=>{
 
 $('undoBtn').onclick=async()=>{
   if(!undoStack.length||!authKey)return;
+  const btn=$('undoBtn');
+  btn.disabled=true;
   const snap=undoStack[undoStack.length-1];
   try{
     $('status').textContent='Undoing…';
@@ -471,6 +472,7 @@ $('undoBtn').onclick=async()=>{
     if(!undoStack.length)hide('undo-card');
     else{$('undo-label').textContent='Last: '+undoStack[undoStack.length-1].label+' — undo available'}
   }catch(e){$('status').textContent='Undo failed: '+e.message}
+  finally{btn.disabled=false}
 };
 
 // Restore from backup
@@ -489,12 +491,11 @@ $('restoreFile').onchange=async e=>{
     if(!confirm('This will replace your '+current.length+' addons with '+list.length+' from the backup. Auto-backup of current state will be saved for undo. Continue?'))return;
     $('status').textContent='Restoring from backup…';
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:list});
-    const ok=await reloadAddons();
-    if(!ok){$('status').textContent='Restore saved but reload failed.';return}
     showUndo({addons:JSON.parse(JSON.stringify(current)),label:'restore'});
     pushed=true;
-    $('status').textContent='Restored '+list.length+' addons from backup. Undo available.';
+    const ok=await reloadAddons();
     $('undo-label').textContent='Last: restored from backup — undo available';
+    $('status').textContent=ok?'Restored '+list.length+' addons from backup. Undo available.':'Restore saved but reload failed. Undo available.';
   }catch(err){
     $('status').textContent=err.message;
   }

--- a/account-tools/index.html
+++ b/account-tools/index.html
@@ -1,4 +1,4 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src https://api.strem.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"><title>Core Account Tools — Read-only Backup & Diff</title><style>
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src https://api.strem.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"><title>Core Account Tools — Backup, Diff & Restore</title><style>
 :root{color-scheme:dark;font-family:system-ui;background:#071018;color:#e6edf3;--cyan:#67e8f9;--border:#243342;--card:#0e1822;--input:#0a121a;--muted:#718493;--warn-bg:#2b210b;--warn-border:#7c5b19;--warn-text:#fbd38d;--green:#34d399;--red:#f87171;--blue:#60a5fa}
 body{margin:0;padding:24px}
 .wrap{max-width:800px;margin:auto}
@@ -14,7 +14,7 @@ button.danger{background:#3b1219;border-color:#7f1d1d;color:var(--red)}
 button:disabled{opacity:.4;cursor:default}
 .row{display:grid;grid-template-columns:1fr 1fr;gap:8px}
 .row3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
-.addon{display:flex;gap:10px;padding:10px 0;border-bottom:1px solid #1e2b36}
+.addon{display:flex;gap:10px;padding:10px 0;border-bottom:1px solid #1e2b36;align-items:center}
 .addon.added{border-left:3px solid var(--green);padding-left:8px}
 .addon.removed{border-left:3px solid var(--red);padding-left:8px;opacity:.7}
 .addon.moved{border-left:3px solid var(--blue);padding-left:8px}
@@ -43,13 +43,18 @@ button:disabled{opacity:.4;cursor:default}
 .inspect dt{color:var(--muted);font-size:.75rem;text-transform:uppercase;letter-spacing:.5px;margin-top:8px}
 .inspect dd{margin:2px 0 0;font-weight:600}
 .diff-summary{padding:12px;background:var(--input);border-radius:9px;margin:8px 0;font-size:.9rem;line-height:1.6}
+.move-btns{display:flex;flex-direction:column;gap:2px;flex-shrink:0}
+.move-btns button{width:28px;height:22px;padding:0;font-size:12px;line-height:1;min-width:0;margin:0;border-radius:5px}
+.undo-bar{display:flex;gap:8px;align-items:center;padding:10px;background:#1a1a2e;border:1px solid #3d3d5c;border-radius:9px;margin:8px 0}
+.undo-bar .undo-label{flex:1;font-size:.85rem;color:#a78bfa}
+.undo-bar button{width:auto;padding:6px 14px;background:#312e81;border-color:#4c1d95;color:#c4b5fd}
 .count{font-weight:900;color:var(--cyan)}
 .hidden{display:none}
 @media(max-width:560px){.row,.row3{grid-template-columns:1fr}}
 </style></head><body><main class="wrap">
 <nav class="toolnav"><a href="../">Configurator</a><a href="../tools/">All Tools</a></nav>
 <h1>Core Account Tools</h1>
-<p>Read-only addon backup, inspection, and comparison. This tool cannot change your account.</p>
+<p>Addon backup, inspection, comparison, and restore. Mutations auto-backup before applying — undo is always available.</p>
 <div class="warn">Login details are sent directly to the Stremio API and kept only in page memory. Never use this from an untrusted copy.</div>
 
 <section class="card" id="auth-card">
@@ -100,6 +105,13 @@ button:disabled{opacity:.4;cursor:default}
 <button class="secondary" id="close-inspect">Close</button>
 </section>
 
+<section class="card hidden" id="undo-card">
+<div class="undo-bar">
+  <span class="undo-label" id="undo-label">Last action can be undone</span>
+  <button id="undoBtn">Undo</button>
+</div>
+</section>
+
 <section class="card hidden" id="actions-card">
 <h2>Actions</h2>
 <div class="row3">
@@ -107,8 +119,14 @@ button:disabled{opacity:.4;cursor:default}
   <button class="secondary" id="importBtn">Import backup</button>
   <button class="secondary" id="diffBtn">Compare snapshots</button>
 </div>
+<div class="row3" style="margin-top:4px">
+  <button class="secondary" id="restoreBtn">Restore from backup</button>
+  <div></div><div></div>
+</div>
 <label for="file" class="sr">Import backup file</label>
 <input hidden id="file" type="file" accept="application/json">
+<label for="restoreFile" class="sr">Restore backup file</label>
+<input hidden id="restoreFile" type="file" accept="application/json">
 <label for="diffFileA" class="sr">Snapshot A</label>
 <input hidden id="diffFileA" type="file" accept="application/json">
 <label for="diffFileB" class="sr">Snapshot B</label>
@@ -126,7 +144,7 @@ button:disabled{opacity:.4;cursor:default}
 const $=id=>document.getElementById(id);
 const esc=s=>String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
-let authKey=null,addons=[],currentSnapshot=null;
+let authKey=null,addons=[],currentSnapshot=null,undoStack=[],isLiveSession=false;
 
 const CRED_RE=/apiKey|password|secret|auth.*key|token/i;
 
@@ -161,14 +179,15 @@ function parseAddons(raw){
   }));
 }
 
-function renderAddon(a,i,extra=''){
+function renderAddon(a,i,extra='',total=0){
   const risk=hasCredRisk(a.transportUrl)?'<span class="tag risk">credential risk</span>':'';
-  return'<div class="addon'+extra+'" data-idx="'+i+'"><span class="num">'+(i+1)+'</span><div class="meta"><div class="name">'+esc(a.name)+risk+'</div><div class="url">'+esc(redactUrl(a.transportUrl))+'</div></div></div>';
+  const moveBtns=isLiveSession&&!extra?'<div class="move-btns">'+(i>0?'<button data-move="up" data-idx="'+i+'" title="Move up">&#9650;</button>':'<button disabled>&#9650;</button>')+(i<total-1?'<button data-move="down" data-idx="'+i+'" title="Move down">&#9660;</button>':'<button disabled>&#9660;</button>')+'</div>':'';
+  return'<div class="addon'+extra+'" data-idx="'+i+'"><span class="num">'+(i+1)+'</span><div class="meta"><div class="name">'+esc(a.name)+risk+'</div><div class="url">'+esc(redactUrl(a.transportUrl))+'</div></div>'+moveBtns+'</div>';
 }
 
 function renderList(list){
   $('addon-count').textContent=list.length;
-  $('addon-list').innerHTML=list.length?list.map((a,i)=>renderAddon(a,i)).join(''):'<p style="color:var(--muted)">No addons match.</p>';
+  $('addon-list').innerHTML=list.length?list.map((a,i)=>renderAddon(a,i,'',list.length)).join(''):'<p style="color:var(--muted)">No addons match.</p>';
 }
 
 function filterAddons(){
@@ -192,6 +211,7 @@ function onLogin(data,label){
   if(!Array.isArray(raw))throw new Error('No addon list found');
   addons=parseAddons(raw);
   currentSnapshot={exportedAt:new Date().toISOString(),source:label,addons:raw};
+  isLiveSession=true;
   renderList(addons);
   showWarnings();
   show('session-card');show('addons-card');show('actions-card');
@@ -250,10 +270,10 @@ $('loginKey').onclick=async()=>{
 
 // Logout
 $('logout').onclick=()=>{
-  authKey=null;addons=[];currentSnapshot=null;
+  authKey=null;addons=[];currentSnapshot=null;undoStack=[];isLiveSession=false;
   $('addon-list').innerHTML='';$('search').value='';$('type-filter').value='';
   $('status').textContent='Session cleared.';
-  hide('session-card');hide('addons-card');hide('actions-card');hide('warnings-card');hide('inspect-card');hide('diff-card');
+  hide('session-card');hide('addons-card');hide('actions-card');hide('warnings-card');hide('inspect-card');hide('diff-card');hide('undo-card');
   show('auth-card');
 };
 
@@ -380,5 +400,100 @@ function runDiff(){
   $('status').textContent='Comparison complete — '+(hasDiff?(added.length+removed.length+moved.length)+' change(s)':'no differences')+'.';
 }
 $('close-diff').onclick=()=>hide('diff-card');
+
+// --- Mutations ---
+
+function showUndo(label){
+  undoStack.push(label);
+  $('undo-label').textContent='Last action: '+label+' — can be undone';
+  show('undo-card');
+}
+
+function hideUndo(){
+  undoStack=[];
+  hide('undo-card');
+}
+
+async function reloadAddons(){
+  try{
+    const data=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
+    const raw=data?.result?.addons;
+    if(!Array.isArray(raw))throw new Error('Reload failed');
+    addons=parseAddons(raw);
+    currentSnapshot={exportedAt:new Date().toISOString(),source:'live',addons:raw};
+    renderList(addons);showWarnings();
+  }catch(e){$('status').textContent='Reload error: '+e.message}
+}
+
+async function doMove(fromIdx,toIdx){
+  if(!authKey||fromIdx===toIdx)return;
+  const raw=currentSnapshot?.addons;
+  if(!raw)return;
+  const prev=JSON.parse(JSON.stringify(raw));
+  const reordered=[...raw];
+  const[item]=reordered.splice(fromIdx,1);
+  reordered.splice(toIdx,0,item);
+  try{
+    $('status').textContent='Moving addon…';
+    undoStack.push({addons:prev,label:'move'});
+    await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:reordered});
+    await reloadAddons();
+    $('status').textContent='Addon moved. Undo available.';
+    $('undo-label').textContent='Last: moved '+esc(item.manifest?.name||'addon')+' — undo available';
+    show('undo-card');
+  }catch(e){
+    undoStack.pop();
+    $('status').textContent='Move failed: '+e.message;
+  }
+}
+
+$('addon-list').addEventListener('click',e=>{
+  const btn=e.target.closest('[data-move]');
+  if(!btn)return;
+  e.stopPropagation();
+  const idx=parseInt(btn.dataset.idx,10);
+  const dir=btn.dataset.move;
+  if(dir==='up'&&idx>0)doMove(idx,idx-1);
+  else if(dir==='down'&&idx<addons.length-1)doMove(idx,idx+1);
+});
+
+$('undoBtn').onclick=async()=>{
+  if(!undoStack.length||!authKey)return;
+  const snap=undoStack.pop();
+  try{
+    $('status').textContent='Undoing…';
+    await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:snap.addons});
+    await reloadAddons();
+    $('status').textContent='Undo complete — restored to previous state.';
+    if(!undoStack.length)hide('undo-card');
+    else{$('undo-label').textContent='Last: '+undoStack[undoStack.length-1].label+' — undo available'}
+  }catch(e){$('status').textContent='Undo failed: '+e.message}
+};
+
+// Restore from backup
+$('restoreBtn').onclick=()=>{
+  if(!authKey)return $('status').textContent='Sign in first.';
+  $('restoreFile').value='';$('restoreFile').click();
+};
+$('restoreFile').onchange=async e=>{
+  try{
+    const raw=JSON.parse(await e.target.files[0].text());
+    const list=raw?.addons||raw?.result?.addons;
+    if(!Array.isArray(list)||!list.length)throw new Error('Backup contains no addons');
+    const current=currentSnapshot?.addons;
+    if(!current)throw new Error('No current snapshot — sign in first');
+    if(!confirm('This will replace your '+current.length+' addons with '+list.length+' from the backup. Auto-backup of current state will be saved for undo. Continue?'))return;
+    $('status').textContent='Restoring from backup…';
+    undoStack.push({addons:JSON.parse(JSON.stringify(current)),label:'restore'});
+    await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:list});
+    await reloadAddons();
+    $('status').textContent='Restored '+list.length+' addons from backup. Undo available.';
+    $('undo-label').textContent='Last: restored from backup — undo available';
+    show('undo-card');
+  }catch(err){
+    if(err.message!=='Backup contains no addons')undoStack.pop();
+    $('status').textContent=err.message;
+  }
+};
 
 })();</script></body></html>

--- a/account-tools/index.html
+++ b/account-tools/index.html
@@ -181,8 +181,9 @@ function parseAddons(raw){
 
 function renderAddon(a,i,extra='',total=0){
   const risk=hasCredRisk(a.transportUrl)?'<span class="tag risk">credential risk</span>':'';
+  const removeBtnHtml=isLiveSession&&!extra?'<button class="danger" data-remove="'+i+'" title="Remove addon" style="width:28px;height:28px;padding:0;font-size:14px;line-height:1;min-width:0;margin:0;border-radius:5px;flex-shrink:0">&times;</button>':'';
   const moveBtns=isLiveSession&&!extra?'<div class="move-btns">'+(i>0?'<button data-move="up" data-idx="'+i+'" title="Move up">&#9650;</button>':'<button disabled>&#9650;</button>')+(i<total-1?'<button data-move="down" data-idx="'+i+'" title="Move down">&#9660;</button>':'<button disabled>&#9660;</button>')+'</div>':'';
-  return'<div class="addon'+extra+'" data-idx="'+i+'"><span class="num">'+(i+1)+'</span><div class="meta"><div class="name">'+esc(a.name)+risk+'</div><div class="url">'+esc(redactUrl(a.transportUrl))+'</div></div>'+moveBtns+'</div>';
+  return'<div class="addon'+extra+'" data-idx="'+i+'"><span class="num">'+(i+1)+'</span><div class="meta"><div class="name">'+esc(a.name)+risk+'</div><div class="url">'+esc(redactUrl(a.transportUrl))+'</div></div>'+moveBtns+removeBtnHtml+'</div>';
 }
 
 function renderList(list){
@@ -431,6 +432,16 @@ async function doMove(fromIdx,toIdx){
   if(!authKey||fromIdx===toIdx)return;
   const raw=currentSnapshot?.addons;
   if(!raw)return;
+  try{
+    $('status').textContent='Verifying current state…';
+    const fresh=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
+    const freshAddons=fresh?.result?.addons||[];
+    if(freshAddons.length!==raw.length||!freshAddons.every((a,i)=>a.transportUrl===raw[i].transportUrl)){
+      $('status').textContent='Collection changed on server — reloading…';
+      await reloadAddons();
+      return;
+    }
+  }catch(e){$('status').textContent='Failed to verify state: '+e.message;return}
   const prev=JSON.parse(JSON.stringify(raw));
   const reordered=[...raw];
   const[item]=reordered.splice(fromIdx,1);
@@ -447,7 +458,44 @@ async function doMove(fromIdx,toIdx){
   }
 }
 
+async function doRemove(idx){
+  if(!authKey)return;
+  const raw=currentSnapshot?.addons;
+  if(!raw||idx<0||idx>=raw.length)return;
+  const name=raw[idx].manifest?.name||'addon';
+  if(!confirm('Remove '+name+'? This cannot be automatically undone without using the Undo button.'))return;
+  try{
+    $('status').textContent='Verifying current state…';
+    const fresh=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
+    const freshAddons=fresh?.result?.addons||[];
+    if(freshAddons.length!==raw.length||!freshAddons.every((a,i)=>a.transportUrl===raw[i].transportUrl)){
+      $('status').textContent='Collection changed on server — reloading…';
+      await reloadAddons();
+      return;
+    }
+  }catch(e){$('status').textContent='Failed to verify state: '+e.message;return}
+  const prev=JSON.parse(JSON.stringify(raw));
+  const updated=[...raw];
+  updated.splice(idx,1);
+  try{
+    $('status').textContent='Removing addon…';
+    await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:updated});
+    showUndo({addons:prev,label:'remove'});
+    const ok=await reloadAddons();
+    $('undo-label').textContent='Last: removed '+esc(name)+' — undo available';
+    $('status').textContent=ok?'Addon removed. Undo available.':'Remove saved but reload failed. Undo available.';
+  }catch(e){
+    $('status').textContent='Remove failed: '+e.message;
+  }
+}
+
 $('addon-list').addEventListener('click',e=>{
+  const removeBtn=e.target.closest('[data-remove]');
+  if(removeBtn){
+    e.stopPropagation();
+    doRemove(parseInt(removeBtn.dataset.remove,10));
+    return;
+  }
   const btn=e.target.closest('[data-move]');
   if(!btn)return;
   e.stopPropagation();
@@ -488,6 +536,14 @@ $('restoreFile').onchange=async e=>{
     if(!Array.isArray(list)||!list.length)throw new Error('Backup contains no addons');
     const current=currentSnapshot?.addons;
     if(!current)throw new Error('No current snapshot — sign in first');
+    $('status').textContent='Verifying current state…';
+    const freshData=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
+    const freshAddons=freshData?.result?.addons||[];
+    if(freshAddons.length!==current.length||!freshAddons.every((a,i)=>a.transportUrl===current[i].transportUrl)){
+      $('status').textContent='Collection changed on server — reloading…';
+      await reloadAddons();
+      return;
+    }
     if(!confirm('This will replace your '+current.length+' addons with '+list.length+' from the backup. Auto-backup of current state will be saved for undo. Continue?'))return;
     $('status').textContent='Restoring from backup…';
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:list});

--- a/account-tools/index.html
+++ b/account-tools/index.html
@@ -428,19 +428,24 @@ async function reloadAddons(){
   }catch(e){$('status').textContent='Reload error: '+e.message;return false}
 }
 
+async function verifyFresh(raw){
+  const fresh=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
+  const freshAddons=fresh?.result?.addons||[];
+  if(freshAddons.length!==raw.length||!freshAddons.every((a,i)=>a.transportUrl===raw[i].transportUrl)){
+    $('status').textContent='Collection changed on server — reloading…';
+    await reloadAddons();
+    return false;
+  }
+  return true;
+}
+
 async function doMove(fromIdx,toIdx){
   if(!authKey||fromIdx===toIdx)return;
   const raw=currentSnapshot?.addons;
   if(!raw)return;
   try{
     $('status').textContent='Verifying current state…';
-    const fresh=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
-    const freshAddons=fresh?.result?.addons||[];
-    if(freshAddons.length!==raw.length||!freshAddons.every((a,i)=>a.transportUrl===raw[i].transportUrl)){
-      $('status').textContent='Collection changed on server — reloading…';
-      await reloadAddons();
-      return;
-    }
+    if(!await verifyFresh(raw))return;
   }catch(e){$('status').textContent='Failed to verify state: '+e.message;return}
   const prev=JSON.parse(JSON.stringify(raw));
   const reordered=[...raw];
@@ -451,7 +456,7 @@ async function doMove(fromIdx,toIdx){
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:reordered});
     showUndo({addons:prev,label:'move'});
     const ok=await reloadAddons();
-    $('undo-label').textContent='Last: moved '+esc(item.manifest?.name||'addon')+' — undo available';
+    $('undo-label').textContent='Last: moved '+(item.manifest?.name||'addon')+' — undo available';
     $('status').textContent=ok?'Addon moved. Undo available.':'Move saved but reload failed. Undo available.';
   }catch(e){
     $('status').textContent='Move failed: '+e.message;
@@ -466,13 +471,7 @@ async function doRemove(idx){
   if(!confirm('Remove '+name+'? This cannot be automatically undone without using the Undo button.'))return;
   try{
     $('status').textContent='Verifying current state…';
-    const fresh=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
-    const freshAddons=fresh?.result?.addons||[];
-    if(freshAddons.length!==raw.length||!freshAddons.every((a,i)=>a.transportUrl===raw[i].transportUrl)){
-      $('status').textContent='Collection changed on server — reloading…';
-      await reloadAddons();
-      return;
-    }
+    if(!await verifyFresh(raw))return;
   }catch(e){$('status').textContent='Failed to verify state: '+e.message;return}
   const prev=JSON.parse(JSON.stringify(raw));
   const updated=[...raw];
@@ -482,7 +481,7 @@ async function doRemove(idx){
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:updated});
     showUndo({addons:prev,label:'remove'});
     const ok=await reloadAddons();
-    $('undo-label').textContent='Last: removed '+esc(name)+' — undo available';
+    $('undo-label').textContent='Last: removed '+name+' — undo available';
     $('status').textContent=ok?'Addon removed. Undo available.':'Remove saved but reload failed. Undo available.';
   }catch(e){
     $('status').textContent='Remove failed: '+e.message;
@@ -529,7 +528,6 @@ $('restoreBtn').onclick=()=>{
   $('restoreFile').value='';$('restoreFile').click();
 };
 $('restoreFile').onchange=async e=>{
-  let pushed=false;
   try{
     const raw=JSON.parse(await e.target.files[0].text());
     const list=raw?.addons||raw?.result?.addons;
@@ -537,23 +535,18 @@ $('restoreFile').onchange=async e=>{
     const current=currentSnapshot?.addons;
     if(!current)throw new Error('No current snapshot — sign in first');
     $('status').textContent='Verifying current state…';
-    const freshData=await post('addonCollectionGet',{type:'AddonCollectionGet',authKey,update:true});
-    const freshAddons=freshData?.result?.addons||[];
-    if(freshAddons.length!==current.length||!freshAddons.every((a,i)=>a.transportUrl===current[i].transportUrl)){
-      $('status').textContent='Collection changed on server — reloading…';
-      await reloadAddons();
-      return;
-    }
+    if(!await verifyFresh(current))return;
     if(!confirm('This will replace your '+current.length+' addons with '+list.length+' from the backup. Auto-backup of current state will be saved for undo. Continue?'))return;
     $('status').textContent='Restoring from backup…';
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:list});
     showUndo({addons:JSON.parse(JSON.stringify(current)),label:'restore'});
-    pushed=true;
     const ok=await reloadAddons();
     $('undo-label').textContent='Last: restored from backup — undo available';
     $('status').textContent=ok?'Restored '+list.length+' addons from backup. Undo available.':'Restore saved but reload failed. Undo available.';
   }catch(err){
     $('status').textContent=err.message;
+  }finally{
+    e.target.value='';
   }
 };
 

--- a/account-tools/index.html
+++ b/account-tools/index.html
@@ -108,19 +108,19 @@ button:disabled{opacity:.4;cursor:default}
 <section class="card hidden" id="undo-card">
 <div class="undo-bar">
   <span class="undo-label" id="undo-label">Last action can be undone</span>
-  <button id="undoBtn">Undo</button>
+  <button type="button" id="undoBtn">Undo</button>
 </div>
 </section>
 
 <section class="card hidden" id="actions-card">
 <h2>Actions</h2>
 <div class="row3">
-  <button id="download">Download backup</button>
-  <button class="secondary" id="importBtn">Import backup</button>
-  <button class="secondary" id="diffBtn">Compare snapshots</button>
+  <button type="button" id="download">Download backup</button>
+  <button type="button" class="secondary" id="importBtn">Import backup</button>
+  <button type="button" class="secondary" id="diffBtn">Compare snapshots</button>
 </div>
 <div class="row3" style="margin-top:4px">
-  <button class="secondary" id="restoreBtn">Restore from backup</button>
+  <button type="button" class="secondary" id="restoreBtn">Restore from backup</button>
   <div></div><div></div>
 </div>
 <label for="file" class="sr">Import backup file</label>
@@ -403,9 +403,10 @@ $('close-diff').onclick=()=>hide('diff-card');
 
 // --- Mutations ---
 
-function showUndo(label){
-  undoStack.push(label);
-  $('undo-label').textContent='Last action: '+label+' — can be undone';
+function showUndo(snap){
+  undoStack.push(snap);
+  if(undoStack.length>10)undoStack.shift();
+  $('undo-label').textContent='Last action: '+snap.label+' — can be undone';
   show('undo-card');
 }
 
@@ -422,7 +423,8 @@ async function reloadAddons(){
     addons=parseAddons(raw);
     currentSnapshot={exportedAt:new Date().toISOString(),source:'live',addons:raw};
     renderList(addons);showWarnings();
-  }catch(e){$('status').textContent='Reload error: '+e.message}
+    return true;
+  }catch(e){$('status').textContent='Reload error: '+e.message;return false}
 }
 
 async function doMove(fromIdx,toIdx){
@@ -435,14 +437,13 @@ async function doMove(fromIdx,toIdx){
   reordered.splice(toIdx,0,item);
   try{
     $('status').textContent='Moving addon…';
-    undoStack.push({addons:prev,label:'move'});
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:reordered});
-    await reloadAddons();
+    const ok=await reloadAddons();
+    if(!ok){$('status').textContent='Move saved but reload failed.';return}
+    showUndo({addons:prev,label:'move'});
     $('status').textContent='Addon moved. Undo available.';
     $('undo-label').textContent='Last: moved '+esc(item.manifest?.name||'addon')+' — undo available';
-    show('undo-card');
   }catch(e){
-    undoStack.pop();
     $('status').textContent='Move failed: '+e.message;
   }
 }
@@ -459,12 +460,14 @@ $('addon-list').addEventListener('click',e=>{
 
 $('undoBtn').onclick=async()=>{
   if(!undoStack.length||!authKey)return;
-  const snap=undoStack.pop();
+  const snap=undoStack[undoStack.length-1];
   try{
     $('status').textContent='Undoing…';
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:snap.addons});
-    await reloadAddons();
-    $('status').textContent='Undo complete — restored to previous state.';
+    undoStack.pop();
+    const ok=await reloadAddons();
+    if(!ok){$('status').textContent='Undo saved but reload failed.'}
+    else{$('status').textContent='Undo complete — restored to previous state.'}
     if(!undoStack.length)hide('undo-card');
     else{$('undo-label').textContent='Last: '+undoStack[undoStack.length-1].label+' — undo available'}
   }catch(e){$('status').textContent='Undo failed: '+e.message}
@@ -476,6 +479,7 @@ $('restoreBtn').onclick=()=>{
   $('restoreFile').value='';$('restoreFile').click();
 };
 $('restoreFile').onchange=async e=>{
+  let pushed=false;
   try{
     const raw=JSON.parse(await e.target.files[0].text());
     const list=raw?.addons||raw?.result?.addons;
@@ -484,14 +488,14 @@ $('restoreFile').onchange=async e=>{
     if(!current)throw new Error('No current snapshot — sign in first');
     if(!confirm('This will replace your '+current.length+' addons with '+list.length+' from the backup. Auto-backup of current state will be saved for undo. Continue?'))return;
     $('status').textContent='Restoring from backup…';
-    undoStack.push({addons:JSON.parse(JSON.stringify(current)),label:'restore'});
     await post('addonCollectionSet',{type:'AddonCollectionSet',authKey,addons:list});
-    await reloadAddons();
+    const ok=await reloadAddons();
+    if(!ok){$('status').textContent='Restore saved but reload failed.';return}
+    showUndo({addons:JSON.parse(JSON.stringify(current)),label:'restore'});
+    pushed=true;
     $('status').textContent='Restored '+list.length+' addons from backup. Undo available.';
     $('undo-label').textContent='Last: restored from backup — undo available';
-    show('undo-card');
   }catch(err){
-    if(err.message!=='Backup contains no addons')undoStack.pop();
     $('status').textContent=err.message;
   }
 };

--- a/account-tools/package-lock.json
+++ b/account-tools/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "core-builds-account-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "core-builds-account-tools",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/account-tools/package.json
+++ b/account-tools/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test 'tests/**/*.test.mjs'"
+    "test": "node --test 'tests/**/*.test.mjs'",
+    "test:e2e": "npx playwright test e2e/"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
   }
 }

--- a/account-tools/package.json
+++ b/account-tools/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test 'tests/**/*.test.mjs'",
-    "test:e2e": "npx playwright test e2e/"
+    "test:e2e": "playwright test e2e/"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1"

--- a/account-tools/playwright.config.mjs
+++ b/account-tools/playwright.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   use: {
     browserName: 'chromium',
     launchOptions: {
-      executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+      executablePath: process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
     },
   },
 });

--- a/account-tools/playwright.config.mjs
+++ b/account-tools/playwright.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    browserName: 'chromium',
+    launchOptions: {
+      executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    },
+  },
+});

--- a/account-tools/src/mutations.js
+++ b/account-tools/src/mutations.js
@@ -63,14 +63,22 @@ export async function restoreFromBackup(backupAddons) {
   return saveWithRollback(authKey, current, backupAddons, 'restore');
 }
 
-export async function undo() {
-  if (!canUndo()) throw new Error('Nothing to undo');
-  const authKey = await requireAuth();
-  const snapshot = peekSnapshot();
+let _undoing = false;
 
-  await _api.setAddonCollection(authKey, snapshot.addons);
-  popSnapshot();
-  return _api.getAddonCollection(authKey);
+export async function undo() {
+  if (_undoing) throw new Error('Undo already in progress');
+  if (!canUndo()) throw new Error('Nothing to undo');
+  _undoing = true;
+  try {
+    const authKey = await requireAuth();
+    const snapshot = peekSnapshot();
+
+    await _api.setAddonCollection(authKey, snapshot.addons);
+    popSnapshot();
+    return _api.getAddonCollection(authKey);
+  } finally {
+    _undoing = false;
+  }
 }
 
 export { canUndo };

--- a/account-tools/src/mutations.js
+++ b/account-tools/src/mutations.js
@@ -1,0 +1,75 @@
+import * as defaultApi from './stremio-api.js';
+import { getAuthKey } from './auth-session.js';
+import { pushSnapshot, popSnapshot, canUndo } from './rollback.js';
+
+let _api = defaultApi;
+
+export function _setApi(api) {
+  _api = api;
+}
+
+export function _resetApi() {
+  _api = defaultApi;
+}
+
+async function requireAuth() {
+  const key = getAuthKey();
+  if (!key) throw new Error('Not authenticated');
+  return key;
+}
+
+async function loadCurrent(authKey) {
+  return _api.getAddonCollection(authKey);
+}
+
+async function saveWithRollback(authKey, currentAddons, newAddons, label) {
+  pushSnapshot(currentAddons, label);
+  await _api.setAddonCollection(authKey, newAddons);
+  return _api.getAddonCollection(authKey);
+}
+
+export async function moveAddon(fromIndex, toIndex) {
+  const authKey = await requireAuth();
+  const current = await loadCurrent(authKey);
+  if (fromIndex < 0 || fromIndex >= current.length) throw new Error('Invalid source index');
+  if (toIndex < 0 || toIndex >= current.length) throw new Error('Invalid target index');
+  if (fromIndex === toIndex) return current;
+
+  const reordered = [...current];
+  const [item] = reordered.splice(fromIndex, 1);
+  reordered.splice(toIndex, 0, item);
+
+  return saveWithRollback(authKey, current, reordered, 'move');
+}
+
+export async function removeAddon(index) {
+  const authKey = await requireAuth();
+  const current = await loadCurrent(authKey);
+  if (index < 0 || index >= current.length) throw new Error('Invalid index');
+
+  const updated = [...current];
+  updated.splice(index, 1);
+
+  return saveWithRollback(authKey, current, updated, 'remove');
+}
+
+export async function restoreFromBackup(backupAddons) {
+  if (!Array.isArray(backupAddons) || backupAddons.length === 0) {
+    throw new Error('Backup contains no addons');
+  }
+  const authKey = await requireAuth();
+  const current = await loadCurrent(authKey);
+
+  return saveWithRollback(authKey, current, backupAddons, 'restore');
+}
+
+export async function undo() {
+  if (!canUndo()) throw new Error('Nothing to undo');
+  const authKey = await requireAuth();
+  const snapshot = popSnapshot();
+
+  await _api.setAddonCollection(authKey, snapshot.addons);
+  return _api.getAddonCollection(authKey);
+}
+
+export { canUndo };

--- a/account-tools/src/mutations.js
+++ b/account-tools/src/mutations.js
@@ -1,6 +1,6 @@
 import * as defaultApi from './stremio-api.js';
 import { getAuthKey } from './auth-session.js';
-import { pushSnapshot, popSnapshot, canUndo } from './rollback.js';
+import { pushSnapshot, popSnapshot, peekSnapshot, canUndo } from './rollback.js';
 
 let _api = defaultApi;
 
@@ -23,8 +23,8 @@ async function loadCurrent(authKey) {
 }
 
 async function saveWithRollback(authKey, currentAddons, newAddons, label) {
-  pushSnapshot(currentAddons, label);
   await _api.setAddonCollection(authKey, newAddons);
+  pushSnapshot(currentAddons, label);
   return _api.getAddonCollection(authKey);
 }
 
@@ -66,9 +66,10 @@ export async function restoreFromBackup(backupAddons) {
 export async function undo() {
   if (!canUndo()) throw new Error('Nothing to undo');
   const authKey = await requireAuth();
-  const snapshot = popSnapshot();
+  const snapshot = peekSnapshot();
 
   await _api.setAddonCollection(authKey, snapshot.addons);
+  popSnapshot();
   return _api.getAddonCollection(authKey);
 }
 

--- a/account-tools/src/rollback.js
+++ b/account-tools/src/rollback.js
@@ -1,0 +1,38 @@
+const MAX_HISTORY = 10;
+let _history = [];
+
+export function pushSnapshot(addons, label = 'auto') {
+  if (!Array.isArray(addons) || addons.length === 0) return;
+  _history.push({
+    addons: JSON.parse(JSON.stringify(addons)),
+    label,
+    timestamp: new Date().toISOString(),
+  });
+  if (_history.length > MAX_HISTORY) _history.shift();
+}
+
+export function popSnapshot() {
+  if (_history.length === 0) return null;
+  return _history.pop();
+}
+
+export function peekSnapshot() {
+  if (_history.length === 0) return null;
+  return _history[_history.length - 1];
+}
+
+export function getHistory() {
+  return _history.map(({ label, timestamp, addons }) => ({
+    label,
+    timestamp,
+    addonCount: addons.length,
+  }));
+}
+
+export function canUndo() {
+  return _history.length > 0;
+}
+
+export function clearHistory() {
+  _history = [];
+}

--- a/account-tools/src/stremio-api.js
+++ b/account-tools/src/stremio-api.js
@@ -30,3 +30,13 @@ export async function getAddonCollection(authKey) {
   if (!data?.result?.addons) throw new Error('Failed to load addon collection');
   return data.result.addons;
 }
+
+export async function setAddonCollection(authKey, addons) {
+  const data = await post('addonCollectionSet', {
+    type: 'AddonCollectionSet',
+    authKey,
+    addons,
+  });
+  if (data.error) throw new Error(data.error);
+  return data;
+}

--- a/account-tools/tests/mutations.test.mjs
+++ b/account-tools/tests/mutations.test.mjs
@@ -209,3 +209,77 @@ test('mutations: requires auth for all operations', async () => {
   await assert.rejects(() => removeAddon(0), /Not authenticated/);
   await assert.rejects(() => restoreFromBackup([{ manifest: { name: 'x' } }]), /Not authenticated/);
 });
+
+test('mutations: failed API write does not push rollback snapshot', async () => {
+  clearHistory();
+  setSession('test-key');
+  const base = ADDONS_3();
+  const api = {
+    getAddonCollection: async () => JSON.parse(JSON.stringify(base)),
+    setAddonCollection: async () => { throw new Error('Server write failed'); },
+  };
+  _setApi(api);
+
+  try {
+    await assert.rejects(() => moveAddon(0, 2), /Server write failed/);
+    assert.ok(!canUndo(), 'No snapshot should be pushed after a failed write');
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: concurrent undo guard rejects second call', async () => {
+  clearHistory();
+  setSession('test-key');
+  const base = ADDONS_3();
+  let resolveSet;
+  const slowApi = {
+    getAddonCollection: async () => JSON.parse(JSON.stringify(base)),
+    setAddonCollection: async (_key, addons) => {
+      return new Promise(resolve => { resolveSet = () => resolve({ result: true }); });
+    },
+  };
+  _setApi(slowApi);
+
+  try {
+    // Do a mutation to have something to undo
+    const fastApi = {
+      getAddonCollection: async () => JSON.parse(JSON.stringify(base)),
+      setAddonCollection: async () => ({ result: true }),
+    };
+    _setApi(fastApi);
+    await removeAddon(0);
+    assert.ok(canUndo());
+
+    // Now use the slow api for undo
+    _setApi(slowApi);
+    const firstUndo = undo();
+    await assert.rejects(() => undo(), /Undo already in progress/);
+    resolveSet();
+    await firstUndo;
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: clearHistory clears rollback so canUndo is false', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await removeAddon(0);
+    assert.ok(canUndo(), 'canUndo should be true after mutation');
+    clearHistory();
+    assert.ok(!canUndo(), 'canUndo should be false after clearHistory');
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});

--- a/account-tools/tests/mutations.test.mjs
+++ b/account-tools/tests/mutations.test.mjs
@@ -235,16 +235,18 @@ test('mutations: concurrent undo guard rejects second call', async () => {
   setSession('test-key');
   const base = ADDONS_3();
   let resolveSet;
+  let entered;
+  const enteredPromise = new Promise(r => { entered = r; });
   const slowApi = {
     getAddonCollection: async () => JSON.parse(JSON.stringify(base)),
     setAddonCollection: async (_key, addons) => {
+      entered();
       return new Promise(resolve => { resolveSet = () => resolve({ result: true }); });
     },
   };
   _setApi(slowApi);
 
   try {
-    // Do a mutation to have something to undo
     const fastApi = {
       getAddonCollection: async () => JSON.parse(JSON.stringify(base)),
       setAddonCollection: async () => ({ result: true }),
@@ -253,9 +255,9 @@ test('mutations: concurrent undo guard rejects second call', async () => {
     await removeAddon(0);
     assert.ok(canUndo());
 
-    // Now use the slow api for undo
     _setApi(slowApi);
     const firstUndo = undo();
+    await enteredPromise;
     await assert.rejects(() => undo(), /Undo already in progress/);
     resolveSet();
     await firstUndo;

--- a/account-tools/tests/mutations.test.mjs
+++ b/account-tools/tests/mutations.test.mjs
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { clearHistory, canUndo, popSnapshot } from '../src/rollback.js';
+import { setSession, clearSession } from '../src/auth-session.js';
+import { _setApi, _resetApi, moveAddon, removeAddon, restoreFromBackup, undo } from '../src/mutations.js';
+
+const makeAddons = (names) => names.map(name => ({
+  manifest: { name, id: name.toLowerCase() },
+  transportUrl: `https://${name.toLowerCase()}.example.com/manifest.json`,
+}));
+
+const ADDONS_3 = () => makeAddons(['Torrentio', 'Comet', 'Cinemeta']);
+
+function mockApi(initialAddons) {
+  let serverAddons = JSON.parse(JSON.stringify(initialAddons));
+  const setCalls = [];
+  return {
+    setCalls,
+    getServerAddons: () => serverAddons,
+    api: {
+      getAddonCollection: async () => JSON.parse(JSON.stringify(serverAddons)),
+      setAddonCollection: async (_key, addons) => {
+        setCalls.push(JSON.parse(JSON.stringify(addons)));
+        serverAddons = addons;
+        return { result: true };
+      },
+    },
+  };
+}
+
+test('mutations: moveAddon pushes rollback snapshot', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await moveAddon(0, 2);
+    assert.ok(canUndo());
+    const snap = popSnapshot();
+    assert.equal(snap.addons.length, 3);
+    assert.equal(snap.addons[0].manifest.name, 'Torrentio');
+    assert.equal(snap.label, 'move');
+    assert.equal(setCalls.length, 1);
+    assert.equal(setCalls[0][0].manifest.name, 'Comet');
+    assert.equal(setCalls[0][1].manifest.name, 'Cinemeta');
+    assert.equal(setCalls[0][2].manifest.name, 'Torrentio');
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: moveAddon same index is no-op', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    const result = await moveAddon(1, 1);
+    assert.equal(result.length, 3);
+    assert.equal(setCalls.length, 0);
+    assert.ok(!canUndo());
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: moveAddon rejects invalid indices', async () => {
+  setSession('test-key');
+  const { api } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await assert.rejects(() => moveAddon(-1, 0), /Invalid source index/);
+    await assert.rejects(() => moveAddon(0, 99), /Invalid target index/);
+  } finally {
+    _resetApi();
+    clearSession();
+  }
+});
+
+test('mutations: removeAddon pushes rollback and removes', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await removeAddon(1);
+    assert.ok(canUndo());
+    assert.equal(setCalls[0].length, 2);
+    assert.equal(setCalls[0][0].manifest.name, 'Torrentio');
+    assert.equal(setCalls[0][1].manifest.name, 'Cinemeta');
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: removeAddon rejects invalid index', async () => {
+  setSession('test-key');
+  const { api } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await assert.rejects(() => removeAddon(99), /Invalid index/);
+    await assert.rejects(() => removeAddon(-1), /Invalid index/);
+  } finally {
+    _resetApi();
+    clearSession();
+  }
+});
+
+test('mutations: restoreFromBackup saves current state before overwriting', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    const backupAddons = makeAddons(['NewAddon', 'AnotherAddon']);
+    await restoreFromBackup(backupAddons);
+
+    assert.ok(canUndo());
+    const snap = popSnapshot();
+    assert.equal(snap.label, 'restore');
+    assert.equal(snap.addons.length, 3);
+    assert.equal(snap.addons[0].manifest.name, 'Torrentio');
+
+    assert.equal(setCalls[0].length, 2);
+    assert.equal(setCalls[0][0].manifest.name, 'NewAddon');
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: restoreFromBackup rejects empty', async () => {
+  setSession('test-key');
+  await assert.rejects(() => restoreFromBackup([]), /no addons/i);
+  await assert.rejects(() => restoreFromBackup(null), /no addons/i);
+  clearSession();
+});
+
+test('mutations: undo restores previous state', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await removeAddon(0);
+    assert.equal(setCalls[0].length, 2);
+
+    await undo();
+    assert.equal(setCalls[1].length, 3);
+    assert.equal(setCalls[1][0].manifest.name, 'Torrentio');
+    assert.ok(!canUndo());
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: multiple undos in LIFO order', async () => {
+  clearHistory();
+  setSession('test-key');
+  const { api, setCalls } = mockApi(ADDONS_3());
+  _setApi(api);
+
+  try {
+    await removeAddon(2);
+    await removeAddon(1);
+
+    await undo();
+    assert.equal(setCalls[2][0].manifest.name, 'Torrentio');
+    assert.equal(setCalls[2].length, 2);
+
+    await undo();
+    assert.equal(setCalls[3].length, 3);
+    assert.ok(!canUndo());
+  } finally {
+    _resetApi();
+    clearSession();
+    clearHistory();
+  }
+});
+
+test('mutations: undo rejects when nothing to undo', async () => {
+  clearHistory();
+  setSession('test-key');
+  await assert.rejects(() => undo(), /Nothing to undo/);
+  clearSession();
+});
+
+test('mutations: requires auth for all operations', async () => {
+  clearSession();
+  clearHistory();
+  await assert.rejects(() => moveAddon(0, 1), /Not authenticated/);
+  await assert.rejects(() => removeAddon(0), /Not authenticated/);
+  await assert.rejects(() => restoreFromBackup([{ manifest: { name: 'x' } }]), /Not authenticated/);
+});

--- a/account-tools/tests/rollback.test.mjs
+++ b/account-tools/tests/rollback.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  pushSnapshot,
+  popSnapshot,
+  peekSnapshot,
+  getHistory,
+  canUndo,
+  clearHistory,
+} from '../src/rollback.js';
+
+const makeAddons = (n) => Array.from({ length: n }, (_, i) => ({
+  manifest: { name: `Addon${i}` },
+  transportUrl: `https://example.com/${i}/manifest.json`,
+}));
+
+test('rollback: starts empty', () => {
+  clearHistory();
+  assert.ok(!canUndo());
+  assert.equal(popSnapshot(), null);
+  assert.equal(peekSnapshot(), null);
+  assert.deepEqual(getHistory(), []);
+});
+
+test('rollback: push and pop', () => {
+  clearHistory();
+  const addons = makeAddons(3);
+  pushSnapshot(addons, 'test-push');
+  assert.ok(canUndo());
+  const snap = popSnapshot();
+  assert.equal(snap.label, 'test-push');
+  assert.equal(snap.addons.length, 3);
+  assert.ok(!canUndo());
+});
+
+test('rollback: deep copies addons', () => {
+  clearHistory();
+  const addons = makeAddons(2);
+  pushSnapshot(addons, 'deep-copy');
+  addons[0].manifest.name = 'Mutated';
+  const snap = popSnapshot();
+  assert.equal(snap.addons[0].manifest.name, 'Addon0');
+});
+
+test('rollback: peek does not consume', () => {
+  clearHistory();
+  pushSnapshot(makeAddons(1), 'peek-test');
+  const a = peekSnapshot();
+  const b = peekSnapshot();
+  assert.equal(a.label, 'peek-test');
+  assert.equal(b.label, 'peek-test');
+  assert.ok(canUndo());
+  clearHistory();
+});
+
+test('rollback: LIFO order', () => {
+  clearHistory();
+  pushSnapshot(makeAddons(1), 'first');
+  pushSnapshot(makeAddons(2), 'second');
+  pushSnapshot(makeAddons(3), 'third');
+  assert.equal(popSnapshot().label, 'third');
+  assert.equal(popSnapshot().label, 'second');
+  assert.equal(popSnapshot().label, 'first');
+  assert.ok(!canUndo());
+});
+
+test('rollback: max history enforced', () => {
+  clearHistory();
+  for (let i = 0; i < 15; i++) {
+    pushSnapshot(makeAddons(1), `push-${i}`);
+  }
+  const history = getHistory();
+  assert.equal(history.length, 10);
+  assert.equal(history[0].label, 'push-5');
+  assert.equal(history[9].label, 'push-14');
+  clearHistory();
+});
+
+test('rollback: ignores empty addons', () => {
+  clearHistory();
+  pushSnapshot([], 'empty');
+  assert.ok(!canUndo());
+  pushSnapshot(null, 'null');
+  assert.ok(!canUndo());
+});
+
+test('rollback: getHistory returns summary', () => {
+  clearHistory();
+  pushSnapshot(makeAddons(3), 'summary-test');
+  const [entry] = getHistory();
+  assert.equal(entry.label, 'summary-test');
+  assert.equal(entry.addonCount, 3);
+  assert.ok(entry.timestamp);
+  assert.equal(entry.addons, undefined);
+  clearHistory();
+});
+
+test('rollback: clearHistory wipes all', () => {
+  pushSnapshot(makeAddons(1), 'a');
+  pushSnapshot(makeAddons(1), 'b');
+  clearHistory();
+  assert.ok(!canUndo());
+  assert.deepEqual(getHistory(), []);
+});

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -2,12 +2,18 @@ from pathlib import Path
 
 HTML = Path('account-tools/index.html').read_text()
 
-def test_account_tool_is_read_only():
+def test_account_tool_has_api_endpoints():
     assert 'addonCollectionGet' in HTML
-    assert 'addonCollectionSet' not in HTML
-    assert 'cannot change your account' in HTML
+    assert 'addonCollectionSet' in HTML
 
 def test_account_tool_clears_password_and_exports_backup():
     assert "$('password').value=''" in HTML
-    assert 'core-account-addons-backup.json' in HTML
-    assert 'Local backup preview' in HTML
+    assert 'stremio-backup-' in HTML
+
+def test_account_tool_has_mutation_controls():
+    assert 'undoBtn' in HTML
+    assert 'restoreBtn' in HTML
+    assert 'data-move' in HTML
+
+def test_account_tool_has_undo_history_limit():
+    assert 'undoStack.length>10' in HTML

--- a/tools/index.html
+++ b/tools/index.html
@@ -264,7 +264,7 @@ body{
       <div class="tool-idx">Account</div>
       <div class="tool-icon yellow"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
       <div class="tool-name">Account Manager</div>
-      <p class="tool-desc">Account-wide addon inspection, restore previews, ordering, cloning, and rollback are planned separately from the current read-only Addon Backup tool.</p>
+      <p class="tool-desc">Addon reorder, removal, restore from backup, and rollback. In development alongside the read-only Addon Backup tool.</p>
       <div class="tool-foot"><span class="badge badge-purple">Security review</span><span class="badge badge-muted">In development</span></div>
     </div>
     <a class="tool-card" href="https://www.npmjs.com/package/core-builds" target="_blank" rel="noopener">

--- a/tools/index.html
+++ b/tools/index.html
@@ -257,33 +257,23 @@ body{
     </a>
   </div>
 
-  <!-- Section 3: Coming Soon -->
-  <div class="section-label">03 · Coming soon</div>
+  <!-- Section 3: New tools -->
+  <div class="section-label">03 · New tools</div>
   <div class="tool-grid g2">
     <div class="tool-card" data-status="locked">
       <div class="tool-idx">Account</div>
-      <div class="tool-icon yellow">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-      </div>
+      <div class="tool-icon yellow"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
       <div class="tool-name">Account Manager</div>
-      <p class="tool-desc">Restore, ordering, cloning, Cinemeta controls, exact diffs, and rollback.</p>
-      <div class="tool-foot">
-        <span class="badge badge-purple">🔒 Security review</span>
-        <span class="badge badge-muted">Locked</span>
-      </div>
+      <p class="tool-desc">Account-wide addon inspection, restore previews, ordering, cloning, and rollback are planned separately from the current read-only Addon Backup tool.</p>
+      <div class="tool-foot"><span class="badge badge-purple">Security review</span><span class="badge badge-muted">In development</span></div>
     </div>
-    <div class="tool-card" data-status="locked">
+    <a class="tool-card" href="https://www.npmjs.com/package/core-builds" target="_blank" rel="noopener">
       <div class="tool-idx">CLI</div>
-      <div class="tool-icon red">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-      </div>
+      <div class="tool-icon red"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
       <div class="tool-name">CLI Tool</div>
       <p class="tool-desc">Generate, validate, and diff templates from the command line. <code>npx core-builds generate</code></p>
-      <div class="tool-foot">
-        <span class="badge badge-yellow">⏳ Planned</span>
-        <span class="badge badge-muted">npm</span>
-      </div>
-    </div>
+      <div class="tool-foot"><span class="badge badge-green">✓ Available</span><span class="tool-link">npm →</span></div>
+    </a>
   </div>
 
   <!-- What's New -->


### PR DESCRIPTION
## Description

Adds mutation capabilities to Account Manager — the fifth PR in the post-#623 sequence. Every mutation auto-backs up the current state before applying, with undo always available.

### New modules:
- **`mutations.js`** — `moveAddon`, `removeAddon`, `restoreFromBackup`, `undo` with dependency-injectable API for testability
- **`rollback.js`** — LIFO snapshot stack (max 10 entries), deep-copied, with `pushSnapshot`, `popSnapshot`, `peekSnapshot`, `canUndo`, `getHistory`, `clearHistory`

### API:
- **`setAddonCollection`** — new Stremio API endpoint wrapper (`addonCollectionSet`)

### UI:
- Move up/down buttons on each addon (live sessions only)
- Undo bar with last-action label
- Restore from backup button with confirmation dialog
- Auto-backup before every mutation

### Safety:
- Every mutation snapshots current state before applying
- Undo restores the exact previous addon list
- Multiple undos supported in LIFO order (up to 10 levels)
- Restore requires user confirmation via `confirm()` dialog
- Rollback snapshots are deep copies — immune to mutation

## Type of Change
- [x] Template improvement (optimisation, new feature)

## Testing
- 59 account-tools tests pass (16 addon-model, 7 auth-session, 8 backup, 8 diff, 11 mutations, 9 rollback)
- 230 configurator tests pass, 25 validation checks pass
- No template JSON changes in this PR

## Related Issues
Step 5 from post-#623 instruction sequence: "Add reorder/restore mutations only after rollback tests pass"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_