### PR TITLE
test: abort e2e when dist/web does not match the working tree

### DIFF
--- a/configurator/e2e/build-provenance.spec.mjs
+++ b/configurator/e2e/build-provenance.spec.mjs
@@ -1,0 +1,37 @@
+/**
+ * Prove the bundle the BROWSER loads matches this working tree.
+ *
+ * global-setup.mjs already compares dist/web on disk against the source fingerprint, and that
+ * catches the common failure: switch branches, forget to rebuild, test the previous branch's
+ * code. But a disk check has a hole. `reuseExistingServer` lets Playwright attach to a server
+ * that is already listening on the port — including one started from a DIFFERENT checkout of
+ * this repo. In that case the disk check validates an artifact the browser never loads, and
+ * passes while the tests run against someone else's build entirely.
+ *
+ * So this asserts over HTTP, against the same baseURL every other spec uses. Whatever is
+ * actually serving the tests has to hand back a stamp matching this tree, no matter which
+ * directory or process it came from, or when it started.
+ */
+import { test, expect } from '@playwright/test';
+import { sourceFingerprint } from '../scripts/source-fingerprint.mjs';
+
+test('the served bundle was built from this working tree', async ({ request, baseURL }) => {
+  const expected = await sourceFingerprint();
+
+  const res = await request.get('/.cb-build-stamp.json');
+  expect(
+    res.ok(),
+    `no build stamp served from ${baseURL} (HTTP ${res.status()}). The server on this port is ` +
+    'not serving a current dist/web — it may belong to another checkout. Stop it and rerun, ' +
+    'or run: npm run build --prefix configurator',
+  ).toBe(true);
+
+  const stamp = await res.json();
+  expect(
+    stamp.fingerprint,
+    `the SERVED bundle does not match this working tree.\n` +
+    `  served: ${String(stamp.fingerprint).slice(0, 12)} (built ${stamp.builtAt})\n` +
+    `  source: ${expected.slice(0, 12)}\n` +
+    'Every other result in this run describes code that is not in your tree.',
+  ).toBe(expected);
+});

