### PR TITLE
fix(tools): scrub real profile key from WuPlay auto-setup placeholder

### DIFF
--- a/tools/genies/wuplay-catalogs.html
+++ b/tools/genies/wuplay-catalogs.html
@@ -284,7 +284,7 @@
     <h2 style="font-size:1.4rem;margin:8px 0 6px">One key unlocks your whole home screen.</h2>
     <p style="color:var(--sub);font-size:.74rem;line-height:1.6;margin-bottom:12px">Paste the <b style="color:var(--tx)">6-character profile key</b> (WuPlay on TV → Edit Profile → profile key). <b style="color:var(--green)">It lives only in this tab's memory</b> — no storage, and it is only ever sent to api.wuplay.app for your own profile. If anything stops mid-way, the steps already done are listed and reversible — and the guided checklist always remains.</p>
     <div class="keybox" style="margin-top:6px">
-      <input type="text" id="wpKeyField" maxlength="8" class="namein" style="font-size:16px;letter-spacing:.18em" placeholder="e.g. p3jrfu" autocomplete="off" spellcheck="false" aria-label="WuPlay profile key">
+      <input type="text" id="wpKeyField" maxlength="8" class="namein" style="font-size:16px;letter-spacing:.18em" placeholder="e.g. demo4u" autocomplete="off" spellcheck="false" aria-label="WuPlay profile key">
       <div class="keywarn" id="wpKeyWarn"></div>
       <div class="kbtns"><button class="kgo" id="wpKeyGo">🔑 That's my profile — let the genie work →</button></div>
     </div>


### PR DESCRIPTION
## Description
Replaces the real WuPlay profile key used as the input placeholder in the auto-setup page with a safe dummy value (`demo4u`).

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)

## Testing
- Verified `grep -rn` returns no hits for the old placeholder across the entire tree.
- Single-line change, no behavioral impact beyond the placeholder text.

## Related Issues
Privacy scrub — no public issue filed (key rotation handled out-of-band by the owner).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_