### PR TITLE
docs: complete the version-bump checklist in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,13 @@ This is **brevityA/Core-Builds**, the canonical repo for Core Builds by Brevity 
 
 - **Create a new PR for every task.** After committing and pushing changes, always open a pull request — even for small or experimental changes.
 - **Build and test before push.** Run `npm run build && npm test && npm run validate` in `configurator/` before pushing configurator changes.
-- **Version consistency.** When bumping `CONFIGURATOR_VERSION` in `app.js`, also update `configurator/package.json`, `versions.json`, `configurator/src/data/changelog.js`, and `configurator/scripts/validate.mjs`.
+- **Version consistency.** When bumping `CONFIGURATOR_VERSION` in `app.js`, also update `configurator/package.json`, `cli/package.json`, `packages/core/package.json`, `versions.json`, and `configurator/src/data/changelog.js`. `cli/tests/package-equivalence.test.mjs` asserts that `cli`, `packages/core` and `versions.configurator` share a `major.minor` — miss either package and 8 CLI tests fail (this list omitted both until v2.93, and CI caught it rather than the local board). `configurator/scripts/validate.mjs` needs no edit: its version check is dynamic.
+  - Then regenerate what derives from those files, or the suites fail downstream:
+    `npm run build --prefix configurator` (the version is baked into the built shell),
+    `python3 scripts/sync-docs.py --apply` (What's New + tools page come from `changelog.js`),
+    and `UPDATE_GOLDEN=1 npx playwright test e2e/golden-configs.spec.mjs` in `configurator/`
+    (all 15 goldens embed `coreBuildsVersion`; review that diff — it should be the version line and nothing else).
+  - Run `npm test` in `configurator/`, `cli/` **and** `packages/core/` before pushing. The configurator suite alone will not catch a version-coupling break.
 
 ---
 


### PR DESCRIPTION
## Description

**The checklist was incomplete, and it cost a CI failure during the v2.93 release.**

It listed five files and omitted `cli/package.json` and `packages/core/package.json`. But `cli/tests/package-equivalence.test.mjs` asserts that `cli`, `packages/core` and `versions.configurator` share a `major.minor` — so bumping the configurator alone breaks 8 CLI tests. That is exactly what happened on #694: CI caught it, the local board did not, because the configurator suite alone cannot see the coupling.

The checklist now also records the regeneration steps that follow a bump. Each of these failed downstream during that same release:

| Step | What breaks without it |
|---|---|
| `npm run build --prefix configurator` | the version is baked into the built shell |
| `python3 scripts/sync-docs.py --apply` | What's New + tools page derive from `changelog.js`; pytest fails |
| `UPDATE_GOLDEN=1 … golden-configs.spec.mjs` | all 15 goldens embed `coreBuildsVersion`; the bump invalidated every one |

Plus an explicit instruction to run the `cli/` and `packages/core/` suites, not just the configurator's.

`configurator/scripts/validate.mjs` is now called out as needing **no** edit — its version check is dynamic (`CHANGELOG[0].v === appVer && pkg.version.startsWith(appVer + '.')`). Listing it alongside files that genuinely need editing was misleading.

## Type of Change
- [ ] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [x] Documentation update
- [ ] Workflow / infrastructure

## Template Checklist

Not applicable — documentation only, one paragraph in `CLAUDE.md`. No code, templates or generated output.

## Testing

- AIOStreams instance: n/a — documentation change.
- TorBox plan: n/a
- Content tested on: n/a

| Suite | Result |
|---|---|
| pytest | 279/279 |
| Static validator | 0 failures |
| Configurator unit | 335/335 |

Also verified that `scripts/sync-docs.py` reports `CLAUDE.md` in sync after the edit — the generator manages other sections of that file, so this confirms it does not own the Workflow Rules block and will not overwrite the change.

## Notes for review

Every claim in the added text was verified against the code rather than written from memory: the `package-equivalence` assertion, the 8-test failure count (from the #694 CI log), the 15 goldens carrying `coreBuildsVersion`, and the dynamic validator check.

## Related Issues

None. Follow-up from the v2.93 release (#694), where this gap surfaced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_