### PR TITLE
fix(tools): point CLI tool card to GitHub source

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -267,12 +267,12 @@ body{
       <p class="tool-desc">Addon reorder, removal, restore from backup, and rollback. In development alongside the read-only Addon Backup tool.</p>
       <div class="tool-foot"><span class="badge badge-purple">Security review</span><span class="badge badge-muted">In development</span></div>
     </div>
-    <a class="tool-card" href="https://www.npmjs.com/package/core-builds" target="_blank" rel="noopener">
+    <a class="tool-card" href="https://github.com/brevityA/Core-Builds/tree/main/cli" target="_blank" rel="noopener">
       <div class="tool-idx">CLI</div>
       <div class="tool-icon red"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
       <div class="tool-name">CLI Tool</div>
       <p class="tool-desc">Generate, validate, and diff templates from the command line. <code>npx core-builds generate</code></p>
-      <div class="tool-foot"><span class="badge badge-green">✓ Available</span><span class="tool-link">npm →</span></div>
+      <div class="tool-foot"><span class="badge badge-cyan">Source available</span><span class="tool-link">GitHub →</span></div>
     </a>
   </div>
 


### PR DESCRIPTION
## Summary
- Update CLI tool card link from npm to GitHub source tree (`cli/`)
- Change badge from "Available" / "npm →" to "Source available" / "GitHub →"

## Test plan
- [ ] Verify tools page renders correctly with new link
- [ ] Confirm CLI card links to `https://github.com/brevityA/Core-Builds/tree/main/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_