--- a/configurator/e2e/global-setup.mjs
+++ b/configurator/e2e/global-setup.mjs
@@ -1,0 +1,66 @@
+/**
+ * Refuse to run e2e against a stale bundle.
+ *
+ * The Playwright webServer serves `dist/web` directly. `dist/` is gitignored, so it is not
+ * branch-tracked: it survives `git checkout` and keeps whatever was built last. Combined with
+ * `reuseExistingServer`, that means an e2e run started right after a branch switch can execute
+ * a completely different branch's JavaScript while reporting confidently about this one.
+ *
+ * This is not hypothetical. On 2026-08-15 a probe reported that structured Stremio errors
+ * rendered as "[object Object]". The source was correct; `dist/web` still held the previous
+ * branch's build. Time went into chasing a defect that did not exist, and — worse — any run
+ * that had happened to pass in that state would have been meaningless.
+ *
+ * So: compare a fingerprint of the source tree against the stamp written by `npm run build`.
+ * Mismatch fails the whole run with an actionable message rather than producing a result about
+ * the wrong code. Set CB_E2E_AUTOBUILD=1 to rebuild automatically instead of failing.
+ */
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { sourceFingerprint, CONFIGURATOR_ROOT, STAMP_RELATIVE } from '../scripts/source-fingerprint.mjs';
+
+const run = promisify(execFile);
+const stampPath = resolve(CONFIGURATOR_ROOT, STAMP_RELATIVE);
+
+async function readStamp() {
+  try {
+    return JSON.parse(await readFile(stampPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function fail(reason) {
+  throw new Error(
+    `\n\n  e2e aborted: the built bundle does not match the working tree.\n` +
+    `  ${reason}\n\n` +
+    `  dist/ is gitignored, so it survives a branch switch and the webServer will happily\n` +
+    `  serve another branch's JavaScript. Any result from this run would describe code that\n` +
+    `  is not in your working tree.\n\n` +
+    `  Fix:  npm run build --prefix configurator\n` +
+    `  Or:   CB_E2E_AUTOBUILD=1 npx playwright test   (rebuilds automatically)\n`,
+  );
+}
+
+export default async function globalSetup() {
+  const expected = await sourceFingerprint();
+  let stamp = await readStamp();
+
+  const stale = !stamp || stamp.fingerprint !== expected;
+
+  if (stale && process.env.CB_E2E_AUTOBUILD === '1') {
+    await run('npm', ['run', 'build'], { cwd: CONFIGURATOR_ROOT });
+    stamp = await readStamp();
+    if (!stamp || stamp.fingerprint !== expected) {
+      fail('a rebuild was attempted but the stamp still does not match.');
+    }
+    return;
+  }
+
+  if (!stamp) fail('no build stamp found in dist/web — the bundle has never been built here.');
+  if (stamp.fingerprint !== expected) {
+    fail(`stamp ${stamp.fingerprint.slice(0, 12)} (built ${stamp.builtAt}) != source ${expected.slice(0, 12)}.`);
+  }
+}

--- a/configurator/playwright.config.mjs
+++ b/configurator/playwright.config.mjs
@@ -2,6 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // Aborts the run if dist/web does not match the working tree. dist/ is gitignored, so it
+  // survives branch switches and the webServer below would otherwise serve another branch's
+  // build without any signal that it had done so.
+  globalSetup: './e2e/global-setup.mjs',
   timeout: 45_000,
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,

--- a/configurator/scripts/build.mjs
+++ b/configurator/scripts/build.mjs
@@ -13,6 +13,12 @@ const web = resolve(dist, 'web');
 const assets = resolve(web, 'assets');
 await mkdir(assets, { recursive: true });
 
+// Fingerprint the tree BEFORE anything reads it. Computing it after the bundle is written
+// would describe the tree as it is at the END of the build: edit a source file mid-build and
+// the stamp would certify a bundle that never contained that edit. Captured here, written
+// only once the build has actually succeeded.
+const buildFingerprint = await sourceFingerprint(root);
+
 const jsOut = resolve(assets, 'app.js');
 await build({
   entryPoints: [resolve(src, 'js/app.js')],
@@ -73,7 +79,7 @@ await writeFile(resolve(root, 'index.html'), standalone);
 // switch — without this stamp, an e2e run after a checkout silently tests another
 // branch's build. Written last, so it only appears when the build actually completed.
 const stamp = {
-  fingerprint: await sourceFingerprint(root),
+  fingerprint: buildFingerprint,
   version: pkg.version,
   builtAt: new Date().toISOString(),
 };

--- a/configurator/scripts/build.mjs
+++ b/configurator/scripts/build.mjs
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir, copyFile, cp } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { sourceFingerprint } from './source-fingerprint.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(root, '..');
@@ -66,6 +67,17 @@ if (standalone.includes('<script type="module" src="./js/app.js"></script>')) th
 if (standalone.includes("import { ICO }")) throw new Error('Standalone build contains unresolved module imports');
 await writeFile(resolve(dist, 'index.html'), standalone);
 await writeFile(resolve(root, 'index.html'), standalone);
+
+// Stamp the source fingerprint into dist/ so the e2e global setup can prove the served
+// bundle matches the working tree. dist/ is gitignored and therefore survives a branch
+// switch — without this stamp, an e2e run after a checkout silently tests another
+// branch's build. Written last, so it only appears when the build actually completed.
+const stamp = {
+  fingerprint: await sourceFingerprint(root),
+  version: pkg.version,
+  builtAt: new Date().toISOString(),
+};
+await writeFile(resolve(web, '.cb-build-stamp.json'), JSON.stringify(stamp, null, 2) + '\n');
 
 console.log(`Built standalone: ${standalone.length} bytes`);
 console.log(`Built web assets: ${js.length} JS bytes, ${css.length} CSS bytes`);

--- a/configurator/scripts/source-fingerprint.mjs
+++ b/configurator/scripts/source-fingerprint.mjs
@@ -1,0 +1,73 @@
+/**
+ * Fingerprint of every source input the build reads.
+ *
+ * Why this exists: `configurator/dist/` is gitignored, so it is NOT branch-tracked. It
+ * survives `git checkout`, and the Playwright webServer serves it directly
+ * (`python3 -m http.server -d dist/web`). Switch branches, run e2e without rebuilding, and
+ * the browser silently executes the bundle from whichever branch was built last — the suite
+ * reports green (or red) about code that is not the code under test.
+ *
+ * That happened on 2026-08-15: a probe reported a rendering defect that turned out to be a
+ * stale artifact from another branch, not the source. The build now stamps this fingerprint
+ * into dist/, and the e2e global setup refuses to run when the stamp does not match.
+ *
+ * Both sides import THIS module so the two fingerprints cannot drift apart.
+ */
+import { createHash } from 'node:crypto';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const CONFIGURATOR_ROOT = resolve(here, '..');
+export const STAMP_RELATIVE = 'dist/web/.cb-build-stamp.json';
+
+// Everything esbuild bundles or the shell template interpolates. package.json is included
+// because the version string is baked into the built shell.
+const SOURCE_DIRS = ['src'];
+const SOURCE_FILES = ['package.json'];
+
+async function walk(dir, out) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out; // a missing optional directory is not a fingerprint input
+  }
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) await walk(full, out);
+    else if (entry.isFile()) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * @returns {Promise<string>} stable sha256 over the sorted (path, content) pairs of every
+ * build input. Content-based, not mtime-based, so a checkout that rewrites timestamps
+ * without changing bytes does not produce a false mismatch.
+ */
+export async function sourceFingerprint(root = CONFIGURATOR_ROOT) {
+  const files = [];
+  for (const dir of SOURCE_DIRS) await walk(resolve(root, dir), files);
+  for (const file of SOURCE_FILES) {
+    const full = resolve(root, file);
+    try {
+      if ((await stat(full)).isFile()) files.push(full);
+    } catch { /* absent — skip */ }
+  }
+
+  // Sort by POSIX-normalised relative path so the digest is platform-stable.
+  const rows = files
+    .map(full => [relative(root, full).split(sep).join('/'), full])
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const hash = createHash('sha256');
+  for (const [rel, full] of rows) {
+    hash.update(rel);
+    hash.update('\0');
+    hash.update(await readFile(full));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}


### PR DESCRIPTION
## Description

**The e2e suite can silently test the wrong branch's code.**

`configurator/dist/` is gitignored, so it is not branch-tracked. It survives a `git checkout` and keeps whatever was built last. The Playwright `webServer` serves that directory directly:

```js
command: 'python3 -m http.server 4173 -d dist/web',
reuseExistingServer: !process.env.CI,
```

Switch branches, run e2e without rebuilding, and the browser executes a different branch's JavaScript while the suite reports confidently about this one. `reuseExistingServer` widens the window further.

**This already cost real time.** On 2026-08-15 a probe reported that structured Stremio errors rendered as `[object Object]`. The source was correct — `dist/web` still held the previous branch's build. Effort went into chasing a defect that did not exist. The more serious version of that failure is quieter: a run that *passes* in this state is meaningless, and nothing signals it.

## The fix

- `npm run build` stamps a content fingerprint of every source input it reads — `src/**` plus `package.json`, whose version is baked into the built shell — into `dist/web/.cb-build-stamp.json`. Written last, so it only appears when the build actually completed.
- A Playwright `globalSetup` recomputes that fingerprint and **aborts the whole run** on mismatch, with a message naming both digests and the fix, rather than producing a result about the wrong code.
- Both sides import the same `scripts/source-fingerprint.mjs`, so the two fingerprints cannot drift apart.
- The digest is **content-based, not mtime-based**, so a checkout that rewrites timestamps without changing bytes is not a false alarm.
- `CB_E2E_AUTOBUILD=1` rebuilds automatically instead of failing, for anyone who prefers that loop.

## Type of Change
- [ ] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [ ] Documentation update
- [x] Workflow / infrastructure

## Template Checklist

Not applicable — no template JSON is added or modified. This touches test harness and build tooling only; no configurator source or generated config changes.

## Testing

- AIOStreams instance: n/a — harness change, no config generation involved.
- TorBox plan: n/a
- Content tested on: n/a

| Suite | Result |
|---|---|
| Configurator unit | 319/319 |
| Static validator | 0 failures |
| CLI | 74/74 |
| packages/core | 35/35 |
| pytest | 279/279 |
| Playwright e2e (desktop) | 53/53 |

**The guard was verified against the failure mode it exists for, not just the happy path:**

1. **Current build** → run proceeds normally.
2. **Source edited without rebuilding** (the exact post-checkout scenario) → run aborts:
   ```
   e2e aborted: the built bundle does not match the working tree.
   stamp e983cd345b1e (built 2026-08-15T12:09:46.307Z) != source 0861d5f53d53.
   Fix:  npm run build --prefix configurator
   ```
3. **`CB_E2E_AUTOBUILD=1` on a stale tree** → rebuilds and passes.

## Notes for review

- Independent of #693, #694 and #695 — branched from `main`, touches no files any of them touch, and can merge in any order.
- CI was never exposed to this failure mode (it builds fresh every run), so this is purely a local-development correctness guard. That is also why it went unnoticed: the gap only opens on a developer machine that switches branches.
- Adds ~0.1s to a run for the fingerprint walk.

## Related Issues

None. Found while investigating a review comment on #693.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_