### PR TITLE
chore: promote Account Manager to available on tools page

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -260,13 +260,13 @@ body{
   <!-- Section 3: New tools -->
   <div class="section-label">03 · New tools</div>
   <div class="tool-grid g2">
-    <div class="tool-card" data-status="locked">
+    <a class="tool-card" href="../account-tools/">
       <div class="tool-idx">Account</div>
       <div class="tool-icon yellow"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
       <div class="tool-name">Account Manager</div>
-      <p class="tool-desc">Addon reorder, removal, restore from backup, and rollback. In development alongside the read-only Addon Backup tool.</p>
-      <div class="tool-foot"><span class="badge badge-purple">Security review</span><span class="badge badge-muted">In development</span></div>
-    </div>
+      <p class="tool-desc">Reorder, remove, restore, and undo addon changes. A backup is created before every account change.</p>
+      <div class="tool-foot"><span class="badge badge-green">&check; Available</span><span class="tool-link">Open &rarr;</span></div>
+    </a>
     <a class="tool-card" href="https://www.npmjs.com/package/core-builds" target="_blank" rel="noopener">
       <div class="tool-idx">CLI</div>
       <div class="tool-icon red"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>


### PR DESCRIPTION
## Summary
- Converts the Account Manager card on the tools page from a locked `div` to a clickable `<a>` linking to `../account-tools/`
- Updates description to match current functionality: "Reorder, remove, restore, and undo addon changes"
- Swaps badge from "Security review / In development" to "Available / Open →"

## Test plan
- [ ] Verify tools page renders correctly with Account Manager as a clickable card
- [ ] Confirm link navigates to `/account-tools/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_