### PR TITLE
Potential fix for code scanning alert no. 363: Clear text storage of sensitive information

### DIFF
--- a/configurator/src/js/app.js
+++ b/configurator/src/js/app.js
@@ -94,6 +94,22 @@ async function selectHealthyHost(timeout=4000) {
 // Set to '' to disable and fall back to direct-only fetches.
 const CORS_PROXY = 'https://core-builds-cors-proxy.tlorenzato26.workers.dev';
 const S = { service:null, device:null, resolution:null, audio:'limited', bandwidthMbps:0, content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'family-v4', p2pEnabled:false, qualityFirst:false, resolutionFirst:false, foreignLangKill:true, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:'',debrider:'',nzbnoob:'',althub:'',usenetcrawler:'',drunkenslug:'',nzbfinder:'',jackett:'',prowlarr:'',subdl:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', streamPool: 'normal', pseArch: 'standard', telemetryOk: false, simpleMode: false, installMode: 'direct', stremioEmail: '', stremioPassword: '', subtitleLangs: ['en'], subtitleAddons: ['aiosubtitle'], proxyEnabled: false, proxiedServices: [], catalogs: ['tmdb-addon'], dedupMerge: false, optionalScrapers: [], cleanInstall: false, quickProfile: 'balanced', preloadEnabled:true, autoPlayMethod:'matchingFile', addonTimeout:6000, patchCinemeta:false, installAIOMeta:false, ageLimit:'none', libraryBoost:'default', nzbFailover:false, nzbFailoverPosition:'after-torrents', maxFailoverNzbs:3 };
+const SENSITIVE_TOP_LEVEL_KEYS = new Set(['instancePassword', 'basePassword', 'stremioPassword']);
+
+function sanitizeSnapshotForStorage(raw) {
+  const out = {};
+  Object.keys(raw || {}).forEach((k) => {
+    if (SENSITIVE_TOP_LEVEL_KEYS.has(k)) return;
+    if (k === 'creds' && raw.creds && typeof raw.creds === 'object') {
+      const scrubbed = {};
+      Object.keys(raw.creds).forEach((ck) => { scrubbed[ck] = ''; });
+      out.creds = scrubbed;
+      return;
+    }
+    out[k] = raw[k];
+  });
+  return out;
+}
 // Conservative playback defaults. These describe the device/app itself, not an AVR attached elsewhere.
 const LANG_OPTS = [
   {v:'English'},{v:'Spanish'},{v:'French'},{v:'German'},{v:'Italian'},
@@ -3469,7 +3485,7 @@ function renderAddonFetchFallback(name, reason, safeMsg) {
     `</div></div>`;
 }
 function renderConfigRejectedDispatch(safeMsg, apiDetail) {
-  try { const snap={}; SHARE_KEYS.forEach(k=>{snap[k]=S[k];}); snap._ver=CONFIGURATOR_VERSION; snap._ts=Date.now(); snap._reason='soft-fail-recovery'; const list=JSON.parse(localStorage.getItem('coreBuildBackups')||'[]'); list.unshift(snap); localStorage.setItem('coreBuildBackups',JSON.stringify(list.slice(0,10))); } catch(e) {}
+  try { const snap={}; SHARE_KEYS.forEach(k=>{snap[k]=S[k];}); const safeSnap = sanitizeSnapshotForStorage(snap); safeSnap._ver=CONFIGURATOR_VERSION; safeSnap._ts=Date.now(); safeSnap._reason='soft-fail-recovery'; const list=JSON.parse(localStorage.getItem('coreBuildBackups')||'[]'); list.unshift(safeSnap); localStorage.setItem('coreBuildBackups',JSON.stringify(list.slice(0,10))); } catch(e) {}
   const sim = (typeof _simulateAddonFail !== 'undefined' && _simulateAddonFail) ? parseAddonFetchError('Failed to fetch manifest for ' + _simulateAddonFail) : null;
   const afe = sim || parseAddonFetchError(apiDetail);
   if (afe) {

--- a/configurator/src/js/app.js
+++ b/configurator/src/js/app.js
@@ -95,6 +95,25 @@ async function selectHealthyHost(timeout=4000) {
 const CORS_PROXY = 'https://core-builds-cors-proxy.tlorenzato26.workers.dev';
 const S = { service:null, device:null, resolution:null, audio:'limited', bandwidthMbps:0, content:null, name:'', multiServices:[], sizeLimit:'unlimited', formatter:'family-v4', p2pEnabled:false, qualityFirst:false, resolutionFirst:false, foreignLangKill:true, matchMode:'balanced', exclude4K:false, excludeDV:false, tmdbToken:'', tmdbApiKey:'', creds:{torbox:'',realdebrid:'',alldebrid:'',premiumize:'',debridlink:'',offcloud:'',easynews:'',easynewsPass:'',nzbgeek:'',debridio:'',debrider:'',nzbnoob:'',althub:'',usenetcrawler:'',drunkenslug:'',nzbfinder:'',jackett:'',prowlarr:'',subdl:''}, instanceHost:'elfhosted', instanceUrl:'', instanceUuid:'', instancePassword:'', baseUuid:'', basePassword:'', quickStart:false, langs: ['English'], langExclusive: false, cacheMode: 'mixed', streamPool: 'normal', pseArch: 'standard', telemetryOk: false, simpleMode: false, installMode: 'direct', stremioEmail: '', stremioPassword: '', subtitleLangs: ['en'], subtitleAddons: ['aiosubtitle'], proxyEnabled: false, proxiedServices: [], catalogs: ['tmdb-addon'], dedupMerge: false, optionalScrapers: [], cleanInstall: false, quickProfile: 'balanced', preloadEnabled:true, autoPlayMethod:'matchingFile', addonTimeout:6000, patchCinemeta:false, installAIOMeta:false, ageLimit:'none', libraryBoost:'default', nzbFailover:false, nzbFailoverPosition:'after-torrents', maxFailoverNzbs:3 };
 const SENSITIVE_TOP_LEVEL_KEYS = new Set(['instancePassword', 'basePassword', 'stremioPassword']);
+const SENSITIVE_KEY_TOKENS = ['password', 'apikey', 'api_key', 'token', 'secret', 'credential', 'auth'];
+
+function isSensitiveKeyName(key) {
+  const n = String(key || '').toLowerCase();
+  if (!n) return false;
+  if (SENSITIVE_TOP_LEVEL_KEYS.has(key)) return true;
+  return SENSITIVE_KEY_TOKENS.some(t => n.includes(t));
+}
+
+function sanitizeValueForStorage(val) {
+  if (Array.isArray(val)) return val.map(sanitizeValueForStorage);
+  if (!val || typeof val !== 'object') return val;
+  const out = {};
+  Object.keys(val).forEach((k) => {
+    if (isSensitiveKeyName(k)) { out[k] = ''; return; }
+    out[k] = sanitizeValueForStorage(val[k]);
+  });
+  return out;
+}
 
 function sanitizeSnapshotForStorage(raw) {
   const out = {};
@@ -106,7 +125,8 @@ function sanitizeSnapshotForStorage(raw) {
       out.creds = scrubbed;
       return;
     }
-    out[k] = raw[k];
+    if (isSensitiveKeyName(k)) { out[k] = ''; return; }
+    out[k] = sanitizeValueForStorage(raw[k]);
   });
   return out;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/brevityA/Core-Builds/security/code-scanning/363](https://github.com/brevityA/Core-Builds/security/code-scanning/363)

Best fix: sanitize state before persistence so no secrets are written to browser storage. Keep runtime behavior unchanged for in-memory use, but redact/drop sensitive fields specifically in the backup path at `renderConfigRejectedDispatch` (line ~3472 region).

Implement by:
1. Adding small helper functions in `configurator/src/js/app.js` to clone and scrub sensitive fields:
   - Remove top-level secrets: `instancePassword`, `basePassword`, `stremioPassword`.
   - Scrub credentials object `creds` values (set to empty strings).
2. Using these helpers when building `snap` before `localStorage.setItem(...)` in `renderConfigRejectedDispatch`.
3. Preserving non-sensitive fields and existing backup behavior (version, timestamp, reason, retention count) unchanged.

This single change addresses the reported variants at the same sink because all tainted secret sources converge into `S` and then into `snap` for storage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
