### PR TITLE
ci: cache Playwright browsers so a slow mirror stops reading as a failure

### DIFF
--- a/.github/workflows/configurator-e2e.yml
+++ b/.github/workflows/configurator-e2e.yml
@@ -50,16 +50,23 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('configurator/package-lock.json') }}
           restore-keys: ${{ runner.os }}-playwright-
 
-      # On a hit the binaries are already present, so only the system libraries
-      # are needed — a much smaller apt transaction than a full --with-deps.
-      # Split rather than always running --with-deps so a cache hit skips the
-      # download entirely instead of re-verifying it.
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+      # Both steps run unconditionally, on purpose.
+      #
+      # An earlier version branched on cache-hit and installed browsers only on a
+      # miss. That trusts the cache to be complete, and a cache entry written from
+      # an interrupted run can hold a partially-downloaded browser — which would
+      # fail at launch, after the install step reported success. Review raised
+      # exactly that.
+      #
+      # `playwright install` is already the right shape for this: it verifies what
+      # is on disk and returns in seconds when the browser is intact, downloading
+      # only what is missing or corrupt. So running it every time costs almost
+      # nothing on a hit, repairs a bad cache entry, and removes any path where
+      # the job reaches the tests without a working browser.
       - name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
 
       - run: npm run test:e2e
       - name: Upload Playwright report on failure

--- a/.github/workflows/configurator-e2e.yml
+++ b/.github/workflows/configurator-e2e.yml
@@ -18,7 +18,12 @@ permissions:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Raised from 15. On 2026-08-19 two consecutive runs on different runners
+    # burned the entire 15-minute budget inside `playwright install` and were
+    # cancelled before a single spec executed — a slow package mirror reading as
+    # a failing build. The suite itself takes ~3 minutes; the headroom is for the
+    # install step, not the tests.
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: configurator
@@ -31,7 +36,31 @@ jobs:
           cache-dependency-path: configurator/package-lock.json
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps chromium
+
+      # Browser binaries are ~150 MB and identical for a given Playwright
+      # version, so downloading them on every run is the single largest avoidable
+      # cost here — and the step that stalled. Keyed on the lockfile so a
+      # Playwright bump invalidates the cache automatically; a stale browser
+      # against a new client is its own confusing failure.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('configurator/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      # On a hit the binaries are already present, so only the system libraries
+      # are needed — a much smaller apt transaction than a full --with-deps.
+      # Split rather than always running --with-deps so a cache hit skips the
+      # download entirely instead of re-verifying it.
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
       - run: npm run test:e2e
       - name: Upload Playwright report on failure
         if: failure()


### PR DESCRIPTION
## Why this exists

On 19 Aug the e2e job was cancelled **twice in a row, on two different runners**, having spent its entire 15-minute budget inside `npx playwright install --with-deps chromium`:

| Attempt | Runner | Stalled on | Outcome |
|---|---|---|---|
| 1 | `…8435` | `playwright install` 08:31:17 → 08:46:21 | cancelled, tests skipped |
| 2 | `…8441` | `playwright install` 08:47:40 → 09:02:42 | cancelled, tests skipped |

Both times `npm run test:e2e` was **skipped** — not one spec executed. #701 therefore showed a red required check that said nothing whatsoever about the code, and had to be merged on a locally-run suite instead. The tests themselves take ~3 minutes.

## What changed

One file, three changes, each aimed at a different part of that failure.

**Cache `~/.cache/ms-playwright`.** The browser binaries are ~150 MB and identical for a given Playwright version, so re-downloading them on every run is both the largest avoidable cost and the step that actually stalled. Keyed on the lockfile hash so a Playwright bump invalidates the cache on its own — a stale browser against a new client is its own confusing failure.

**Split the install.** On a cache hit only the system libraries are needed (`playwright install-deps`), a far smaller apt transaction than a full `--with-deps`; on a miss the original command runs unchanged.

**`timeout-minutes` 15 → 25.** Caching makes the stall less likely, not impossible. The headroom is for the install step, not the tests, which have never needed it.

## Fails safe

The two install conditions are exhaustive. If the cache step itself errors, `cache-hit` is empty, `!= 'true'` is true, and the full `--with-deps` install runs. There is no path where the job proceeds to `test:e2e` without a browser.

## Verified / not verified

**Verified locally:** the workflow YAML parses; step order and conditions resolve as intended; `playwright install-deps` is a real subcommand on the pinned `1.62.1`; the diff touches this one file and nothing else.

**Not verifiable from here:** whether a cache *hit* actually satisfies the suite on a runner. This branch's own CI run is the first real test of that, and it will necessarily be a cache **miss** (nothing has populated the key yet) — so the first run exercises the unchanged path, and the second run is the one that proves the hit path. Worth watching a follow-up run before assuming it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_