### PR TITLE
fix: sync Configurator v2.89 version badge

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -183,7 +183,7 @@
       <div id="stepStrip"></div>
       <div id="breadcrumbs"></div>
     </div>
-    <span id="hdrVersionBadge" data-action="show-changelog" style="position:absolute;top:9px;right:12px;font-size:.62rem;font-weight:800;color:#00d4ff;background:linear-gradient(135deg,rgba(0,212,255,.15),rgba(168,85,247,.12));border:1px solid rgba(0,212,255,.55);border-radius:5px;padding:2px 7px;letter-spacing:.07em;cursor:pointer;box-shadow:0 0 8px rgba(0,212,255,.25),inset 0 1px 0 rgba(255,255,255,.07);transition:all .15s" title="View changelog">v2.78</span>
+    <span id="hdrVersionBadge" data-action="show-changelog" style="position:absolute;top:9px;right:12px;font-size:.62rem;font-weight:800;color:#00d4ff;background:linear-gradient(135deg,rgba(0,212,255,.15),rgba(168,85,247,.12));border:1px solid rgba(0,212,255,.55);border-radius:5px;padding:2px 7px;letter-spacing:.07em;cursor:pointer;box-shadow:0 0 8px rgba(0,212,255,.25),inset 0 1px 0 rgba(255,255,255,.07);transition:all .15s" title="View changelog">v2.89</span>
   </header>
 
   <div id="main"></div>

--- a/configurator/scripts/build.mjs
+++ b/configurator/scripts/build.mjs
@@ -30,7 +30,11 @@ const { code: css } = await transform(rawCss, { loader: 'css', minify: true, tar
 await writeFile(resolve(assets, 'app.css'), css);
 await copyFile(resolve(src, 'vendor/qrcode.min.js'), resolve(assets, 'qrcode.min.js'));
 
-const shell = await readFile(resolve(src, 'index.html'), 'utf8');
+const pkg = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+const displayVersion = pkg.version.replace(/\.0$/, '');
+const rawShell = await readFile(resolve(src, 'index.html'), 'utf8');
+if (!rawShell.includes('__CB_VERSION__')) throw new Error('Source index.html is missing the __CB_VERSION__ placeholder');
+const shell = rawShell.replace(/__CB_VERSION__/g, displayVersion);
 const js = await readFile(jsOut, 'utf8');
 const qr = await readFile(resolve(src, 'vendor/qrcode.min.js'), 'utf8');
 const digest = value => createHash('sha256').update(value).digest('hex').slice(0, 12);

--- a/configurator/scripts/validate.mjs
+++ b/configurator/scripts/validate.mjs
@@ -98,6 +98,7 @@ const checks = {
   'partial exports': app.includes('const PARTIAL_EXPORT_FIELDS') && app.includes("credentials:{}") && app.includes("exportPartial(el.dataset.kind)"),
   'Core Tools links': app.includes('Back Up Addons') && app.includes('All Core Tools') && app.includes('Back up your current addons first'),
   'cache-busted web assets': buildScript.includes("createHash('sha256')") && buildScript.includes('app.js?v=${assetVersions.js}') && buildScript.includes('app.css?v=${assetVersions.css}'),
+  'version badge placeholder': shell.includes('v__CB_VERSION__') && !(/v\d+\.\d+<\/span>/.test(shell)),
   'module shell': shell.includes('type="module" src="./js/app.js"'),
   'Cinebye fallback allowed by CSP': appOrigins.has('https://cinebye.dinsden.top') && hasCinebyeCspOrigin,
   'external source CSS': cssFiles.every(file => shell.includes(`./styles/${file}`)) && !shell.includes('<style>'),

--- a/configurator/src/index.html
+++ b/configurator/src/index.html
@@ -188,7 +188,7 @@
       <div id="stepStrip"></div>
       <div id="breadcrumbs"></div>
     </div>
-    <span id="hdrVersionBadge" data-action="show-changelog" style="position:absolute;top:9px;right:12px;font-size:.62rem;font-weight:800;color:#00d4ff;background:linear-gradient(135deg,rgba(0,212,255,.15),rgba(168,85,247,.12));border:1px solid rgba(0,212,255,.55);border-radius:5px;padding:2px 7px;letter-spacing:.07em;cursor:pointer;box-shadow:0 0 8px rgba(0,212,255,.25),inset 0 1px 0 rgba(255,255,255,.07);transition:all .15s" title="View changelog">v2.78</span>
+    <span id="hdrVersionBadge" data-action="show-changelog" style="position:absolute;top:9px;right:12px;font-size:.62rem;font-weight:800;color:#00d4ff;background:linear-gradient(135deg,rgba(0,212,255,.15),rgba(168,85,247,.12));border:1px solid rgba(0,212,255,.55);border-radius:5px;padding:2px 7px;letter-spacing:.07em;cursor:pointer;box-shadow:0 0 8px rgba(0,212,255,.25),inset 0 1px 0 rgba(255,255,255,.07);transition:all .15s" title="View changelog">v__CB_VERSION__</span>
   </header>
 
   <div id="main"></div>

--- a/configurator/tests/version-badge.test.mjs
+++ b/configurator/tests/version-badge.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+const displayVersion = pkg.version.replace(/\.0$/, '');
+const shell = await readFile(new URL('../src/index.html', import.meta.url), 'utf8');
+const built = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+const buildScript = await readFile(new URL('../scripts/build.mjs', import.meta.url), 'utf8');
+
+test('source index.html uses __CB_VERSION__ placeholder, not a hard-coded version', () => {
+  assert.ok(shell.includes('v__CB_VERSION__'), 'source should contain the placeholder token');
+  assert.ok(!(/v\d+\.\d+<\/span>/.test(shell)), 'source should not hard-code a version in the badge');
+});
+
+test('built index.html contains the package.json version in the header badge', () => {
+  const expected = `title="View changelog">v${displayVersion}</span>`;
+  assert.ok(built.includes(expected), `built HTML should contain "${expected}"`);
+});
+
+test('built index.html does not contain the raw placeholder', () => {
+  assert.ok(!built.includes('__CB_VERSION__'), 'built HTML should not contain unresolved placeholder');
+});
+
+test('build script reads version from package.json', () => {
+  assert.ok(buildScript.includes("readFile(resolve(root, 'package.json')"), 'build should read package.json');
+  assert.ok(buildScript.includes('__CB_VERSION__'), 'build should replace the placeholder');
+});


### PR DESCRIPTION
## Summary

Fixes the Configurator header version badge being stale in the initial static HTML.

The release source was correctly bumped to v2.89, but `configurator/src/index.html` still carried an old hard-coded badge. The build now derives the display version from `configurator/package.json` and injects it into generated output.

## Changes

- Replace the static version badge with a build-time placeholder.
- Read the version from `configurator/package.json`.
- Inject the display version during standalone and web builds.
- Add regression coverage for:
  - source placeholder use;
  - built v2.89 output;
  - no unresolved placeholder;
  - package-version build source.

## Validation

- `npm test`
- `npm run validate`
- `npm run build`
- `npm run test:e2e`
- `git diff --check`

## Notes

- No template logic changes.
- No Docsalot changes.
- No release, deployment, or publication is included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_