### PR TITLE
feat(speedtest): engine v3 — worker-isolated, first-byte-anchored, 2-rep median

### DIFF
--- a/.github/workflows/speedtest-engine.yml
+++ b/.github/workflows/speedtest-engine.yml
@@ -1,0 +1,78 @@
+# CoreSpeed Engine CI
+# ─────────────────────────────────────────────────────────────────────────────
+# Deploy to the repo as:  .github/workflows/speedtest-engine.yml
+# It expects the speedtest tool at:  tools/speedtest/
+#   index.html         (the shipped page)
+#   test-engine.mjs    (the harness)
+#   check-syntax.mjs   (inline-script syntax check)
+#
+# Two jobs:
+#   unit  — syntax + pure-logic tests, NO network. Runs on every push/PR that
+#           touches the speedtest tool. Fast (<1 min).
+#   live  — runs the real worker against the live TorBox CDN (downloads a few
+#           hundred MB). Runs nightly and on manual dispatch, so we don't burn
+#           CDN data on every commit.
+name: CoreSpeed Engine
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tools/speedtest/**"
+      - ".github/workflows/speedtest-engine.yml"
+  pull_request:
+    paths:
+      - "tools/speedtest/**"
+      - ".github/workflows/speedtest-engine.yml"
+  schedule:
+    # Nightly live verification — 03:17 UTC (~13:17 AEST, off-peak for the CDN)
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      run_live:
+        description: "Also run the live CDN test (downloads a few hundred MB from TorBox CDN)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: speedtest-engine-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  unit:
+    name: "Syntax + unit (offline)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: "Syntax-check the shipped page"
+        run: node tools/speedtest/check-syntax.mjs tools/speedtest/index.html
+      - name: "Unit tests (pure logic, no network)"
+        run: node tools/speedtest/test-engine.mjs --unit
+
+  live:
+    name: "Live CDN protocol test"
+    needs: unit
+    # Nightly schedule, or manual dispatch with run_live enabled.
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_live == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: "Live test against TorBox CDN"
+        env:
+          # Override the target node here (or via repo variable CORESPEED_LIVE_URL)
+          # if TorBox renames the closest 1 GB test file.
+          LIVE_URL: ${{ vars.CORESPEED_LIVE_URL || 'https://store-011.wnam.tb-cdn.io/dld/1GB.bin' }}
+        run: node tools/speedtest/test-engine.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1024,8 +1024,8 @@ The speed test is a **single self-contained `tools/speedtest/index.html`** (zero
   - `node tools/speedtest/check-syntax.mjs tools/speedtest/index.html` — always
   - `node tools/speedtest/test-engine.mjs --unit` — always before push (offline, 27 tests)
   - `node tools/speedtest/test-engine.mjs` — before push when touching the engine (live CDN, ~0.4 GB; `LIVE_URL=…` overrides the node)
-  - `node tools/speedtest/benchmark.mjs` — manual only, downloads 0.2–1.5 GB, never a gate
-- **CI:** `.github/workflows/speedtest-engine.yml` — unit job on every push/PR touching the tool; live CDN job nightly + manual dispatch (override node via repo variable `CORESPEED_LIVE_URL`).
+  - `node tools/speedtest/benchmark.mjs` — manual only, downloads ~0.5–2.5 GB (`--full` and `--rounds N` both increase it; `--budget` caps it), never a gate
+- **CI:** `.github/workflows/speedtest-engine.yml` — unit job on PRs and on pushes to `main` touching the tool; live CDN job nightly + manual dispatch (override node via repo variable `CORESPEED_LIVE_URL`).
 - **Snapshot:** the `SNAPSHOT` const in `index.html` is a dated fallback endpoint list. TorBox renames nodes occasionally; if the live CI job fails or the on-page badge shows a stale/unverified snapshot, refresh the const from the two API calls in `tools/speedtest/README.md`.
 - **Do not modify `cloudflare-worker/`** for speedtest work — the v3 endpoint chain uses the existing `GET /proxy/v1/api/speedtest` lane and its `HOST_SCOPES` restrictions.
 - **Worker deploys are not proven by a green tick** (preserved from the v2 speedtest README, which v3 replaced): `deploy-worker.yml` fires on pushes to `main` touching `cloudflare-worker/**`, but it reports success even when it *skips* the deploy because the Cloudflare secrets are unset. Confirm the "Deploy to Cloudflare Workers" step actually ran before believing anything shipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1013,3 +1013,19 @@ Same structure but with `service` key after `seadex` for debrid provider priorit
 - Reddit (Core Crew): https://www.reddit.com/r/CoreBuilds/
 - AIOStreams: https://github.com/Viren070/AIOStreams
 - AIOStreams docs: https://docs.aiostreams.viren070.me
+---
+
+## Speed Test (tools/speedtest) — engine v3
+
+The speed test is a **single self-contained `tools/speedtest/index.html`** (zero build step, zero dependencies), deployed to Pages by the existing `deploy-configurator.yml`. It measures every TorBox Hyperdrive CDN node; the methodology is documented in its README.
+
+- **Engine invariants (deliberate accuracy fixes — do not regress):** all byte counting runs in a Web Worker (never the main thread); measurement windows are first-byte-anchored on the 1 GB file; nodes are measured twice and ranked by median steady-state; failed/skipped nodes are never ranked; units are decimal (MiB/s only via the labelled toggle).
+- **Test surface** (from the repo root):
+  - `node tools/speedtest/check-syntax.mjs tools/speedtest/index.html` — always
+  - `node tools/speedtest/test-engine.mjs --unit` — always before push (offline, 27 tests)
+  - `node tools/speedtest/test-engine.mjs` — before push when touching the engine (live CDN, ~0.4 GB; `LIVE_URL=…` overrides the node)
+  - `node tools/speedtest/benchmark.mjs` — manual only, downloads 0.2–1.5 GB, never a gate
+- **CI:** `.github/workflows/speedtest-engine.yml` — unit job on every push/PR touching the tool; live CDN job nightly + manual dispatch (override node via repo variable `CORESPEED_LIVE_URL`).
+- **Snapshot:** the `SNAPSHOT` const in `index.html` is a dated fallback endpoint list. TorBox renames nodes occasionally; if the live CI job fails or the on-page badge shows a stale/unverified snapshot, refresh the const from the two API calls in `tools/speedtest/README.md`.
+- **Do not modify `cloudflare-worker/`** for speedtest work — the v3 endpoint chain uses the existing `GET /proxy/v1/api/speedtest` lane and its `HOST_SCOPES` restrictions.
+- **Worker deploys are not proven by a green tick** (preserved from the v2 speedtest README, which v3 replaced): `deploy-worker.yml` fires on pushes to `main` touching `cloudflare-worker/**`, but it reports success even when it *skips* the deploy because the Cloudflare secrets are unset. Confirm the "Deploy to Cloudflare Workers" step actually ran before believing anything shipped.

--- a/tools/speedtest/README.md
+++ b/tools/speedtest/README.md
@@ -1,72 +1,60 @@
-# CoreSpeed — TorBox CDN Speed Test
+# CoreSpeed — TorBox CDN Speed Test (engine v3)
 
-A client-side speed test for [TorBox](https://torbox.app)'s Hyperdrive CDN, built into the Core Builds tool suite. Live at `brevitya.github.io/Core-Builds/tools/speedtest/` (also linked from the Builder splash → *Utilities*).
+A client-side speed test for [TorBox](https://torbox.app)'s Hyperdrive CDN, built into the Core Builds tool suite. Live at `brevitya.github.io/Core-Builds/tools/speedtest/`.
 
-## Why the methodology matters (v2)
+## What it measures, and why the methodology matters
 
-TorBox's CDN is a mix of direct per-region servers (Lisbon, Mumbai, Tokyo…) and Cloudflare-fronted edge nodes (`store-XXX`). The official TorBox speedtest answers one question: **what does a single connection from your ISP to each node actually get?** It tests nodes **sequentially** (one at a time, so nothing else eats your line), with **one connection** (what a player uses), ~30 s per node, ping = trimmed mean of 5 HEADs, all inside a Web Worker.
+v3 exists because v1/v2 numbers didn't match TorBox's own speedtest — and the audit (`docs`/community reports) showed the difference was methodology, not the CDN:
 
-CoreSpeed v1 raced all 17 nodes **concurrently with 4 streams each** — fun, but misleading: parallel streams mask latency (a player can't use them), and the concurrent start makes fast-ramping nodes steal bandwidth, so rankings became ramp noise. A supporter in southern Europe could legitimately see *India* win — their ISP routes to Akamai Mumbai well over 4 streams — while real single-connection playback there would buffer. That's exactly the "opposite to the TorBox website" report.
+- **Worker-isolated measurement.** Every byte is counted inside a dedicated Web Worker. The UI can't starve the read loop or cap measured throughput (v2 ran the read loop on the main thread while rebuilding the map/table/canvas every 250 ms).
+- **1 GB file, first-byte-anchored window.** Each node gets a 15 s window (10/20 s selectable) measured from the first byte on the 1 GB file, so TCP slow-start is <10 % of the window on any line up to ~700 Mbps. (v2's 10 s cap on the 100 MB file collapsed to ~1 s on fast lines and measured a partial file on slow ones.)
+- **Two reps, median.** Rep 2 re-samples the second half of the file via Range. Headline = median of per-rep *steady-state* (window minus the first 2 s) — one throttled rep dilutes instead of defining the result. Rep-to-rep σ is shown as a Consistency column.
+- **Honest stats, both shown.** `Steady` (playback number), `Raw avg` = bytes ÷ time-since-first-byte, plus peak, p95, TTFB and ping (5 × 1-byte Range GETs, trimmed mean of the middle 3, 4 s timeout per round — timed, unlike TorBox's own pre-test HEADs).
+- **Decimal units** (Mbps = 10⁶ bit/s; MB/s = 10⁶ B/s), with an optional correctly-labelled MiB/s toggle. (The midnight fork reports binary MiB/s labelled "MB/s" — ~4.8 % inflation.)
+- **Failed/skipped nodes are never ranked** — they get a labelled "Not ranked" section with the reason.
 
-**CoreSpeed v2 fixes this:**
+### Modes
 
-- **Sequential mode (default)** — one node at a time, **one connection**, 10 s cap or file-complete. Same approach as TorBox's own test, ~75–180 s for all 17 nodes. This is the number that matters for playback, and the only mode that produces streaming verdicts.
-- **Burst / Quick / Full** are explicitly labeled **multi-stream capacity races** — they show pipe capacity and are fun, but produce no playback verdicts.
-- **Ping = trimmed mean of 5 HEADs** (drop best & worst, mean the middle 3) — matching TorBox's site.
-- **Verdicts are ping-aware** — a node with >250 ms ping can't earn a "4K" verdict no matter how fast it downloads; >400 ms caps at SD. (Buffering on high-latency routes is real even when throughput looks fine.)
-- **Route-anomaly notices** — if a far node wins, the winner banner says so explicitly instead of just crowning it.
-- **Topology transparency** — Cloudflare-fronted / edge nodes are badged in the table and legend, because "US West" served from *your* local Cloudflare edge is a different beast from a direct server.
-- **Diagnostics export** — the ⛨ button downloads a JSON report (per-node pings, all 5 rounds, DNS A-records, your ISP/ASN, measurement metadata) so supporters can share evidence instead of screenshots.
+| Mode | What | Data (worst case) | Time (17 nodes) |
+|---|---|---|---|
+| **Accurate** (default) | Sequential, 1 connection, 2 reps × 15 s on 1 GB, median steady, playback verdicts | ≤ ~2 GB/node; 12 GB budget skips, never truncates | ~9 min slow … ~2 min on Gbps lines (budget-limited to ~6 nodes) |
+| **Express** | Closest + top-4-by-ping, 1 rep × 15 s | ≤ 5 GB — always fits | ~90–120 s |
+| **Capacity race** | All scoped nodes at once, 1–8 real Range connections each, 20 s, 250 MB–1 GB/node | ~8.5 GB @ 500 MB/node | ~20–30 s |
 
-## What it does
-
-- **Sequential accurate test (default)** — single connection per node, live gauge/sparkline for the current node, ETA, then a ranked table with stability, verdicts, and a winner banner.
-- **Capacity races** — Burst (5–20 s/node, N streams), Quick (100 MB file), Full (1 GB file), all nodes at once with live leaderboard.
-- **World map** — nodes sized/coloured by measured speed, winner crowned, your location marked (ipwho.is, falls back to your closest CDN).
-- **History + compare** — last 15 runs in `localStorage`, Δ-vs-previous columns, load any past run back.
-- **Exports** — Markdown report (copy), CSV, JSON, and the diagnostics JSON.
-- Hard 12 GB data budget, instant Stop, per-node caps (10 s sequential, 45/90 s quick/full).
-
-No API key, no backend, no tracking — everything runs in the browser.
+The capacity race is *real* parallelism (N workers, independent 1/N slices) — TorBox's own "multithreaded" mode is a single TCP connection with 1 MB buffering. Capacity numbers are pipe capacity, never a playback verdict.
 
 ## How it gets the CDN list
 
-TorBox's speedtest API (`https://api.torbox.app/v1/api/speedtest`) doesn't send `Access-Control-Allow-Origin`, so browsers can't call it directly. CoreSpeed falls back in order:
+TorBox's speedtest API (`https://api.torbox.app/v1/api/speedtest`) doesn't send `Access-Control-Allow-Origin`, so the chain is:
 
-1. **Core Builds worker proxy** — `GET /proxy/v1/api/speedtest?host=https://api.torbox.app&test_length=short` against the suite's Cloudflare Worker. **Live since 19 Aug 2026** — no allowlist edit or redeploy is needed any more, and it was verified against the running worker rather than assumed.
-2. **Direct API call** — kept for the day TorBox opens CORS; harmless when it fails.
-3. **Embedded snapshot** — the last known node list (date-stamped in the badge). Results still measure real files on real nodes; only the *directory* can go stale if TorBox renames nodes — they do rename occasionally (e.g. `store-039` replaced `nexus-125`), so refresh the snapshot when the badge date is old.
+1. **`?worker=` override** (your own proxy) — pass `?worker=https://your-proxy.example`
+2. **Core Builds worker proxy** — `GET /proxy/v1/api/speedtest?host=…&test_length=…` against `core-builds-cors-proxy.tlorenzato26.workers.dev` (restricted to that one path; see `cloudflare-worker/worker.js` `HOST_SCOPES`)
+3. **Direct API call** — kept for the day TorBox opens CORS
+4. **Embedded snapshot** — last known node list (date-stamped in the badge), **probed** on load (1-byte Range GET per host); if >20 % are unreachable it retries the live list once, else the badge says `snapshot … · unverified`
 
-If you host your own worker instance, pass it with `?worker=https://your-proxy.example`.
-
-### How narrow that lane is
-
-The generic proxy accepts GET/POST/PATCH on any path and forwards a caller-supplied
-`Authorization` header, which the WuPlay device-token lane depends on. Applied to a
-third-party API where users hold their own account keys, that would make the worker an
-authenticated relay for the whole of TorBox. `HOST_SCOPES` in `cloudflare-worker/worker.js`
-therefore restricts this host to `GET /v1/api/speedtest` and strips credentials; four tests
-in `worker.test.js` hold it shut, and the deployed worker returns
-`path not allowed for this host` / `method not allowed for this host` for anything else.
-
-Deployment is automatic — `.github/workflows/deploy-worker.yml` fires on any push to `main`
-touching `cloudflare-worker/**`. Note that workflow reports success even when it *skips* the
-deploy because secrets are unset, so a green tick alone does not prove anything shipped:
-check that the "Deploy to Cloudflare Workers" step actually ran.
-
-## Keeping the snapshot fresh
-
-The embedded snapshot lives in `tools/speedtest/index.html` (`SNAPSHOT` const). Refresh it with the output of:
+TorBox renames nodes occasionally (two in the week before v3 shipped: `store-039`→`store-011` wnam, `nexus-083`→`nexus-244` latm). Refresh the `SNAPSHOT` const with:
 
 ```bash
 curl -s "https://api.torbox.app/v1/api/speedtest?test_length=short"
 curl -s "https://api.torbox.app/v1/api/speedtest?test_length=long"
+# merge by region+name into SNAPSHOT.data (url_long from the long list)
 ```
 
-(merge by region+name; see the `SNAPSHOT.data` shape in the file).
+The nightly CI live test will flag engine/endpoint breakage the day it happens.
+
+## Tests & benchmark
+
+| Command | What | Network |
+|---|---|---|
+| `node check-syntax.mjs` | Compiles the shipped page's inline script | no |
+| `node test-engine.mjs --unit` | 27 pure-logic tests (median, verdicts, units, snapshot, ranking) | no |
+| `node test-engine.mjs` | Unit + **live**: runs the shipped worker source against the real CDN (ping protocol, first-byte window, byte-exact Range slices, abort) | ~0.4 GB |
+| `node benchmark.mjs [--full] [--rounds N]` | Side-by-side vs **TorBox's actual `speedtest-worker.js`** (fetched fresh) + curl, paired per-round deltas, 2.5 GB budget guard | ~0.5–1.5 GB |
+
+`LIVE_URL=…` overrides the CDN target. CI (` .github/workflows/speedtest-engine.yml `) runs the offline job on every push to this folder and the live job nightly + on demand.
 
 ## Architecture
 
-Single self-contained `index.html` (inline CSS + JS, ~115 KB) — matches the suite's other tool pages (genies, inspector, preflight). Zero build step; shipped by the existing `deploy-configurator.yml` Pages workflow, which copies repo-root `tools/` beside the configurator.
+Single self-contained `index.html` (inline CSS + JS, ~139 KB) — matches the suite's other tool pages. Zero build step; shipped by the existing `deploy-configurator.yml` Pages workflow, which copies repo-root `tools/` beside the configurator. The script is structured so everything above the `/* ================= UI SECTION ================= */` marker is DOM-free and unit-tested in Node; the harness extracts and runs the actual shipped `WORKER_SRC`.
 
-**Measurement engine:** ping phase (5× HEAD per node, concurrent) → sequential single-stream phase or concurrent multi-stream race. Byte counting happens in the fetch read loop (`performance.now()`-deltas, not timer-based), a 250 ms sampler drives the UI (gauge, spark, table), first-interval baselines exclude connection-setup buffering, stability = 1 − σ/μ over post-slow-start samples, sustained = bytes ÷ active time. Every async path captures its run object so a stale timer can never corrupt a newer run.
+No API key, no tracking — everything runs in the browser. Hard 12 GB data budget, instant Stop, per-node caps, background-safe measurement (window cap checked on chunk arrival, immune to tab timer throttling).

--- a/tools/speedtest/README.md
+++ b/tools/speedtest/README.md
@@ -49,9 +49,9 @@ The nightly CI live test will flag engine/endpoint breakage the day it happens.
 | `node check-syntax.mjs` | Compiles the shipped page's inline script | no |
 | `node test-engine.mjs --unit` | 27 pure-logic tests (median, verdicts, units, snapshot, ranking) | no |
 | `node test-engine.mjs` | Unit + **live**: runs the shipped worker source against the real CDN (ping protocol, first-byte window, byte-exact Range slices, abort) | ~0.4 GB |
-| `node benchmark.mjs [--full] [--rounds N]` | Side-by-side vs **TorBox's actual `speedtest-worker.js`** (fetched fresh) + curl, paired per-round deltas, 2.5 GB budget guard | ~0.5–1.5 GB |
+| `node benchmark.mjs [--full] [--rounds N]` | Side-by-side vs **TorBox's actual `speedtest-worker.js`** (fetched fresh) + curl, paired per-round deltas, 2.5 GB budget guard | ~0.5–2.5 GB (`--full` and `--rounds N` both increase it) |
 
-`LIVE_URL=…` overrides the CDN target. CI (` .github/workflows/speedtest-engine.yml `) runs the offline job on every push to this folder and the live job nightly + on demand.
+`LIVE_URL=…` overrides the CDN target. CI (` .github/workflows/speedtest-engine.yml `) runs the offline job on pull requests and on pushes to `main` touching this folder, and the live job nightly + on demand.
 
 ## Architecture
 

--- a/tools/speedtest/benchmark.mjs
+++ b/tools/speedtest/benchmark.mjs
@@ -1,0 +1,263 @@
+/* CoreSpeed v3 vs TorBox official vs curl — side-by-side accuracy benchmark
+ * ─────────────────────────────────────────────────────────────────────────────
+ * What it does
+ *   For one CDN node, K rounds, each round runs three legs SEQUENTIALLY (no
+ *   cross-contamination on the line):
+ *
+ *   v3      — the SHIPPED CoreSpeed v3 worker (extracted verbatim from
+ *             index.html), TorBox's 100 MB file, first-byte-anchored stats.
+ *             Headline: avgFb (bytes ÷ time since first byte) + steady.
+ *   torbox  — TorBox's ACTUAL speedtest-worker.js code (verbatim), their exact
+ *             protocol: single-HEAD ping, HEAD for size, fetch, 50 ms sampler,
+ *             headline averageSpeed = totalBytes·8/10⁶ ÷ totalTime where the
+ *             clock starts BEFORE the fetch (setup + TTFB + ramp included).
+ *   curl    — OS-level reference: raw line speed, no JS/browser stack.
+ *
+ *   Then (with --full) a fourth leg:
+ *   v3full  — the shipped v3 worker in its native mode: 1 GB file, first-byte-
+ *             anchored window (default 15 s), two reps, median steady.
+ *
+ * Why this answers "why are the numbers different"
+ *   v3 and torbox legs use the SAME 100 MB file on the SAME line in the SAME
+ *   round. So:
+ *     avgFb(v3) − average(torbox)  ≈ the setup/TTFB time TorBox's clock includes
+ *     steady(v3) − average(torbox) ≈ setup inclusion + slow-start exclusion
+ *     * − curl                        ≈ each JS method's overhead vs the raw line
+ *
+ * Usage
+ *   node benchmark.mjs                       # tier A (3 legs × 2 rounds)
+ *   node benchmark.mjs --full                # + v3 native 1 GB/15 s × 2 reps
+ *   node benchmark.mjs --rounds 3 --window 20
+ *   LIVE_URL=https://nexus-090.cnam.tb-cdn.io/dld/1GB.bin node benchmark.mjs
+ *
+ * Data budget: hard stop at DATA_BUDGET (default 2.5 GB) — the CDN is known to
+ * rate-limit heavy per-host pulls; the report flags anything it skipped.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import vm from 'node:vm';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+const pExecFile = promisify(execFile);
+
+/* ────────────────────────── args ────────────────────────── */
+const arg = (name, dflt) => {
+  const i = process.argv.indexOf(name);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+};
+const FLAG = (name) => process.argv.includes(name);
+const ROUNDS = Math.max(1, Number(arg('--rounds', '2')));
+const V3_WINDOW_MS = Number(arg('--window', '30000'));   // cap for the 100 MB leg (file usually completes first)
+const TORBOX_STOP_MS = Number(arg('--torbox-stop', '30000')); // real site stops at 30 s
+const FULL_WINDOW_MS = Number(arg('--full-window', '15000'));
+const FULL_MAX_BYTES = 600 * 1024 * 1024;                // cap v3-native data on very fast lines
+const DATA_BUDGET = Number(arg('--budget', String(2.5 * 1024 ** 3)));
+const FULL = FLAG('--full');
+
+const LIVE_URL = process.env.LIVE_URL || 'https://store-011.wnam.tb-cdn.io/dld/1GB.bin';
+const URL100 = LIVE_URL.replace(/\/dld\/[^/]+$/, '/dld/100MB.bin');
+const NODE_LABEL = new URL(LIVE_URL).host;
+console.log(`\nCoreSpeed v3 vs TorBox official vs curl\nnode: ${NODE_LABEL}\nrounds: ${ROUNDS}${FULL ? ' (+ v3 native 1 GB)' : ''}  budget: ${(DATA_BUDGET / 1024 ** 3).toFixed(1)} GB\n`);
+
+/* ────────────────────────── shared plumbing (same as test-engine) ────────────────────────── */
+function makeWorkerEnv(src) {
+  const messages = [];
+  const listeners = {};
+  const self = {
+    postMessage: (m) => messages.push(m),
+    addEventListener: (n, fn) => { listeners[n] = fn; },
+    removeEventListener: () => {},
+    onmessage: null,
+  };
+  const ctx = { self, performance, fetch, setTimeout, clearTimeout, setInterval, clearInterval, AbortController, URL, console };
+  vm.createContext(ctx);
+  vm.runInContext(src, ctx, { filename: 'worker.js' });
+  return {
+    messages,
+    send: (data) => { if (self.onmessage) self.onmessage({ data }); else listeners.message && listeners.message({ data }); },
+    stop: () => { if (listeners.message) listeners.message({ data: 'stop' }); },
+  };
+}
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+async function until(messages, type, timeoutMs = 60000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    const m = messages.find(x => x.type === type);
+    if (m) return m;
+    await wait(100);
+  }
+  return null;
+}
+
+/* ────────────────────────── sources ────────────────────────── */
+const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
+const V3_SRC = html.match(/const WORKER_SRC = `([\s\S]*?)`;/)[1];
+// TorBox's current protocol — use a local copy if present (e.g. a pinned test
+// fixture), otherwise fetch it fresh from torbox.app so we always benchmark
+// against their CURRENT worker.
+function loadTorboxWorker() {
+  const local = new URL('./torbox-speedtest-worker.js', import.meta.url);
+  if (existsSync(local)) return readFileSync(local, 'utf8');
+  const pin = process.env.TB_WORKER;
+  if (pin) return readFileSync(pin, 'utf8');
+  // sync fetch via curl to stay in the top-level sync flow
+  const src = execFileSync('curl', ['-sL', '--max-time', '20', 'https://torbox.app/speedtest-worker.js'], { encoding: 'utf8' });
+  if (!src || src.length < 500) throw new Error('could not download torbox speedtest-worker.js');
+  return src;
+}
+const TB_SRC = loadTorboxWorker();
+
+let usedBytes = 0;
+const guard = (b) => { usedBytes += b || 0; if (usedBytes > DATA_BUDGET) throw new Error('BUDGET'); };
+
+/* ────────────────────────── legs ────────────────────────── */
+async function legV3() {
+  const env = makeWorkerEnv(V3_SRC);
+  env.send({ url: URL100, withPing: true, pingRounds: 5, windowMs: V3_WINDOW_MS, graceMs: 8000 });
+  const done = await until(env.messages, 'done', V3_WINDOW_MS + 20000);
+  if (!done) return { status: 'no-response' };
+  guard(done.bytes);
+  return { status: done.status, ok: done.ok, avgFbMbps: done.avgFbMbps, steadyMbps: done.steadyMbps, peakMbps: done.peakMbps, ping: done.ping, ttfbMs: done.ttfb, firstByteMs: done.firstByteMs, bytes: done.bytes };
+}
+
+async function legTorbox() {
+  // TorBox protocol, verbatim: single-HEAD ping, then fetch; page stops at 30 s.
+  const env = makeWorkerEnv(TB_SRC);
+  env.send({ type: 'start', data: { server: { url: URL100, region: NODE_LABEL, name: NODE_LABEL, closest: true }, isMultithreaded: false, userCountry: 'AU' } });
+  const stopT = setTimeout(() => env.stop(), TORBOX_STOP_MS);
+  const complete = await until(env.messages, 'complete', TORBOX_STOP_MS + 15000);
+  clearTimeout(stopT);
+  env.stop();
+  if (!complete) return { status: 'no-response' };
+  const r = complete.results || {};
+  guard(r.bytes || 0);
+  return { status: 'complete', averageSpeedMbps: r.averageSpeedMbps, maxSpeedMbps: r.maxSpeedMbps, ping: r.ping, region: r.region };
+}
+
+async function legCurl() {
+  try {
+    const { stdout } = await pExecFile('curl', ['-s', '--max-time', String(Math.ceil(V3_WINDOW_MS / 1000) + 5), '-o', '/dev/null', '-w', '%{http_code} %{speed_download} %{size_download} %{time_starttransfer}', URL100], { timeout: (V3_WINDOW_MS / 1000 + 10) * 1000 });
+    const [code, bps, bytes, ttfb] = stdout.trim().split(' ').map(Number);
+    if (code !== 200 && code !== 206) return { status: `http ${code}` };
+    guard(bytes);
+    return { status: 'ok', mbps: (bps * 8) / 1e6, bytes, ttfbMs: ttfb * 1000 };
+  } catch (e) {
+    return { status: 'error: ' + (e.message || 'curl failed').slice(0, 60) };
+  }
+}
+
+async function legV3Full() {
+  // Native v3 mode: 1 GB file, first-byte-anchored window, 2 reps, median steady.
+  const reps = [];
+  for (let i = 0; i < 2; i++) {
+    const env = makeWorkerEnv(V3_SRC);
+    const range = i === 1 ? { start: Math.floor(1073741824 / 2), end: 1073741823 } : null;
+    env.send({ url: LIVE_URL, withPing: i === 0, pingRounds: 5, windowMs: FULL_WINDOW_MS, graceMs: 8000, range, maxBytes: FULL_MAX_BYTES });
+    const done = await until(env.messages, 'done', FULL_WINDOW_MS + 20000);
+    if (!done) break;
+    guard(done.bytes);
+    reps.push(done);
+    await wait(500);
+  }
+  const ok = reps.filter(r => r.ok);
+  const med = (arr) => { if (!arr.length) return null; const s = arr.slice().sort((a, b) => a - b); const m = Math.floor(s.length / 2); return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; };
+  return {
+    reps: ok.length,
+    steadyMbps: med(ok.map(r => r.steadyMbps).filter(v => v != null)),
+    avgFbMbps: med(ok.map(r => r.avgFbMbps).filter(v => v != null)),
+    peakMbps: Math.max(...ok.map(r => r.peakMbps || 0)),
+    ping: ok.length ? ok[0].ping : null,
+    ttfbMs: ok.length ? ok[0].ttfb : null,
+    bytes: ok.reduce((a, r) => a + r.bytes, 0),
+  };
+}
+
+/* ────────────────────────── run ────────────────────────── */
+const rounds = [];
+const median = (arr) => { const a = arr.filter(v => v != null && isFinite(v)); if (!a.length) return null; const s = a.slice().sort((x, y) => x - y); const m = Math.floor(s.length / 2); return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; };
+
+for (let r = 1; r <= ROUNDS; r++) {
+  const round = { round: r };
+  const runLeg = async (name, fn) => {
+    process.stdout.write(`  round ${r} · ${name.padEnd(8)} `);
+    try { round[name] = await fn(); }
+    catch (e) { round[name] = { status: e.message === 'BUDGET' ? 'skipped (data budget)' : 'error: ' + (e.message || e) }; }
+    const g = round[name];
+    const headline = name === 'torbox' ? g.averageSpeedMbps : name === 'curl' ? g.mbps : g.avgFbMbps;
+    console.log(`${g.status}${headline != null ? ' → ' + headline.toFixed(1) + ' Mbps' : ''}`);
+  };
+  console.log(`round ${r}/${ROUNDS}`);
+  await runLeg('v3', legV3);
+  await wait(1000);
+  await runLeg('torbox', legTorbox);
+  await wait(1000);
+  await runLeg('curl', legCurl);
+  if (usedBytes > DATA_BUDGET * 0.85) { console.log('data budget nearly exhausted — skipping remaining rounds'); break; }
+  rounds.push(round);
+}
+
+let v3full = null;
+if (FULL) {
+  console.log(`\nv3 native (1 GB, ${FULL_WINDOW_MS / 1000} s window, 2 reps)`);
+  try { v3full = await legV3Full(); console.log(`  → steady ${v3full.steadyMbps ? v3full.steadyMbps.toFixed(1) : '—'} Mbps over ${v3full.reps} reps, ${(v3full.bytes / 1024 ** 3).toFixed(2)} GB`); }
+  catch (e) { v3full = { error: e.message }; }
+}
+
+/* ────────────────────────── report ────────────────────────── */
+const M = (key) => median(rounds.map(rd => rd[key] && rd[key][key === 'torbox' ? 'averageSpeedMbps' : key === 'curl' ? 'mbps' : 'avgFbMbps']));
+const med = (sel) => median(rounds.map(sel));
+const pct = (a, b) => (a != null && b != null && b > 0) ? ((a - b) / b) * 100 : null;
+
+const report = {
+  ts: new Date().toISOString(),
+  node: NODE_LABEL, url100: URL100, url1gb: LIVE_URL,
+  roundCount: ROUNDS, full: !!v3full, usedBytes,
+  rounds,
+  median: {
+    v3_avgFbMbps: M('v3'), v3_steadyMbps: med(rd => rd.v3 && rd.v3.steadyMbps), v3_ping: med(rd => rd.v3 && rd.v3.ping), v3_ttfbMs: med(rd => rd.v3 && rd.v3.ttfbMs),
+    torbox_avgMbps: M('torbox'), torbox_maxMbps: med(rd => rd.torbox && rd.torbox.maxSpeedMbps), torbox_ping: med(rd => rd.torbox && rd.torbox.ping),
+    curl_mbps: M('curl'),
+  },
+  v3full: v3full,
+  // Per-ROUND paired deltas — v3 and torbox measured the same file seconds
+  // apart, so round-to-round line noise cancels in these ratios. This is the
+  // rigorous comparison; the medians above are secondary.
+  per_round_deltas_pct: rounds.map(rd => ({
+    round: rd.round,
+    v3_avgFb_vs_torbox_avg: pct(rd.v3 && rd.v3.avgFbMbps, rd.torbox && rd.torbox.averageSpeedMbps),
+    v3_avgFb_vs_curl: pct(rd.v3 && rd.v3.avgFbMbps, rd.curl && rd.curl.mbps),
+    torbox_avg_vs_curl: pct(rd.torbox && rd.torbox.averageSpeedMbps, rd.curl && rd.curl.mbps),
+  })),
+  deltas_pct: {
+    // median of the per-round paired deltas (the headline numbers)
+    v3_avgFb_vs_torbox_avg: median(rounds.map(rd => pct(rd.v3 && rd.v3.avgFbMbps, rd.torbox && rd.torbox.averageSpeedMbps))),
+    v3_avgFb_vs_curl: median(rounds.map(rd => pct(rd.v3 && rd.v3.avgFbMbps, rd.curl && rd.curl.mbps))),
+    torbox_avg_vs_curl: median(rounds.map(rd => pct(rd.torbox && rd.torbox.averageSpeedMbps, rd.curl && rd.curl.mbps))),
+  },
+  notes: [
+    'v3 and torbox legs use the SAME 100 MB file on the same line, same round — only the protocol differs.',
+    'v3 avgFb = bytes ÷ (end − firstByte). TorBox average = bytes ÷ (end − fetchStart) i.e. includes DNS+TCP+TLS+TTFB.',
+    'v3 steady = window minus first 2 s (slow-start excluded); TorBox has no steady-state statistic.',
+    'curl is the OS-level reference (no JS/browser stack).',
+    'Numbers are vantage-point specific (this machine to this node) — they document METHODOLOGY, not absolute line speed.',
+  ],
+};
+
+const f1 = (v) => (v == null ? '—' : v.toFixed(1));
+console.log('\n' + '═'.repeat(78));
+console.log('PER-ROUND HEADLINE (same 100 MB file, legs ~1 s apart — paired)');
+console.log('─'.repeat(78));
+report.per_round_deltas_pct.forEach(d => {
+  console.log(`  round ${d.round}:  v3 vs torbox ${d.v3_avgFb_vs_torbox_avg == null ? '—' : d.v3_avgFb_vs_torbox_avg.toFixed(1).padStart(7)}%   v3 vs curl ${d.v3_avgFb_vs_curl == null ? '—' : d.v3_avgFb_vs_curl.toFixed(1).padStart(7)}%   torbox vs curl ${d.torbox_avg_vs_curl == null ? '—' : d.torbox_avg_vs_curl.toFixed(1).padStart(7)}%`);
+});
+console.log('─'.repeat(78));
+console.log(`  medians:  v3 avgFb ${f1(report.median.v3_avgFbMbps)} Mbps · torbox avg ${f1(report.median.torbox_avgMbps)} Mbps · curl raw ${f1(report.median.curl_mbps)} Mbps`);
+console.log('  Δ v3 avgFb − torbox avg (median of paired): ' + (report.deltas_pct.v3_avgFb_vs_torbox_avg == null ? '—' : report.deltas_pct.v3_avgFb_vs_torbox_avg.toFixed(1) + '%') + '   ← setup/TTFB TorBox includes');
+console.log('  Δ v3 avgFb − curl (median of paired)      : ' + (report.deltas_pct.v3_avgFb_vs_curl == null ? '—' : report.deltas_pct.v3_avgFb_vs_curl.toFixed(1) + '%'));
+console.log('  Δ torbox avg − curl (median of paired)    : ' + (report.deltas_pct.torbox_avg_vs_curl == null ? '—' : report.deltas_pct.torbox_avg_vs_curl.toFixed(1) + '%'));
+if (v3full && v3full.steadyMbps) console.log(`  v3-full  steady ${f1(v3full.steadyMbps)} Mbps (1 GB, ${FULL_WINDOW_MS / 1000} s × 2 reps — the mode where the steady statistic is meaningful)`);
+console.log('═'.repeat(78));
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+const jsonPath = `benchmark-report-${stamp}.json`;
+writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+console.log(`\nreport: ${jsonPath} · data used: ${(usedBytes / 1024 ** 3).toFixed(2)} GB`);

--- a/tools/speedtest/benchmark.mjs
+++ b/tools/speedtest/benchmark.mjs
@@ -191,8 +191,8 @@ for (let r = 1; r <= ROUNDS; r++) {
   await runLeg('torbox', legTorbox);
   await wait(1000);
   await runLeg('curl', legCurl);
-  if (usedBytes > DATA_BUDGET * 0.85) { console.log('data budget nearly exhausted — skipping remaining rounds'); break; }
   rounds.push(round);
+  if (usedBytes > DATA_BUDGET * 0.85) { console.log('data budget nearly exhausted — skipping remaining rounds'); break; }
 }
 
 let v3full = null;
@@ -210,7 +210,7 @@ const pct = (a, b) => (a != null && b != null && b > 0) ? ((a - b) / b) * 100 : 
 const report = {
   ts: new Date().toISOString(),
   node: NODE_LABEL, url100: URL100, url1gb: LIVE_URL,
-  roundCount: ROUNDS, full: !!v3full, usedBytes,
+  roundCount: rounds.length, full: !!v3full, usedBytes,
   rounds,
   median: {
     v3_avgFbMbps: M('v3'), v3_steadyMbps: med(rd => rd.v3 && rd.v3.steadyMbps), v3_ping: med(rd => rd.v3 && rd.v3.ping), v3_ttfbMs: med(rd => rd.v3 && rd.v3.ttfbMs),

--- a/tools/speedtest/check-syntax.mjs
+++ b/tools/speedtest/check-syntax.mjs
@@ -7,7 +7,7 @@ import vm from 'node:vm';
 
 const target = process.argv[2] || new URL('./index.html', import.meta.url);
 const html = readFileSync(target, 'utf8');
-const m = html.match(/<script>([\s\S]*)<\/script>/);
+const m = html.match(/<script>([\s\S]*)<\/script>/i);
 if (!m) {
   console.error('FAIL: no <script> block found in', target);
   process.exit(1);

--- a/tools/speedtest/check-syntax.mjs
+++ b/tools/speedtest/check-syntax.mjs
@@ -1,0 +1,22 @@
+/* CI: syntax-check the inline <script> of the shipped speedtest page.
+ * Lives next to index.html in the repo (tools/speedtest/check-syntax.mjs).
+ * Usage: node check-syntax.mjs [path-to-index.html]
+ */
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const target = process.argv[2] || new URL('./index.html', import.meta.url);
+const html = readFileSync(target, 'utf8');
+const m = html.match(/<script>([\s\S]*)<\/script>/);
+if (!m) {
+  console.error('FAIL: no <script> block found in', target);
+  process.exit(1);
+}
+try {
+  // vm.Script compiles (throws on syntax error) without executing.
+  new vm.Script(m[1], { filename: 'speedtest-inline.js' });
+} catch (e) {
+  console.error('FAIL: inline script has a syntax error:\n' + e.message);
+  process.exit(1);
+}
+console.log(`OK: inline script compiles (${m[1].length} chars, ${target.pathname || target})`);

--- a/tools/speedtest/check-syntax.mjs
+++ b/tools/speedtest/check-syntax.mjs
@@ -7,7 +7,7 @@ import vm from 'node:vm';
 
 const target = process.argv[2] || new URL('./index.html', import.meta.url);
 const html = readFileSync(target, 'utf8');
-const m = html.match(/<script\b[^>]*>([\s\S]*)<\/script>/i);
+const m = html.match(/<script>([\s\S]*)<\/script>/i);
 if (!m) {
   console.error('FAIL: no <script> block found in', target);
   process.exit(1);

--- a/tools/speedtest/check-syntax.mjs
+++ b/tools/speedtest/check-syntax.mjs
@@ -7,7 +7,7 @@ import vm from 'node:vm';
 
 const target = process.argv[2] || new URL('./index.html', import.meta.url);
 const html = readFileSync(target, 'utf8');
-const m = html.match(/<script>([\s\S]*)<\/script>/i);
+const m = html.match(/<script\b[^>]*>([\s\S]*)<\/script>/i);
 if (!m) {
   console.error('FAIL: no <script> block found in', target);
   process.exit(1);

--- a/tools/speedtest/index.html
+++ b/tools/speedtest/index.html
@@ -3,11 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="CoreSpeed — measure single-connection latency and throughput to every TorBox Hyperdrive CDN node, the same way TorBox's own speedtest does. See which CDN actually streams best from where you are.">
+<meta name="description" content="CoreSpeed v3 — worker-isolated, first-byte-anchored speed test of every TorBox Hyperdrive CDN node. Two-rep median steady-state per node, real multi-connection capacity race, live map, playback verdicts, exports.">
 <title>CoreSpeed — TorBox CDN Speed Test · Core Builds</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 44 44'%3E%3Cpath d='M22 4 39 14v16L22 40 5 30V14Z' fill='none' stroke='%2300d4ff' stroke-width='2'/%3E%3Cpath d='m22 13 9 9-9 9-9-9Z' fill='%23a78bfa'/%3E%3C/svg%3E">
 <style>
-
 :root{
   --th-bg:#0d1017;--th-card:#151923;--th-card-alt:#111720;
   --th-border:rgba(255,255,255,.06);--th-border-strong:rgba(255,255,255,.12);
@@ -297,11 +296,19 @@ tr.rank-3 .rank-num{color:#d29a6a}
 }
 .toast.show{transform:translateX(-50%) translateY(0)}
 
-
+/* ── v3 additions ── */
+.endpoint-badge.verified{border-color:var(--th-green-border);color:var(--th-green)}
+.endpoint-badge.unverified{border-color:var(--th-red-border);color:var(--th-red)}
+.unit-toggle{display:flex;gap:6px}
+.row-skip{opacity:.42}
+.fail-sec{margin-top:12px;padding-top:10px;border-top:1px dashed var(--th-border-strong)}
+.fail-sec .t{font-size:.62rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:var(--th-tx4);margin-bottom:8px}
+.fail-row{display:flex;align-items:center;gap:10px;padding:6px 8px;font-size:.7rem;color:var(--th-tx2)}
+.fail-row .c{margin-left:auto;font-size:.62rem;color:var(--th-tx4)}
+.mini-reps{font-size:.6rem;color:var(--th-tx4);font-weight:700}
 </style>
 </head>
 <body>
-<div class="wrap">
 <div class="wrap">
 <!-- HEADER BANNER -->
 <header class="hdr-banner">
@@ -309,7 +316,7 @@ tr.rank-3 .rank-num{color:#d29a6a}
   <div class="hdr-divider" aria-hidden="true"></div>
   <div class="hdr-text">
     <div class="hdr-title"><span class="hdr-core">Core</span> <span class="hdr-speed">Speed</span></div>
-    <div class="hdr-sub">TORBOX CDN SPEED TEST · HYPERDRIVE</div>
+    <div class="hdr-sub">TORBOX CDN SPEED TEST · HYPERDRIVE · ENGINE v3</div>
   </div>
   <div class="hdr-actions">
     <a class="hdr-btn" href="../../">← Configurator</a>
@@ -321,9 +328,9 @@ tr.rank-3 .rank-num{color:#d29a6a}
 
 <!-- HERO -->
 <section class="hero">
-  <div class="kicker"><span class="sep"></span>core speed · measure your route to every TorBox CDN</div>
+  <div class="kicker"><span class="sep"></span>core speed v3 · worker-isolated · first-byte anchored</div>
   <h1>How fast is <em>your</em> route to TorBox?</h1>
-  <p class="lede">Tests <b>all TorBox CDN nodes at once</b> — latency first, then sustained multi-stream downloads from real Hyperdrive test files. Live per-region ranking, a world map, and a recommendation for the CDN that streams best from where you are. No API key needed.</p>
+  <p class="lede">Every node tested <b>one at a time, one connection</b>, on TorBox's 1 GB file — measurement anchored at the <b>first byte</b>, two reps, ranked by <b>median steady-state</b> (slow-start excluded). All byte counting runs in a Web Worker, so the UI can't distort the numbers. Capacity mode adds a real multi-connection race. No API key.</p>
 </section>
 
 <!-- CONTROLS -->
@@ -332,28 +339,41 @@ tr.rank-3 .rank-num{color:#d29a6a}
     <div class="ctl">
       <label for="modeSel">Test mode</label>
       <select id="modeSel">
-        <option value="sequential" selected>🎯 Sequential — accurate (default)</option>
-        <option value="burst">⚡ Burst race — all CDNs at once</option>
-        <option value="quick">🚀 Quick — 100 MB file</option>
-        <option value="full">🏔 Full — 1 GB file</option>
+        <option value="accurate" selected>🎯 Accurate — single connection (default)</option>
+        <option value="express">⏱ Express — 5 nodes, ~90 s</option>
+        <option value="capacity">⚡ Capacity race — all at once</option>
       </select>
     </div>
-    <div class="ctl">
-      <label for="durSel">Burst length</label>
-      <select id="durSel">
-        <option value="5">5 seconds</option>
-        <option value="10" selected>10 seconds</option>
-        <option value="15">15 seconds</option>
+    <div class="ctl" id="ctlReps">
+      <label for="repsSel">Reps per node</label>
+      <select id="repsSel">
+        <option value="1">1 rep</option>
+        <option value="2" selected>2 reps (median)</option>
+      </select>
+    </div>
+    <div class="ctl" id="ctlWindow">
+      <label for="windowSel">Window</label>
+      <select id="windowSel">
+        <option value="10">10 seconds</option>
+        <option value="15" selected>15 seconds</option>
         <option value="20">20 seconds</option>
       </select>
     </div>
-    <div class="ctl">
-      <label for="streamsSel">Streams per CDN</label>
+    <div class="ctl" id="ctlStreams" hidden>
+      <label for="streamsSel">Connections / CDN</label>
       <select id="streamsSel">
-        <option value="1">1 stream</option>
-        <option value="2">2 streams</option>
-        <option value="4" selected>4 streams</option>
-        <option value="8">8 streams</option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="4" selected>4</option>
+        <option value="8">8</option>
+      </select>
+    </div>
+    <div class="ctl" id="ctlCap" hidden>
+      <label for="capSel">Data per CDN</label>
+      <select id="capSel">
+        <option value="250">250 MB</option>
+        <option value="500" selected>500 MB</option>
+        <option value="1024">1 GB</option>
       </select>
     </div>
     <div class="ctl">
@@ -364,13 +384,20 @@ tr.rank-3 .rank-num{color:#d29a6a}
         <option value="closest">Closest only</option>
       </select>
     </div>
+    <div class="ctl">
+      <label>Secondary unit</label>
+      <div class="unit-toggle" id="unitToggle" role="group" aria-label="Secondary unit">
+        <button class="chip on" data-unit="mb" type="button">MB/s</button>
+        <button class="chip" data-unit="mib" type="button">MiB/s</button>
+      </div>
+    </div>
     <div class="ctl-spacer"></div>
     <button class="btn-ghost" id="refreshBtn" type="button" title="Re-fetch the CDN endpoint list from TorBox">↻ Endpoints</button>
     <button class="btn-go" id="goBtn" type="button" disabled><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg><span>Start Test</span></button>
   </div>
   <div class="data-note">
     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
-    <span id="dataNote">Sequential tests ONE node at a time with ONE connection — the same approach as TorBox's own speedtest and the number that matters for playback. ~2–3 min for all 17 nodes; use the scope selector to shorten it.</span>
+    <span id="dataNote">Loading…</span>
   </div>
 </section>
 
@@ -382,7 +409,9 @@ tr.rank-3 .rank-num{color:#d29a6a}
   <span class="stat">
     <span>Elapsed <b id="stElapsed">0s</b></span>
     <span>Data <b id="stData">0 MB</b></span>
+    <span>Budget <b id="stBudget">12 GB</b></span>
     <span>Done <b id="stDone">0/0</b></span>
+    <span>ETA <b id="stEta">—</b></span>
     <span>Peak <b id="stPeak">—</b></span>
   </span>
 </div>
@@ -408,7 +437,7 @@ tr.rank-3 .rank-num{color:#d29a6a}
     </svg>
     <div class="gauge-readout">
       <div class="gauge-value" id="gaugeValue">0<span class="unit">Mbps</span></div>
-      <div class="gauge-sub"><span id="gaugeSubLbl">aggregate across all CDNs</span> · <span class="fast" id="gaugeFastest">—</span></div>
+      <div class="gauge-sub"><span id="gaugeSubLbl">current CDN · single connection</span> · <span class="fast" id="gaugeFastest">—</span></div>
     </div>
   </div>
   <div class="side-stats">
@@ -420,7 +449,7 @@ tr.rank-3 .rank-num{color:#d29a6a}
     </div>
     <div class="spark-wrap">
       <div class="spark-head">
-        <span class="k">Aggregate throughput</span>
+        <span class="k">Live throughput</span>
         <span class="v" id="sparkNow">0 <small>Mbps</small></span>
         <span class="spacer"></span>
         <span class="legend" id="sparkLegend">last 60 s</span>
@@ -435,15 +464,15 @@ tr.rank-3 .rank-num{color:#d29a6a}
   <div class="card">
     <div class="card-head">
       <div>
-        <div class="t">Live CDN race</div>
-        <div class="sub" id="liveSub">One node at a time in Sequential mode — ranked when finished.</div>
+        <div class="t">Live test</div>
+        <div class="sub" id="liveSub">One node at a time — first-byte-anchored window, reps, worker-isolated.</div>
       </div>
       <span class="spacer"></span>
       <span class="chip-mini run" id="liveBadge" hidden>● testing</span>
     </div>
     <div style="overflow-x:auto">
       <table class="live-table" id="liveTable">
-        <thead><tr><th>#</th><th>Region</th><th>Ping</th><th>Speed (live / max)</th><th>Status</th></tr></thead>
+        <thead><tr><th>#</th><th>Region</th><th>Ping</th><th>TTFB</th><th>Speed (live)</th><th>Rep</th><th>Status</th></tr></thead>
         <tbody id="liveBody"></tbody>
       </table>
     </div>
@@ -452,7 +481,7 @@ tr.rank-3 .rank-num{color:#d29a6a}
     <div class="card-head">
       <div>
         <div class="t">Hyperdrive map</div>
-        <div class="sub" id="mapSub">Dot size = sustained single-connection speed · colour = rank.</div>
+        <div class="sub" id="mapSub">Dot size = steady-state speed · colour = quality · 📍 you.</div>
       </div>
       <span class="spacer"></span>
       <span class="chip-mini" id="mapYouBadge" hidden>📍 you</span>
@@ -477,7 +506,7 @@ tr.rank-3 .rank-num{color:#d29a6a}
       <button class="btn-ghost" id="copyMdBtn" type="button">⧉ Copy report</button>
       <button class="btn-ghost" id="csvBtn" type="button">↓ CSV</button>
       <button class="btn-ghost" id="jsonBtn" type="button">↓ JSON</button>
-      <button class="btn-ghost" id="diagBtn" type="button" title="Collect a diagnostic report (per-node pings, DNS records, your ISP) to share when results look wrong">⛨ Diagnostics</button>
+      <button class="btn-ghost" id="diagBtn" type="button" title="Collect a diagnostic report (per-node pings, all rounds, DNS records, your ISP) to share when results look wrong">⛨ Diagnostics</button>
     </div>
   </div>
   <div class="winner" id="winnerBox"></div>
@@ -488,15 +517,20 @@ tr.rank-3 .rank-num{color:#d29a6a}
           <th data-sort="rank">#</th>
           <th data-sort="region">Region</th>
           <th data-sort="ping">Ping</th>
-          <th data-sort="avg">Sustained</th>
-          <th data-sort="max">Peak</th>
-          <th data-sort="stability">Stability</th>
+          <th data-sort="ttfb">TTFB</th>
+          <th data-sort="steady">Steady <small style="text-transform:none;font-weight:600">(median)</small></th>
+          <th data-sort="avgFb">Raw avg</th>
+          <th data-sort="peak">Peak</th>
+          <th data-sort="p95">p95</th>
+          <th data-sort="reps">Reps</th>
+          <th data-sort="consistency">Consistency</th>
           <th data-sort="delta" id="thDelta" hidden>Δ vs prev</th>
           <th>Streaming</th>
         </tr>
       </thead>
       <tbody id="resultsBody"></tbody>
     </table>
+    <div class="fail-sec" id="failedSec" hidden><div class="t">Not ranked (no valid measurement)</div><div id="failedList"></div></div>
   </div>
 </section>
 
@@ -514,38 +548,83 @@ tr.rank-3 .rank-num{color:#d29a6a}
 </section>
 
 <footer class="footer">
+  <span>Engine v3 · worker-isolated measurement · first-byte-anchored windows · decimal units.</span>
   <span>Built on TorBox's public speedtest API · test files served by TorBox's Hyperdrive CDN.</span>
   <span>Core Builds is not affiliated with TorBox.</span>
   <span><a href="https://github.com/brevityA/Core-Builds">Source</a> · <a href="https://www.reddit.com/r/CoreBuilds/">Core Crew</a> · <a href="https://ko-fi.com/branding_brevity">Support</a></span>
 </footer>
 
 <div class="toast" id="toast" role="status" aria-live="polite"></div>
-
-</div>
-
 </div>
 <script>
-/* CoreSpeed — TorBox CDN speed test
- * Engine v2 — methodology aligned with TorBox's own speedtest:
- *  - Default "Sequential" mode tests ONE node at a time with ONE connection (what a
- *    streaming player actually gets), like TorBox's official test. No cross-node
- *    contention, no multi-stream latency masking.
- *  - Burst/Quick/Full are capacity races (all nodes at once, N streams) and are
- *    clearly labelled as such — their numbers are not used for playback verdicts.
- *  - Ping = 5 HEAD requests, trimmed mean (drop min & max), matching TorBox's method.
- * Endpoint list: Core-Builds worker proxy → direct API → embedded snapshot (badged). */
+/* ============================================================================
+ * CoreSpeed v3 — measurement engine
+ * ----------------------------------------------------------------------------
+ * Design (each item maps to a defect in SPEEDTEST-AUDIT.md):
+ *
+ *  V3-1 [F1,F10] Every byte is counted inside a dedicated Web Worker. The
+ *        main thread only renders UI — it can no longer starve the read loop
+ *        or cap measured throughput on TV webviews. (TorBox does this; v2 did
+ *        not — v2 had 0 workers.)
+ *  V3-2 [T3,T4,F11] Ping = 5 × 1-byte Range GETs (HTTP 206), 60 ms spacing,
+ *        4 s timeout per round, trimmed mean of the middle 3 + min + MAD.
+ *        Timed (TorBox's pre-test HEADs have no timeout), and the *same*
+ *        method is displayed everywhere (TorBox flips between two methods).
+ *        Pings run with a concurrency limit of 4 origins (v2 fired ~85
+ *        handshakes at once).
+ *  V3-3 [F2,F3,F13] Transfer uses the 1 GB file with a first-byte-anchored
+ *        window (default 15 s). The window stays ≥ window on any line up to
+ *        ~700 Mbps, so TCP slow-start is <10 % of it. (v2: 10 s cap on the
+ *        100 MB file — ~1 s ramp-dominated window on a Gbps line.)
+ *  V3-4 [F4,T8] Two reps per node (rep 2 re-samples the second half of the
+ *        file via Range). Headline = MEDIAN of per-rep steady-state speeds.
+ *  V3-5 [F3] Per-node report: TTFB (warm GET), avgFb = bytes ÷ time since
+ *        first byte (the honest average), steady = window minus first 2 s
+ *        (playback number), peak, p95.
+ *  V3-6 [F5,M5] Nodes without a valid measurement (error/timeout/skipped)
+ *        are listed separately and NEVER ranked.
+ *  V3-7 Instant stop (all workers aborted + terminated), one automatic retry
+ *        per rep, 8 s first-byte grace with its own abort timer.
+ *  V3-8 [F8] Endpoint chain: ?worker override → default proxy → direct API →
+ *        embedded snapshot, and when the snapshot is used it is *probed*
+ *        (1-byte Range GET per host); >20 % unreachable → live retry once →
+ *        else the badge says "snapshot (unverified)".
+ *  V3-9 [F7] preconnect() warms up to 8 scoped origins before the run; each
+ *        rep also does a 1-byte warm GET on the exact transfer URL before the
+ *        clock starts (TorBox's worker does the equivalent size-HEAD).
+ *  V3-10 [F9] Background-safe: the read loop is an await chain inside the
+ *        worker (no timer dependence); the window cap is checked on every
+ *        chunk arrival, not by a throttled setInterval.
+ *  V3-11 [M1] Units are decimal (Mbps = 10⁶ bit/s; MB/s = 10⁶ B/s). A MiB/s
+ *        toggle exists and is labelled as binary. (midnight reports binary
+ *        MiB/s labelled "MB/s" — ~4.8 % inflation.)
+ *  V3-12 [T1] Capacity mode = REAL N-connection Range split (N workers, each
+ *        an independent 1/N slice, summed per-slice steady rates) — beats
+ *        TorBox's "multithreaded" mode, which is one TCP connection with
+ *        1 MB buffering.
+ *
+ * Section layout: everything above the "UI SECTION" marker is pure
+ * (no DOM) and is unit-tested in test-engine.mjs against the live CDN.
+ * ==========================================================================*/
 'use strict';
 
-/* ────────────────────────── Constants ────────────────────────── */
-const WORKER = (new URLSearchParams(location.search).get('worker') || 'https://core-builds-cors-proxy.tlorenzato26.workers.dev').replace(/\/+$/, '');
+/* ────────────────────────── constants ────────────────────────── */
 const API_HOST = 'https://api.torbox.app';
+const DEFAULT_PROXY = 'https://core-builds-cors-proxy.tlorenzato26.workers.dev';
 const GEO_API = 'https://ipwho.is/';
-const DATA_BUDGET_BYTES = 12 * 1024 * 1024 * 1024;
-const HISTORY_KEY = 'coreSpeedHistory';
+const DNS_API = 'https://dns.google/resolve';
+const BUDGET_BYTES = 12 * 1024 * 1024 * 1024;   // hard global data budget
+const FILE_1GB = 1073741824;                    // /dld/1GB.bin (verified size)
+const HISTORY_KEY = 'coreSpeedHistoryV3';
 const HISTORY_MAX = 15;
-const SAMPLE_WINDOW = 240;
-const SEQ_CAP_MS = 10000;        // per-node sequential measurement cap
-const PING_ROUNDS = 5;           // 5 HEADs, trimmed mean — same as TorBox's site
+const PING_ROUNDS = 5;
+const PING_CONCURRENCY = 4;
+const STEADY_OFFSET_MS = 2000;                  // slow-start exclusion
+const ENGINE_VERSION = 3;
+
+if (typeof AbortSignal !== 'undefined' && !AbortSignal.timeout) {
+  AbortSignal.timeout = (ms) => { const c = new AbortController(); setTimeout(() => c.abort(), ms); return c.signal; };
+}
 
 const REGION_META = {
   wnam: { label: 'US West',       city: 'Los Angeles',    flag: '🇺🇸', net: 'Cloudflare edge' },
@@ -566,581 +645,849 @@ const REGION_META = {
   hare: { label: 'Bunny CDN',     city: 'Anycast',        flag: '🌐', net: 'Bunny edge (LA)' },
   erth: { label: 'Cloudflare',    city: 'Anycast',        flag: '🌐', net: 'Cloudflare anycast' },
 };
-const SNAPSHOT = { fetched: '2026-08-19', data: [{"region":"wnam","name":"store-039","domain":"https://store-039.wnam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://store-039.wnam.tb-cdn.io/dld/100MB.bin","url_long":"https://store-039.wnam.tb-cdn.io/dld/1GB.bin","closest":true,"lat":34.0522,"lng":-118.2437},{"region":"cnam","name":"nexus-090","domain":"https://nexus-090.cnam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-090.cnam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-090.cnam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":41.8781,"lng":-87.6298},{"region":"snam","name":"nexus-212","domain":"https://nexus-212.snam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-212.snam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-212.snam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":25.7617,"lng":-80.1918},{"region":"enam","name":"nexus-087","domain":"https://nexus-087.enam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-087.enam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-087.enam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":40.7128,"lng":-74.006},{"region":"seur","name":"nexus-140","domain":"https://nexus-140.seur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-140.seur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-140.seur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":38.7167,"lng":-9.1333},{"region":"latm","name":"nexus-083","domain":"https://nexus-083.latm.tb-cdn.cx","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-083.latm.tb-cdn.cx/dld/100MB.bin","url_long":"https://nexus-083.latm.tb-cdn.cx/dld/1GB.bin","closest":false,"lat":-23.5505,"lng":-46.6333},{"region":"neur","name":"nexus-174","domain":"https://nexus-174.neur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-174.neur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-174.neur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":51.5074,"lng":-0.1278},{"region":"ceur","name":"nexus-067","domain":"https://nexus-067.ceur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-067.ceur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-067.ceur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":48.5833,"lng":7.75},{"region":"weur","name":"store-068","domain":"https://store-068.weur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://store-068.weur.tb-cdn.st/dld/100MB.bin","url_long":"https://store-068.weur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":52.374,"lng":4.8897},{"region":"hare","name":"bunnycdn","domain":"https://nexus.hare.tb-cdn.earth","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus.hare.tb-cdn.earth/dld/100MB.bin","url_long":"https://nexus.hare.tb-cdn.earth/dld/1GB.bin","closest":false,"lat":0,"lng":0},{"region":"erth","name":"cloudflare","domain":"https://nexus.erth.tb-cdn.earth","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus.erth.tb-cdn.earth/dld/100MB.bin","url_long":"https://nexus.erth.tb-cdn.earth/dld/1GB.bin","closest":false,"lat":0,"lng":0},{"region":"nord","name":"nexus-226","domain":"https://nexus-226.nord.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-226.nord.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-226.nord.tb-cdn.st/dld/1GB.bin","closest":false,"lat":59.9139,"lng":10.7522},{"region":"slav","name":"nexus-077","domain":"https://nexus-077.slav.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-077.slav.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-077.slav.tb-cdn.st/dld/1GB.bin","closest":false,"lat":50.4501,"lng":30.5234},{"region":"indi","name":"nexus-160","domain":"https://nexus-160.indi.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-160.indi.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-160.indi.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":19.076,"lng":72.8777},{"region":"zafr","name":"nexus-211","domain":"https://nexus-211.zafr.tb-cdn.to","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-211.zafr.tb-cdn.to/dld/100MB.bin","url_long":"https://nexus-211.zafr.tb-cdn.to/dld/1GB.bin","closest":false,"lat":-26.2041,"lng":28.0473},{"region":"apac","name":"nexus-197","domain":"https://nexus-197.apac.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-197.apac.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-197.apac.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":1.3521,"lng":103.8198},{"region":"japn","name":"nexus-115","domain":"https://nexus-115.japn.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-115.japn.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-115.japn.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":35.6895,"lng":139.6917}] };
+const SNAPSHOT = {"fetched":"2026-08-26","data":[{"region":"wnam","name":"store-011","domain":"https://store-011.wnam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://store-011.wnam.tb-cdn.io/dld/100MB.bin","url_long":"https://store-011.wnam.tb-cdn.io/dld/1GB.bin","closest":true,"lat":34.0522,"lng":-118.2437},{"region":"cnam","name":"nexus-090","domain":"https://nexus-090.cnam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-090.cnam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-090.cnam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":41.8781,"lng":-87.6298},{"region":"snam","name":"nexus-212","domain":"https://nexus-212.snam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-212.snam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-212.snam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":25.7617,"lng":-80.1918},{"region":"enam","name":"nexus-087","domain":"https://nexus-087.enam.tb-cdn.io","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-087.enam.tb-cdn.io/dld/100MB.bin","url_long":"https://nexus-087.enam.tb-cdn.io/dld/1GB.bin","closest":false,"lat":40.7128,"lng":-74.006},{"region":"seur","name":"nexus-140","domain":"https://nexus-140.seur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-140.seur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-140.seur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":38.7167,"lng":-9.1333},{"region":"latm","name":"nexus-244","domain":"https://nexus-244.latm.tb-cdn.cx","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-244.latm.tb-cdn.cx/dld/100MB.bin","url_long":"https://nexus-244.latm.tb-cdn.cx/dld/1GB.bin","closest":false,"lat":-23.5505,"lng":-46.6333},{"region":"neur","name":"nexus-174","domain":"https://nexus-174.neur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-174.neur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-174.neur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":51.5074,"lng":-0.1278},{"region":"ceur","name":"nexus-067","domain":"https://nexus-067.ceur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-067.ceur.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-067.ceur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":48.5833,"lng":7.75},{"region":"weur","name":"store-068","domain":"https://store-068.weur.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://store-068.weur.tb-cdn.st/dld/100MB.bin","url_long":"https://store-068.weur.tb-cdn.st/dld/1GB.bin","closest":false,"lat":52.374,"lng":4.8897},{"region":"hare","name":"bunnycdn","domain":"https://nexus.hare.tb-cdn.earth","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus.hare.tb-cdn.earth/dld/100MB.bin","url_long":"https://nexus.hare.tb-cdn.earth/dld/1GB.bin","closest":false,"lat":0,"lng":0},{"region":"erth","name":"cloudflare","domain":"https://nexus.erth.tb-cdn.earth","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus.erth.tb-cdn.earth/dld/100MB.bin","url_long":"https://nexus.erth.tb-cdn.earth/dld/1GB.bin","closest":false,"lat":0,"lng":0},{"region":"nord","name":"nexus-226","domain":"https://nexus-226.nord.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-226.nord.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-226.nord.tb-cdn.st/dld/1GB.bin","closest":false,"lat":59.9139,"lng":10.7522},{"region":"slav","name":"nexus-077","domain":"https://nexus-077.slav.tb-cdn.st","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-077.slav.tb-cdn.st/dld/100MB.bin","url_long":"https://nexus-077.slav.tb-cdn.st/dld/1GB.bin","closest":false,"lat":50.4501,"lng":30.5234},{"region":"indi","name":"nexus-160","domain":"https://nexus-160.indi.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-160.indi.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-160.indi.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":19.076,"lng":72.8777},{"region":"zafr","name":"nexus-211","domain":"https://nexus-211.zafr.tb-cdn.to","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-211.zafr.tb-cdn.to/dld/100MB.bin","url_long":"https://nexus-211.zafr.tb-cdn.to/dld/1GB.bin","closest":false,"lat":-26.2041,"lng":28.0473},{"region":"apac","name":"nexus-230","domain":"https://nexus-230.apac.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-230.apac.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-230.apac.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":1.3521,"lng":103.8198},{"region":"japn","name":"nexus-115","domain":"https://nexus-115.japn.tb-cdn.pw","path_short":"/dld/100MB.bin","path_long":"/dld/1GB.bin","url":"https://nexus-115.japn.tb-cdn.pw/dld/100MB.bin","url_long":"https://nexus-115.japn.tb-cdn.pw/dld/1GB.bin","closest":false,"lat":35.6895,"lng":139.6917}]};
 const WORLD_PATH = "M-67.75 53.85L-65.05 54.70L-69.23 55.50L-72.26 54.50L-74.66 52.84L-71.11 54.07L-69.35 52.52L-67.75 53.85Z M-58.55 51.10L-57.75 51.55L-58.05 51.90L-60.70 52.30L-61.20 51.85L-58.55 51.10Z M70.28 49.71L68.75 49.77L68.94 48.62L70.53 49.06L70.28 49.71Z M145.40 40.79L148.29 40.88L147.91 43.21L146.05 43.55L144.72 41.16L145.40 40.79Z M173.02 40.92L174.25 41.35L172.71 43.37L173.08 43.85L171.45 44.24L170.62 45.91L169.33 46.64L166.68 46.22L167.05 45.11L170.52 43.03L172.10 40.96L172.80 40.49L173.02 40.92Z M174.61 36.16L176.76 37.88L178.52 37.70L177.97 39.17L177.21 39.15L175.24 41.69L174.65 41.28L175.23 40.46L174.90 39.91L173.82 39.51L174.57 38.80L174.70 37.38L172.64 34.53L174.33 35.27L174.61 36.16Z M167.12 22.16L165.47 21.68L164.03 20.11L167.12 22.16Z M178.37 17.34L178.55 18.15L177.38 18.16L178.37 17.34Z M179.36 16.80L178.60 16.64L180.00 16.07L179.36 16.80Z M-179.92 16.50L-179.79 16.02L-179.92 16.50Z M167.84 16.47L167.22 15.89L167.84 16.47Z M167.11 14.93L167.27 15.74L166.63 14.63L167.11 14.93Z M50.06 13.56L50.38 15.71L49.67 15.71L47.10 24.94L45.41 25.60L44.04 24.99L43.25 22.06L44.37 20.07L43.96 17.41L44.45 16.22L46.31 15.78L47.71 14.59L49.19 12.04L50.06 13.56Z M143.56 13.76L143.92 14.55L144.56 14.17L145.37 14.98L146.39 18.96L148.85 20.39L149.68 22.34L150.73 22.40L150.90 23.46L153.14 26.07L153.57 28.11L152.89 31.64L150.33 35.67L150.00 37.43L146.32 39.04L144.88 38.42L145.03 37.90L143.61 38.81L140.64 38.02L139.57 36.14L138.12 35.61L138.21 34.38L136.83 35.26L137.81 32.90L135.99 34.89L134.27 32.62L131.33 31.50L126.15 32.22L124.22 32.96L123.66 33.89L119.89 33.98L118.02 35.06L115.03 34.20L115.71 33.26L115.69 31.61L113.34 26.12L113.78 26.55L113.44 25.62L114.23 26.30L113.39 24.38L114.15 21.76L114.23 22.52L116.71 20.70L120.86 19.68L123.01 16.41L123.86 17.07L123.50 16.60L125.69 14.23L127.07 13.82L128.36 14.87L129.62 14.97L130.62 12.54L132.58 12.11L131.82 11.27L132.36 11.13L135.30 12.25L136.49 11.86L136.95 12.35L135.50 15.00L140.22 17.71L141.27 16.39L141.69 12.41L142.52 10.67L143.56 13.76Z M162.12 10.48L162.40 10.83L161.70 10.82L161.32 10.20L162.12 10.48Z M120.72 10.24L118.97 9.56L119.90 9.36L120.72 10.24Z M160.85 9.87L159.70 9.24L160.85 9.87Z M161.68 9.60L160.58 8.32L161.68 9.60Z M124.44 10.14L123.46 10.24L125.09 8.66L127.34 8.40L124.44 10.14Z M117.90 8.10L119.13 8.71L116.74 9.03L117.90 8.10Z M122.90 8.09L122.76 8.65L119.92 8.81L122.90 8.09Z M159.88 8.34L158.21 7.42L159.88 8.34Z M157.54 7.35L156.54 6.60L157.54 7.35Z M108.62 6.78L110.76 6.47L115.71 8.37L114.56 8.75L105.37 6.85L106.05 5.90L108.62 6.78Z M134.72 6.21L134.21 6.90L134.50 5.45L134.72 6.21Z M155.88 6.82L154.51 5.14L155.88 6.82Z M151.98 5.48L150.24 6.32L148.32 5.75L150.14 5.00L150.81 5.46L151.54 4.17L152.34 4.31L151.98 5.48Z M127.25 3.46L125.99 3.18L127.25 3.46Z M130.47 3.09L130.83 3.86L127.90 3.39L128.14 2.84L130.47 3.09Z M153.14 4.50L150.66 2.74L152.24 3.24L153.14 4.50Z M134.14 1.15L134.42 2.77L135.46 3.37L136.29 2.31L138.33 1.70L144.58 3.86L145.98 5.47L147.65 6.08L147.89 6.61L146.97 6.72L147.19 7.39L150.69 10.58L147.91 10.13L146.05 8.07L144.74 7.63L143.29 8.25L143.41 8.98L142.63 9.33L139.13 8.10L137.61 8.41L138.67 7.32L137.93 5.39L133.66 3.54L132.98 4.11L131.99 2.82L133.70 2.21L132.23 2.21L130.52 0.94L132.38 0.37L134.14 1.15Z M125.24 -1.42L123.69 -0.24L120.18 -0.24L120.04 0.52L120.94 1.41L123.34 0.62L121.51 1.90L123.16 5.34L122.24 5.28L122.72 4.46L121.49 4.57L120.97 2.63L120.31 2.93L120.43 5.53L119.37 5.38L119.50 3.49L118.77 2.80L120.04 -0.57L120.89 -1.31L122.93 -0.88L125.24 -1.42Z M128.69 -1.13L128.10 0.90L127.40 -1.01L127.93 -2.17L128.69 -1.13Z M105.82 5.85L104.71 5.87L102.58 4.22L98.60 -1.82L95.29 -5.48L97.48 -5.25L100.64 -2.10L101.66 -2.08L103.84 -0.10L103.44 0.71L106.11 3.06L105.82 5.85Z M117.88 -1.83L119.00 -0.90L117.81 -0.78L117.52 0.80L116.56 1.49L116.15 4.01L110.22 2.93L109.09 0.46L109.07 -1.34L109.66 -2.01L111.17 -1.85L111.37 -2.70L113.00 -3.10L116.73 -6.92L119.18 -5.41L117.31 -3.23L117.88 -1.83Z M126.38 -8.41L126.54 -7.19L126.20 -6.27L125.83 -7.29L125.36 -6.79L125.40 -5.58L124.22 -6.16L124.24 -7.36L123.61 -7.83L121.92 -7.19L123.49 -8.69L123.84 -8.24L125.47 -8.99L125.41 -9.76L126.38 -8.41Z M81.22 -6.20L80.35 -5.97L79.87 -6.76L80.15 -9.82L81.79 -7.52L81.22 -6.20Z M-60.94 -10.11L-61.95 -10.09L-61.10 -10.89L-60.94 -10.11Z M123.98 -10.28L123.00 -9.02L122.38 -9.71L122.95 -10.88L123.50 -10.94L123.34 -10.27L124.08 -11.23L123.98 -10.28Z M118.50 -9.32L117.17 -8.37L119.51 -11.37L119.69 -10.55L118.50 -9.32Z M121.88 -11.89L123.12 -11.58L122.00 -10.44L121.88 -11.89Z M125.50 -12.16L125.78 -11.05L125.01 -11.31L125.28 -10.36L124.80 -10.13L124.30 -11.50L124.88 -11.79L124.27 -12.56L125.50 -12.16Z M121.53 -13.07L121.26 -12.21L120.32 -13.47L121.53 -13.07Z M121.32 -18.50L122.25 -18.48L122.52 -17.09L121.66 -15.93L121.73 -14.33L123.95 -13.78L124.08 -12.54L122.93 -13.55L120.63 -13.86L120.99 -14.53L120.07 -14.97L119.88 -16.36L120.29 -16.03L120.72 -18.51L121.32 -18.50Z M-65.59 -18.23L-67.18 -17.95L-67.24 -18.37L-65.59 -18.23Z M-76.90 -17.87L-78.34 -18.23L-76.20 -17.89L-76.90 -17.87Z M-72.58 -19.87L-69.95 -19.65L-68.32 -18.61L-70.67 -18.43L-71.40 -17.60L-74.46 -18.34L-72.33 -18.67L-73.42 -19.64L-72.58 -19.87Z M110.34 -18.68L108.66 -18.51L108.63 -19.37L110.79 -20.08L110.34 -18.68Z M-155.54 -19.08L-155.86 -20.27L-154.81 -19.51L-155.54 -19.08Z M-156.08 -20.64L-156.71 -20.93L-156.08 -20.64Z M-156.76 -21.18L-157.33 -21.10L-156.76 -21.18Z M-157.65 -21.32L-158.29 -21.58L-157.65 -21.32Z M-159.35 -21.98L-159.80 -22.07L-159.35 -21.98Z M-79.68 -22.77L-74.18 -20.28L-77.76 -19.86L-77.09 -20.41L-78.72 -21.60L-82.17 -22.39L-81.80 -22.64L-84.97 -21.90L-82.27 -23.19L-79.68 -22.77Z M-77.53 -23.76L-78.41 -24.58L-78.19 -25.21L-77.53 -23.76Z M121.18 -22.79L120.75 -21.97L120.11 -23.56L121.50 -25.30L121.95 -25.00L121.18 -22.79Z M-77.82 -26.58L-78.98 -26.79L-77.82 -26.58Z M-77.00 -26.59L-77.17 -25.88L-77.79 -27.04L-77.00 -26.59Z M134.64 -34.15L134.20 -33.20L132.36 -32.99L132.92 -34.06L134.64 -34.15Z M34.58 -35.67L32.98 -34.57L32.26 -35.10L34.58 -35.67Z M23.70 -35.71L26.29 -35.30L24.72 -34.92L23.51 -35.28L23.70 -35.71Z M15.52 -38.23L15.10 -36.62L12.43 -37.61L12.57 -38.13L15.52 -38.23Z M9.21 -41.21L9.81 -40.50L9.67 -39.18L8.81 -38.91L8.16 -40.95L9.21 -41.21Z M140.98 -37.14L140.25 -35.14L137.22 -34.61L135.79 -33.46L135.08 -34.60L130.99 -33.89L132.00 -33.15L131.33 -31.45L130.20 -31.42L130.45 -32.32L129.41 -33.30L132.62 -35.43L135.68 -35.53L136.72 -37.30L137.39 -36.83L139.43 -38.22L139.88 -40.56L141.37 -41.38L141.88 -39.18L140.96 -38.17L140.98 -37.14Z M9.56 -42.15L9.23 -41.38L8.54 -42.26L9.39 -43.01L9.56 -42.15Z M143.91 -44.17L145.32 -44.38L145.54 -43.26L144.06 -42.99L143.18 -42.00L141.61 -42.68L141.07 -41.58L139.96 -41.57L139.82 -42.56L140.31 -43.33L141.38 -43.39L141.97 -45.55L143.91 -44.17Z M-63.66 -46.55L-62.01 -46.44L-62.87 -45.97L-64.39 -46.73L-63.66 -46.55Z M-61.81 -49.11L-64.52 -49.87L-61.81 -49.11Z M-123.51 -48.51L-125.66 -48.83L-128.06 -49.99L-128.36 -50.77L-125.76 -50.30L-123.51 -48.51Z M-56.13 -50.69L-56.80 -49.81L-56.14 -50.15L-55.47 -49.94L-55.82 -49.59L-53.48 -49.25L-53.79 -48.52L-53.09 -48.69L-52.65 -47.54L-53.07 -46.66L-54.18 -46.81L-54.24 -47.75L-55.40 -46.88L-56.00 -46.92L-55.29 -47.39L-56.25 -47.63L-59.27 -47.60L-58.80 -48.25L-59.23 -48.52L-57.36 -50.72L-55.41 -51.59L-56.13 -50.69Z M-132.71 -54.04L-131.75 -54.12L-132.05 -52.98L-131.18 -52.18L-133.05 -53.41L-133.18 -54.17L-132.71 -54.04Z M143.65 -50.75L144.65 -48.98L143.17 -49.31L142.56 -47.86L143.51 -46.14L142.75 -46.74L142.09 -45.97L142.18 -50.95L141.59 -51.94L141.68 -53.30L142.61 -53.76L142.21 -54.23L142.65 -54.37L143.65 -50.75Z M-6.79 -52.26L-9.98 -51.82L-9.17 -52.86L-9.69 -53.88L-6.73 -55.17L-5.66 -54.55L-6.79 -52.26Z M12.69 -55.61L12.09 -54.80L10.90 -55.78L12.37 -56.11L12.69 -55.61Z M-153.01 -57.12L-154.01 -56.73L-154.67 -57.46L-153.23 -57.97L-152.14 -57.59L-153.01 -57.12Z M-3.01 -58.63L-4.07 -57.55L-1.96 -57.68L-3.12 -55.97L-2.09 -55.91L0.47 -52.93L1.68 -52.74L1.05 -51.81L1.45 -51.29L-5.25 -49.96L-5.78 -50.16L-3.41 -51.43L-5.27 -51.99L-4.22 -52.30L-4.58 -53.50L-3.09 -53.40L-2.95 -53.98L-4.84 -54.79L-5.05 -55.78L-5.59 -55.31L-6.15 -56.79L-5.01 -58.63L-3.01 -58.63Z M-165.58 -59.91L-167.46 -60.21L-165.58 -59.91Z M-79.27 -62.16L-79.66 -61.63L-80.36 -62.02L-79.27 -62.16Z M-81.90 -62.71L-83.99 -62.45L-81.90 -62.71Z M-171.73 -63.78L-168.69 -63.30L-169.53 -62.98L-171.73 -63.78Z M-85.16 -65.66L-80.10 -63.73L-80.99 -63.41L-83.11 -64.10L-85.52 -63.05L-85.87 -63.64L-87.22 -63.54L-86.35 -64.04L-85.88 -65.74L-85.16 -65.66Z M-14.51 -66.46L-14.74 -65.81L-13.61 -65.13L-18.66 -63.50L-22.76 -63.96L-21.78 -64.40L-23.96 -64.89L-22.23 -65.38L-24.33 -65.61L-22.13 -66.41L-20.58 -65.73L-14.51 -66.46Z M-75.87 -67.15L-77.24 -67.59L-76.81 -68.15L-75.11 -68.01L-75.87 -67.15Z M-175.01 -66.58L-174.34 -66.34L-174.57 -67.06L-171.86 -66.91L-169.90 -65.98L-172.53 -65.44L-172.96 -64.25L-178.36 -65.39L-178.69 -66.11L-179.88 -65.87L-179.43 -65.40L-180.00 -64.98L-180.00 -68.96L-174.93 -67.21L-175.01 -66.58Z M-95.65 -69.11L-99.80 -69.40L-98.22 -70.14L-95.65 -69.11Z M180.00 -70.83L178.73 -71.10L180.00 -71.52L180.00 -70.83Z M-178.69 -70.89L-180.00 -70.83L-180.00 -71.52L-177.58 -71.27L-178.69 -70.89Z M-90.55 -69.50L-90.55 -68.48L-89.22 -69.26L-88.02 -68.62L-88.32 -67.87L-87.35 -67.20L-85.58 -68.78L-85.52 -69.88L-82.62 -69.66L-81.28 -69.16L-81.96 -68.13L-81.26 -67.60L-83.34 -66.41L-85.77 -66.56L-87.32 -64.78L-89.91 -64.03L-90.77 -62.96L-93.16 -62.02L-94.24 -60.90L-94.68 -58.95L-93.22 -58.78L-92.30 -57.09L-90.90 -57.28L-85.01 -55.30L-82.27 -55.15L-82.12 -53.28L-79.91 -51.21L-78.60 -52.56L-79.83 -54.67L-76.54 -56.53L-77.30 -58.05L-78.52 -58.80L-77.34 -59.85L-78.11 -62.32L-73.84 -62.44L-71.37 -61.14L-69.59 -61.06L-69.29 -58.96L-67.65 -58.21L-64.58 -60.34L-61.40 -56.97L-61.80 -56.34L-57.33 -54.63L-55.76 -53.27L-55.68 -52.15L-60.03 -50.24L-66.40 -50.23L-71.10 -46.82L-68.65 -48.30L-65.06 -49.23L-64.17 -48.74L-65.12 -48.07L-64.47 -46.24L-61.52 -45.88L-60.52 -47.01L-59.80 -45.92L-65.36 -43.55L-66.12 -43.62L-66.16 -44.47L-64.43 -45.29L-67.14 -45.14L-70.69 -43.03L-70.83 -42.34L-69.97 -41.64L-73.71 -40.93L-71.95 -40.93L-73.95 -40.75L-74.91 -38.94L-75.53 -39.50L-75.06 -38.40L-75.94 -37.22L-76.35 -39.15L-76.33 -38.08L-76.96 -38.23L-76.30 -37.92L-75.73 -35.55L-81.34 -31.44L-80.06 -26.88L-80.38 -25.21L-81.71 -25.87L-82.93 -29.10L-84.10 -30.09L-85.11 -29.64L-86.40 -30.40L-89.18 -30.32L-89.22 -29.29L-90.15 -29.12L-93.85 -29.71L-96.59 -28.31L-97.37 -27.38L-97.87 -22.44L-96.29 -19.32L-94.43 -18.14L-92.04 -18.70L-90.77 -19.28L-90.28 -21.00L-87.05 -21.54L-88.93 -15.89L-84.98 -16.00L-83.41 -15.27L-83.81 -11.10L-81.44 -8.79L-79.57 -9.61L-76.84 -8.64L-74.91 -11.08L-73.41 -11.23L-71.75 -12.44L-71.14 -12.11L-71.95 -11.42L-71.70 -9.07L-71.04 -9.86L-71.40 -10.97L-70.16 -11.38L-69.94 -12.16L-68.19 -10.55L-64.89 -10.08L-64.32 -10.64L-61.88 -10.72L-62.73 -10.42L-62.39 -9.95L-60.83 -9.38L-60.67 -8.58L-59.10 -8.00L-57.15 -5.97L-53.96 -5.76L-51.32 -4.20L-49.97 -1.74L-50.39 0.08L-48.62 0.24L-48.58 1.24L-47.82 0.58L-44.91 1.55L-44.58 2.69L-39.98 2.87L-37.22 4.82L-35.60 5.15L-34.73 7.34L-35.13 9.00L-38.67 13.06L-39.27 17.87L-40.94 21.94L-41.99 22.97L-44.65 23.35L-47.65 24.89L-48.50 25.88L-48.89 28.67L-53.81 34.40L-56.22 34.86L-58.43 33.91L-56.79 36.90L-57.75 38.18L-59.23 38.72L-62.34 38.83L-62.15 40.68L-62.75 41.03L-65.12 41.06L-64.98 42.06L-63.46 42.56L-65.18 43.50L-65.57 45.04L-67.29 45.55L-67.58 46.30L-65.64 47.24L-65.99 48.13L-69.14 50.73L-68.15 52.35L-70.85 52.90L-71.01 53.83L-74.95 52.26L-75.61 48.67L-74.13 46.94L-75.64 46.65L-74.69 45.76L-74.35 44.10L-73.24 44.45L-72.72 42.38L-73.39 42.12L-73.70 43.37L-74.33 43.22L-73.22 39.26L-73.59 37.16L-71.44 32.42L-70.16 19.76L-70.37 18.35L-71.46 17.36L-76.01 14.65L-79.76 7.19L-81.25 6.14L-81.41 4.74L-79.77 2.66L-80.97 2.25L-80.93 1.06L-80.09 -0.77L-78.86 -1.38L-77.13 -3.85L-78.18 -8.32L-79.56 -8.93L-80.48 -8.09L-80.00 -7.55L-80.89 -7.22L-81.06 -7.82L-83.51 -8.45L-84.98 -10.09L-85.11 -9.56L-85.66 -9.93L-85.71 -11.09L-87.49 -13.30L-91.23 -13.93L-94.69 -16.20L-96.56 -15.65L-103.50 -18.29L-105.49 -19.95L-105.27 -21.42L-106.03 -22.77L-112.23 -28.95L-113.15 -31.17L-114.78 -31.80L-114.67 -30.16L-109.43 -23.19L-110.03 -22.82L-112.18 -24.74L-112.30 -26.01L-115.06 -27.72L-114.16 -28.57L-115.52 -29.56L-117.30 -33.05L-120.62 -34.61L-124.40 -40.31L-123.90 -45.52L-124.69 -48.18L-123.12 -48.04L-122.59 -47.10L-122.84 -49.00L-127.44 -50.83L-127.85 -52.33L-129.13 -52.76L-134.08 -58.12L-136.63 -58.21L-139.87 -59.54L-147.11 -60.88L-148.22 -60.67L-148.02 -59.98L-151.72 -59.16L-151.41 -60.73L-150.62 -61.28L-154.02 -59.35L-153.29 -58.86L-154.23 -58.15L-158.43 -55.99L-164.79 -54.40L-157.72 -57.57L-157.04 -58.92L-161.97 -58.67L-161.87 -59.63L-163.82 -59.80L-166.12 -61.50L-164.56 -63.15L-160.77 -63.77L-161.52 -64.40L-160.78 -64.79L-164.96 -64.45L-168.11 -65.67L-164.47 -66.58L-161.68 -66.12L-166.76 -68.36L-161.91 -70.33L-156.58 -71.36L-136.50 -68.90L-129.79 -70.19L-129.11 -69.78L-128.14 -70.48L-125.76 -69.48L-124.42 -70.16L-124.29 -69.40L-121.47 -69.80L-113.90 -68.40L-115.30 -67.90L-109.95 -67.98L-108.88 -67.38L-107.79 -67.89L-108.81 -68.31L-108.17 -68.65L-106.15 -68.80L-101.45 -67.65L-98.44 -67.78L-98.56 -68.40L-97.67 -68.58L-96.12 -68.24L-96.13 -67.29L-94.68 -68.06L-94.23 -69.07L-96.47 -70.09L-96.39 -71.19L-95.21 -71.92L-92.88 -71.32L-91.52 -70.19L-92.41 -69.70L-90.55 -69.50Z M-114.17 -73.12L-114.67 -72.65L-112.44 -72.96L-111.05 -72.45L-109.92 -72.96L-108.19 -71.65L-107.69 -72.07L-108.40 -73.09L-106.52 -73.08L-105.40 -72.67L-104.46 -70.99L-100.98 -70.02L-101.09 -69.58L-102.73 -69.50L-102.09 -69.12L-102.43 -68.75L-105.96 -69.18L-113.31 -68.54L-117.34 -69.96L-112.42 -70.37L-117.90 -70.54L-118.43 -70.91L-116.11 -71.31L-119.40 -71.56L-117.87 -72.71L-114.17 -73.12Z M-104.50 -73.42L-105.38 -72.76L-106.94 -73.46L-104.50 -73.42Z M-76.34 -73.10L-79.49 -72.74L-80.88 -73.33L-78.06 -73.65L-76.34 -73.10Z M-86.56 -73.16L-85.77 -72.53L-84.85 -73.34L-82.32 -73.75L-80.60 -72.72L-80.75 -72.06L-77.82 -72.75L-74.10 -71.33L-72.24 -71.56L-68.79 -70.53L-66.97 -69.19L-68.81 -68.72L-61.85 -66.86L-63.92 -65.00L-66.72 -66.39L-68.02 -66.26L-68.14 -65.69L-65.32 -64.38L-64.67 -63.39L-65.01 -62.67L-68.78 -63.75L-66.17 -61.93L-71.02 -62.91L-74.83 -64.68L-77.71 -64.23L-78.56 -64.57L-77.90 -65.31L-73.96 -65.45L-74.29 -65.81L-72.65 -67.28L-72.93 -67.73L-78.96 -70.17L-84.94 -69.97L-88.68 -70.41L-89.51 -70.76L-88.47 -71.22L-89.89 -71.22L-90.21 -72.24L-89.44 -73.13L-85.83 -73.80L-86.56 -73.16Z M-100.36 -73.84L-97.38 -73.76L-98.05 -72.99L-96.54 -72.56L-96.72 -71.66L-99.32 -71.36L-102.50 -72.51L-100.44 -72.71L-101.54 -73.36L-100.36 -73.84Z M143.60 -73.21L139.86 -73.37L142.06 -73.86L143.60 -73.21Z M-93.20 -72.77L-95.41 -72.06L-96.02 -73.44L-94.50 -74.13L-90.51 -73.86L-93.20 -72.77Z M-120.46 -71.40L-123.09 -70.90L-125.93 -71.87L-123.94 -73.68L-124.92 -74.29L-117.56 -74.19L-115.51 -73.48L-119.22 -72.52L-120.46 -71.40Z M150.73 -75.08L146.12 -75.17L150.73 -75.08Z M-93.61 -74.98L-96.82 -74.93L-94.85 -75.65L-93.61 -74.98Z M145.09 -75.56L144.30 -74.82L138.96 -74.61L136.97 -75.26L138.83 -76.14L145.09 -75.56Z M-98.50 -76.72L-97.74 -76.26L-98.16 -75.00L-102.50 -75.56L-102.57 -76.34L-98.50 -76.72Z M-108.21 -76.20L-105.88 -75.97L-105.70 -75.48L-112.22 -74.42L-113.87 -74.72L-111.79 -75.16L-117.71 -75.22L-115.40 -76.48L-109.07 -75.47L-110.50 -76.43L-109.58 -76.79L-108.21 -76.20Z M57.54 -70.72L53.68 -70.76L51.46 -72.01L54.43 -73.63L53.51 -73.75L55.90 -74.63L55.63 -75.08L61.17 -76.25L68.16 -76.94L68.85 -76.54L58.48 -74.31L55.42 -72.37L55.62 -71.54L57.54 -70.72Z M-94.68 -77.10L-91.61 -76.78L-89.19 -75.61L-81.13 -75.71L-79.83 -74.92L-89.76 -74.52L-92.42 -74.84L-93.89 -76.32L-97.12 -76.75L-94.68 -77.10Z M-116.20 -77.65L-117.11 -76.53L-122.85 -76.12L-119.10 -77.51L-116.20 -77.65Z M106.97 -76.97L107.24 -76.48L111.08 -76.71L114.13 -75.85L109.40 -74.18L113.02 -73.98L113.53 -73.34L115.57 -73.75L123.20 -72.97L123.26 -73.74L126.98 -73.57L128.59 -73.04L129.05 -72.40L128.46 -71.98L131.29 -70.79L132.25 -71.84L139.87 -71.49L139.15 -72.42L140.47 -72.85L149.50 -72.20L152.97 -70.84L159.00 -70.87L159.83 -70.45L159.71 -69.72L160.94 -69.44L167.84 -69.58L169.58 -68.69L170.82 -69.01L170.01 -69.65L170.45 -70.10L175.72 -69.88L180.00 -68.96L180.00 -64.98L177.41 -64.61L179.37 -62.98L179.23 -62.30L177.36 -62.52L173.68 -61.65L170.33 -59.88L168.90 -60.57L166.30 -59.79L163.54 -59.87L162.02 -58.24L163.19 -57.62L163.06 -56.16L162.13 -56.12L161.70 -55.29L162.12 -54.86L160.37 -54.34L160.02 -53.20L158.53 -52.96L158.23 -51.94L156.79 -51.01L155.43 -55.38L155.91 -56.77L156.81 -57.83L158.36 -58.06L163.67 -61.14L164.47 -62.55L163.26 -62.47L160.12 -60.54L159.30 -61.77L156.72 -61.43L154.22 -59.76L155.04 -59.15L151.27 -58.78L151.34 -59.50L149.78 -59.66L142.20 -59.04L135.13 -54.73L138.16 -53.76L139.90 -54.19L141.35 -53.09L141.38 -52.24L140.06 -48.45L138.22 -46.31L134.87 -43.40L133.54 -42.81L132.28 -43.28L127.53 -39.76L129.46 -36.78L129.09 -35.08L126.49 -34.39L126.12 -36.73L126.86 -36.89L124.71 -38.11L125.32 -39.55L124.27 -39.93L121.05 -38.90L122.17 -40.42L121.64 -40.95L118.04 -39.20L117.53 -38.74L118.91 -37.45L122.36 -37.45L122.52 -36.93L121.10 -36.65L119.15 -34.91L120.23 -34.36L121.91 -31.69L121.26 -30.68L122.09 -29.83L121.68 -28.23L118.66 -24.55L115.89 -22.78L110.79 -21.40L110.44 -20.34L109.89 -20.28L109.86 -21.40L108.52 -21.72L105.88 -19.75L105.66 -19.06L108.88 -15.28L109.34 -13.43L109.20 -11.67L105.16 -8.60L105.08 -9.92L103.50 -10.63L102.59 -12.19L100.83 -12.63L100.98 -13.41L100.10 -13.41L99.22 -9.24L99.87 -9.21L100.46 -7.43L102.96 -5.52L104.23 -1.29L101.39 -2.76L100.09 -6.46L98.50 -8.38L98.34 -7.79L98.76 -11.44L97.16 -16.93L95.37 -15.71L94.19 -16.04L94.32 -18.21L91.42 -22.77L90.50 -22.81L90.27 -21.84L86.98 -21.50L86.50 -20.15L82.19 -16.56L80.32 -15.90L79.86 -10.36L77.54 -7.97L76.59 -8.90L73.53 -15.99L72.63 -21.36L70.47 -20.88L69.16 -22.09L69.35 -22.84L66.37 -25.43L61.50 -25.08L57.40 -25.74L56.49 -27.14L54.72 -26.48L51.52 -27.87L50.12 -30.15L47.97 -29.98L50.81 -24.75L51.01 -26.01L51.59 -25.80L51.79 -24.02L54.01 -24.12L56.36 -26.40L56.85 -24.24L58.73 -23.57L59.81 -22.31L57.83 -20.24L57.69 -18.94L55.27 -17.23L52.39 -16.38L52.17 -15.60L48.68 -14.00L43.48 -12.64L42.65 -16.77L39.14 -21.29L38.49 -23.69L34.63 -28.06L34.92 -29.50L33.92 -27.65L32.42 -29.85L35.69 -23.93L35.53 -23.10L36.87 -22.00L37.48 -18.61L38.41 -18.00L39.27 -15.92L43.32 -12.39L42.72 -11.74L44.61 -10.44L51.11 -12.02L51.05 -10.64L47.74 -4.22L40.26 2.57L39.20 4.68L38.80 6.48L39.44 6.84L39.19 8.49L40.48 10.77L40.78 14.69L39.45 16.72L34.79 19.78L35.61 23.71L32.57 25.73L32.20 28.75L28.22 32.77L25.78 33.94L22.57 33.86L19.62 34.82L18.38 34.14L18.22 31.66L15.21 27.09L14.26 22.11L11.79 18.07L11.78 15.79L13.69 10.73L11.92 5.04L8.80 1.11L9.80 -3.07L9.40 -3.73L8.50 -4.77L5.90 -4.26L4.33 -6.27L1.87 -6.14L-1.96 -4.71L-4.65 -5.17L-7.52 -4.34L-9.00 -4.83L-12.43 -7.26L-14.84 -10.88L-16.61 -12.17L-16.71 -13.60L-17.62 -14.73L-16.46 -16.14L-16.15 -18.11L-16.97 -21.89L-14.44 -26.25L-9.56 -29.93L-9.30 -32.56L-6.91 -34.11L-5.93 -35.76L-2.17 -35.17L1.47 -36.61L9.51 -37.35L11.10 -36.90L10.34 -33.79L15.25 -32.27L15.71 -31.38L19.09 -30.27L20.05 -30.99L20.13 -32.24L21.54 -32.84L28.91 -30.87L30.98 -31.56L33.77 -30.97L36.00 -34.64L36.16 -36.65L32.51 -36.11L31.70 -36.64L29.70 -36.14L27.64 -36.66L26.32 -38.21L26.80 -38.99L26.17 -39.46L27.28 -40.42L28.82 -40.46L29.24 -41.22L31.15 -41.09L33.51 -42.02L38.35 -40.95L40.37 -41.01L41.70 -41.96L41.45 -42.65L36.68 -45.24L38.23 -46.24L37.67 -46.64L39.12 -47.26L34.96 -46.27L35.02 -45.65L36.33 -45.11L33.88 -44.36L32.45 -45.33L33.30 -46.08L30.75 -46.58L29.63 -45.04L28.84 -44.91L27.67 -42.58L28.81 -41.05L26.36 -40.15L26.06 -40.82L24.93 -40.95L23.71 -40.69L24.41 -40.13L23.90 -39.96L22.63 -40.26L24.04 -37.66L23.12 -37.92L23.15 -36.42L22.49 -36.41L19.41 -40.25L19.54 -41.72L13.14 -45.74L12.33 -45.38L12.59 -44.09L18.48 -40.17L16.87 -40.44L16.45 -39.80L17.05 -38.90L16.10 -37.99L15.41 -40.05L12.11 -41.70L10.20 -43.92L8.89 -44.37L6.53 -43.13L3.10 -43.08L3.04 -41.89L0.81 -41.01L-0.28 -39.31L0.11 -38.74L-2.15 -36.67L-4.37 -36.68L-5.38 -35.95L-6.52 -36.94L-8.90 -36.87L-8.84 -38.27L-9.53 -38.74L-8.77 -40.76L-9.39 -43.03L-7.98 -43.75L-1.90 -43.42L-1.38 -44.02L-1.19 -46.01L-2.96 -47.57L-4.49 -47.96L-4.59 -48.68L-1.62 -48.64L-1.93 -49.78L-0.99 -49.35L1.34 -50.13L1.64 -50.95L3.83 -51.62L4.71 -53.09L8.12 -53.53L8.80 -54.02L8.12 -55.52L8.54 -57.11L10.58 -57.73L10.25 -56.89L10.91 -56.46L9.65 -55.47L10.94 -54.01L12.52 -54.47L14.12 -53.76L17.62 -54.85L19.66 -54.43L21.27 -55.19L21.58 -57.41L22.52 -57.75L24.12 -57.03L24.43 -58.38L23.34 -59.19L29.12 -60.03L28.07 -60.50L22.87 -59.85L21.32 -60.72L21.06 -62.61L21.54 -63.19L25.40 -65.11L23.90 -66.01L22.18 -65.72L21.21 -65.03L21.37 -64.41L17.85 -62.75L17.12 -61.34L18.79 -60.08L16.83 -58.72L15.88 -56.10L12.94 -55.36L10.36 -59.47L8.38 -58.31L5.67 -58.59L4.99 -61.97L10.53 -64.49L14.76 -67.81L19.18 -69.82L23.02 -70.20L24.55 -71.03L28.17 -71.19L31.29 -70.45L30.01 -70.19L31.10 -69.56L32.13 -69.91L36.51 -69.06L41.06 -67.46L41.13 -66.79L38.38 -66.00L33.18 -66.63L34.81 -65.90L34.94 -64.41L37.01 -63.85L36.52 -64.78L37.18 -65.14L39.59 -64.52L40.44 -64.76L39.76 -65.50L42.09 -66.48L43.95 -66.07L44.53 -66.76L43.45 -68.57L46.25 -68.25L46.82 -67.69L45.56 -67.57L45.56 -67.01L46.35 -66.67L53.72 -68.86L54.47 -68.81L53.49 -68.20L58.80 -68.88L59.94 -68.28L61.08 -68.94L60.03 -69.52L60.55 -69.85L68.51 -68.09L69.18 -68.62L66.93 -69.45L66.69 -71.03L69.20 -72.84L72.59 -72.78L72.80 -72.22L71.85 -71.41L72.79 -70.39L72.56 -69.02L73.67 -68.41L71.28 -66.32L72.42 -66.17L75.05 -67.76L74.47 -68.33L74.94 -68.99L73.60 -69.63L74.40 -70.63L73.10 -71.45L74.89 -72.12L74.66 -72.83L75.68 -72.30L75.29 -71.34L76.36 -71.15L75.90 -71.87L77.58 -72.27L81.50 -71.75L80.51 -73.65L86.82 -73.94L86.01 -74.46L87.17 -75.12L100.76 -76.43L104.35 -77.70L106.07 -77.37L104.71 -77.13L106.97 -76.97Z M-93.84 -77.52L-96.44 -77.83L-93.84 -77.52Z M-110.19 -77.70L-113.53 -77.73L-109.85 -78.00L-110.19 -77.70Z M24.72 -77.85L20.73 -77.68L21.42 -77.94L20.81 -78.25L22.88 -78.45L24.72 -77.85Z M-109.66 -78.60L-112.54 -78.41L-109.66 -78.60Z M-95.83 -78.06L-98.12 -78.08L-98.63 -78.87L-95.56 -78.42L-95.83 -78.06Z M-100.06 -78.32L-99.67 -77.91L-105.18 -78.38L-104.21 -78.68L-105.49 -79.30L-100.06 -78.32Z M105.08 -78.31L99.44 -77.92L102.09 -79.35L105.37 -78.71L105.08 -78.31Z M18.25 -79.70L21.54 -78.96L19.03 -78.56L17.12 -76.81L15.91 -76.77L13.76 -77.38L14.67 -77.74L10.44 -79.65L18.25 -79.70Z M25.45 -80.41L27.41 -80.06L23.02 -79.40L17.37 -80.32L25.45 -80.41Z M51.14 -80.55L47.59 -80.01L46.50 -80.25L47.07 -80.56L44.85 -80.59L51.14 -80.55Z M99.94 -78.88L94.97 -79.04L91.18 -80.34L95.94 -81.25L100.19 -79.78L99.94 -78.88Z M-87.02 -79.66L-85.81 -79.34L-90.80 -78.22L-92.88 -78.34L-93.95 -78.75L-93.15 -79.38L-96.71 -80.16L-94.30 -80.98L-94.74 -81.21L-92.41 -81.26L-87.02 -79.66Z M-68.50 -83.11L-61.85 -82.63L-67.66 -81.50L-65.48 -81.51L-71.18 -79.80L-76.91 -79.32L-75.53 -79.20L-76.22 -79.02L-75.39 -78.53L-79.76 -77.21L-77.89 -76.78L-80.56 -76.18L-89.49 -76.47L-89.62 -76.95L-87.77 -77.18L-88.26 -77.90L-84.98 -77.54L-87.96 -78.37L-85.09 -79.35L-86.93 -80.25L-81.85 -80.46L-87.60 -80.52L-91.59 -81.89L-79.31 -83.13L-68.50 -83.11Z M-27.10 -83.52L-20.85 -82.73L-31.90 -82.20L-22.07 -81.73L-23.17 -81.15L-15.77 -81.91L-12.21 -81.29L-20.05 -80.18L-17.73 -80.13L-19.70 -78.75L-19.67 -77.64L-18.47 -76.99L-21.68 -76.63L-19.83 -76.10L-19.60 -75.25L-20.67 -75.16L-19.37 -74.30L-21.59 -74.22L-20.43 -73.82L-20.76 -73.46L-23.57 -73.31L-22.30 -72.18L-24.79 -72.33L-22.13 -71.47L-21.75 -70.66L-23.54 -70.47L-25.54 -71.43L-25.20 -70.75L-26.36 -70.23L-22.35 -70.13L-27.75 -68.47L-31.78 -68.12L-34.20 -66.68L-39.81 -65.46L-41.19 -63.48L-42.82 -62.68L-42.42 -61.90L-43.38 -60.10L-48.26 -60.86L-51.63 -63.63L-53.97 -67.19L-52.98 -68.36L-51.48 -68.73L-50.87 -69.93L-53.46 -69.28L-54.68 -69.61L-54.36 -70.82L-51.39 -70.57L-55.83 -71.65L-54.72 -72.59L-58.59 -75.52L-61.27 -76.10L-68.50 -76.06L-71.40 -77.01L-66.76 -77.38L-73.30 -78.04L-65.71 -79.39L-65.32 -79.76L-68.02 -80.12L-62.23 -81.32L-62.65 -81.77L-50.39 -82.44L-44.52 -81.66L-46.90 -82.20L-46.76 -82.63L-38.62 -83.55L-27.10 -83.52Z";
 
-/* ────────────────────────── Small helpers ────────────────────────── */
-const $ = id => document.getElementById(id);
-function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
-function fmtMbps(v) { if (!isFinite(v)) return '—'; if (v >= 1000) return (v / 1000).toFixed(2) + ' Gbps'; if (v >= 100) return Math.round(v) + ' Mbps'; if (v >= 10) return v.toFixed(1) + ' Mbps'; return v.toFixed(1) + ' Mbps'; }
-function fmtMBps(v) { if (!isFinite(v)) return '—'; return (v / 8).toFixed(1) + ' MB/s'; }
+/* ────────────────────────── pure helpers (no DOM) ────────────────────────── */
+const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+function mean(a) { return a.length ? a.reduce((x, y) => x + y, 0) / a.length : NaN; }
+function sd(a) { if (a.length < 2) return 0; const m = mean(a); return Math.sqrt(a.reduce((x, y) => x + (y - m) ** 2, 0) / a.length); }
+function median(a) {
+  if (!a || !a.length) return null;
+  const s = a.slice().sort((x, y) => x - y);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+function downSample(arr, n) {
+  if (!arr || arr.length <= n) return arr || [];
+  const step = arr.length / n, out = [];
+  for (let i = 0; i < n; i++) out.push(arr[Math.floor(i * step)]);
+  return out;
+}
+function fmtMbps(v) {
+  if (v == null || !isFinite(v)) return '—';
+  if (v >= 1000) return (v / 1000).toFixed(2) + ' Gbps';
+  if (v >= 100) return Math.round(v) + ' Mbps';
+  return v.toFixed(1) + ' Mbps';
+}
+function fmtUnit(mbps, unit) {
+  if (mbps == null || !isFinite(mbps)) return '—';
+  return unit === 'mib' ? (mbps / 8 / 1.048576).toFixed(1) + ' MiB/s' : (mbps / 8).toFixed(1) + ' MB/s';
+}
 function fmtMs(v) { return v == null || !isFinite(v) ? '—' : Math.round(v) + ' ms'; }
-function fmtBytes(b) { if (b < 1024 * 1024) return (b / 1024).toFixed(0) + ' KB'; if (b < 1024 * 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + ' MB'; return (b / (1024 * 1024 * 1024)).toFixed(2) + ' GB'; }
-function now() { return performance.now(); }
-function mean(arr) { return arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : NaN; }
-function toast(msg, ms = 3200) {
+function fmtBytes(b) {
+  if (b < 1024 * 1024) return (b / 1024).toFixed(0) + ' KB';
+  if (b < 1024 * 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + ' MB';
+  return (b / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+}
+function fmtEta(s) {
+  if (s == null || !isFinite(s) || s < 0) return '—';
+  return s < 90 ? Math.round(s) + 's' : (s / 60).toFixed(1) + 'm';
+}
+function hostOf(url) { try { return new URL(url).origin; } catch (e) { return null; } }
+
+/* Playback verdict — single-connection data only. base = 0.85 × steady
+ * (headroom for the player's own overhead), ping-aware caps. */
+function verdictFor(steady, ping) {
+  if (steady == null || !isFinite(steady) || steady <= 0) return null;
+  const base = steady * 0.85;
+  let v;
+  if (base >= 150) v = ['v4k', '4K Remux ready'];
+  else if (base >= 60) v = ['v4k', '4K streaming'];
+  else if (base >= 25) v = ['vq', '1080p Remux / 4K'];
+  else if (base >= 8) v = ['vf', '1080p'];
+  else if (base >= 4) v = ['vf', '720p'];
+  else v = ['vs', 'SD only'];
+  if (ping != null && ping > 400) v = ['vs', 'SD — very high latency'];
+  else if (ping != null && ping > 250) v = base >= 8 ? ['vf', '1080p max — high latency'] : ['vs', 'SD — high latency'];
+  return v;
+}
+
+/* ────────────────────────── worker source (the whole measurement) ────────────────────────── */
+const WORKER_SRC = `
+'use strict';
+const T = () => performance.now();
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+let aborter = null;
+
+async function timedFetch(url, opts, ms, ctrl) {
+  const inner = new AbortController();
+  const onAbort = () => inner.abort();
+  if (ctrl && !ctrl.signal.aborted) ctrl.signal.addEventListener('abort', onAbort);
+  const to = setTimeout(() => inner.abort(), ms);
+  try {
+    return await fetch(url, Object.assign({ cache: 'no-store' }, opts, { signal: inner.signal }));
+  } finally {
+    clearTimeout(to);
+    if (ctrl) ctrl.signal.removeEventListener('abort', onAbort);
+  }
+}
+
+self.onmessage = async (ev) => {
+  const { url, pingRounds = 0, windowMs = 0, graceMs = 8000, range = null, maxBytes = 0, withPing = false } = ev.data || {};
+  aborter = new AbortController();
+  const post = (m) => self.postMessage(m);
+
+  /* ---- ping: N x 1-byte Range GETs, trimmed mean of middle 3 ---- */
+  let ping = null, pingMin = null, jitter = null, pingsAll = [];
+  if (withPing && pingRounds > 0) {
+    const times = [];
+    for (let i = 0; i < pingRounds; i++) {
+      if (aborter.signal.aborted) break;
+      const t0 = T();
+      try {
+        const r = await timedFetch(url, { headers: { Range: 'bytes=0-0' } }, 4000, aborter);
+        if (!r.ok && r.status !== 206) throw new Error('http ' + r.status);
+        await r.text();
+        const dt = T() - t0;
+        times.push(dt); pingsAll.push(Math.round(dt));
+      } catch (e) { /* drop the round */ }
+      await sleep(60);
+    }
+    if (times.length >= 3) {
+      const s = times.slice().sort((a, b) => a - b);
+      const mid = s.slice(1, -1);
+      ping = mid.reduce((a, b) => a + b, 0) / mid.length;
+      pingMin = s[0];
+      const m = mean(times);
+      jitter = times.reduce((a, b) => a + Math.abs(b - m), 0) / times.length;
+    }
+    post({ type: 'ping', ping, pingMin, jitter, pingsAll });
+  }
+
+  if (windowMs <= 0) {
+    post({ type: 'done', ok: ping != null, status: ping != null ? 'ping-only' : 'error', err: null,
+      ping, pingMin, jitter, pingsAll, ttfb: null, bytes: 0, firstByteMs: null,
+      avgFbMbps: null, steadyMbps: null, peakMbps: null, p95Mbps: null, elapsedMs: 0, marks: [] });
+    return;
+  }
+
+  /* ---- warm: 1-byte GET on the exact URL the measurement will use ---- */
+  let ttfb = null;
+  if (!aborter.signal.aborted) {
+    const t0 = T();
+    try {
+      const r = await timedFetch(url, { headers: { Range: 'bytes=0-0' } }, 5000, aborter);
+      await r.text();
+      ttfb = T() - t0;
+    } catch (e) { /* cold start — the transfer will include it */ }
+  }
+
+  /* ---- transfer: first-byte-anchored window on the (1 GB) file ---- */
+  const fetchStart = T();
+  let firstByte = null, totalBytes = 0, status = 'error', errMsg = '';
+  const marks = [];
+  let retries = 2, noByteTimer = null;
+  const hdrs = range ? { Range: 'bytes=' + range.start + '-' + range.end } : {};
+
+  while (retries-- > 0 && firstByte == null) {
+    if (aborter.signal.aborted) break;
+    try {
+      const res = await timedFetch(url, { headers: hdrs }, windowMs + graceMs + 10000, aborter);
+      if (!res.ok) throw new Error('http ' + res.status);
+      if (!res.body) throw new Error('no body');
+      const reader = res.body.getReader();
+      noByteTimer = setTimeout(() => { if (firstByte == null) aborter.abort(); }, graceMs);
+      while (true) {
+        if (aborter.signal.aborted) break;
+        const rd = await reader.read();
+        if (rd.done) { status = 'complete'; break; }
+        const t = T();
+        if (firstByte == null) { firstByte = t; clearTimeout(noByteTimer); }
+        totalBytes += rd.value.byteLength;
+        const last = marks[marks.length - 1];
+        if (!last || t - last.t >= 200) {
+          marks.push({ t, b: totalBytes });
+          if (marks.length >= 2) {
+            const a = marks[marks.length - 2], z = marks[marks.length - 1];
+            const d = (z.t - a.t) / 1000;
+            if (d > 0.05) post({ type: 'progress', bytes: totalBytes, mbps: (z.b - a.b) * 8 / 1e6 / d, ms: Math.round(t - firstByte) });
+          }
+          // window cap checked on chunk arrival — immune to background timer throttling
+          if (t - firstByte >= windowMs || (maxBytes > 0 && totalBytes >= maxBytes)) {
+            status = 'capped';
+            try { reader.cancel(); } catch (e) {}
+            break;
+          }
+        }
+      }
+      if (noByteTimer) clearTimeout(noByteTimer);
+      if (status !== 'complete' && status !== 'capped') status = 'aborted';
+    } catch (e) {
+      if (noByteTimer) clearTimeout(noByteTimer);
+      errMsg = (e && e.message) || 'fetch failed';
+      if (retries > 0) await sleep(500); // single retry
+    }
+  }
+  if (firstByte == null) status = (status === 'aborted') ? 'aborted' : 'timeout';
+
+  /* ---- statistics (first-byte anchored) ---- */
+  const endT = T();
+  let avgFb = null, steady = null, peak = null, p95 = null;
+  if (firstByte != null) {
+    const fbDur = (endT - firstByte) / 1000;
+    if (fbDur > 0.5) avgFb = totalBytes * 8 / 1e6 / fbDur;
+    const st = marks.filter(m => m.t - firstByte >= 2000);
+    if (st.length >= 2) {
+      const a = st[0], z = st[st.length - 1], d = (z.t - a.t) / 1000;
+      if (d > 0.5) steady = (z.b - a.b) * 8 / 1e6 / d;
+    } else {
+      // Short transfer (e.g. a capacity-mode slice): never reaches the 2 s
+      // slow-start mark — fall back to the last half of the transfer, which
+      // still excludes the ramp.
+      const total = endT - firstByte;
+      if (total >= 800) {
+        const mid = marks.filter(m => m.t - firstByte >= total / 2);
+        if (mid.length >= 2) {
+          const a = mid[0], z = mid[mid.length - 1], d = (z.t - a.t) / 1000;
+          if (d > 0.2) steady = (z.b - a.b) * 8 / 1e6 / d;
+        }
+      }
+    }
+    const inst = [];
+    for (let i = 1; i < marks.length; i++) {
+      const a = marks[i - 1], z = marks[i], d = (z.t - a.t) / 1000;
+      if (d > 0.05) inst.push((z.b - a.b) * 8 / 1e6 / d);
+    }
+    if (inst.length) {
+      peak = Math.max.apply(null, inst);
+      const si = inst.slice().sort((a, b) => a - b);
+      p95 = si[Math.min(si.length - 1, Math.floor(si.length * 0.95))];
+    }
+  }
+  post({ type: 'done',
+    ok: firstByte != null && (status === 'complete' || status === 'capped'),
+    status, err: errMsg || null,
+    ping, pingMin, jitter, pingsAll, ttfb,
+    bytes: totalBytes, firstByteMs: firstByte != null ? Math.round(firstByte - fetchStart) : null,
+    avgFbMbps: avgFb, steadyMbps: steady, peakMbps: peak, p95Mbps: p95,
+    elapsedMs: Math.round(endT - fetchStart),
+    marks: marks.filter((_, i) => i % 2 === 0) });
+};
+
+function mean(a) { return a.length ? a.reduce((x, y) => x + y, 0) / a.length : NaN; }
+
+self.addEventListener('message', (ev) => { if (ev.data === 'stop' && aborter) aborter.abort(); });
+`;
+
+/* ────────────────────────── engine (browser worker management) ────────────────────────── */
+const Engine = {
+  _url: null,
+  _active: new Set(),
+  makeWorker() {
+    if (!this._url) this._url = URL.createObjectURL(new Blob([WORKER_SRC], { type: 'application/javascript' }));
+    const w = new Worker(this._url);
+    this._active.add(w);
+    return w;
+  },
+  runWorker(msg, onMsg) {
+    const w = this.makeWorker();
+    const promise = new Promise((resolve, reject) => {
+      const onm = (ev) => {
+        const d = ev.data || {};
+        if (d.type === 'done') {
+          w.removeEventListener('message', onm);
+          w.removeEventListener('error', one);
+          resolve(d);
+        } else if (onMsg) onMsg(d);
+      };
+      const one = (ev) => {
+        w.removeEventListener('message', onm);
+        reject(new Error((ev && ev.message) || 'worker failed'));
+      };
+      w.addEventListener('message', onm);
+      w.addEventListener('error', one);
+      w.postMessage(msg);
+    });
+    promise.finally(() => {
+      this._active.delete(w);
+      try { w.postMessage('stop'); } catch (e) {}
+      try { w.terminate(); } catch (e) {}
+    });
+    return { promise, worker: w };
+  },
+  stopAll() {
+    for (const w of [...this._active]) { try { w.postMessage('stop'); } catch (e) {} }
+  },
+};
+
+/* ────────────────────────── endpoint discovery (fetch only) ────────────────────────── */
+function proxyChain() {
+  const out = [];
+  try {
+    const p = new URLSearchParams(typeof location !== 'undefined' ? location.search : '').get('worker');
+    if (p) out.push(String(p).replace(/\/+$/, ''));
+  } catch (e) {}
+  out.push(DEFAULT_PROXY);
+  return out;
+}
+async function tryProxy(base, length) {
+  const url = base + '/proxy/v1/api/speedtest?host=' + encodeURIComponent(API_HOST) + '&test_length=' + length;
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout(8000), cache: 'no-store' });
+    if (!r.ok) return null;
+    const j = await r.json();
+    if (j && Array.isArray(j.data) && j.data.length) return { id: 'worker', data: j.data };
+  } catch (e) {}
+  return null;
+}
+async function tryDirect(length) {
+  const url = API_HOST + '/v1/api/speedtest?test_length=' + length;
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout(8000), cache: 'no-store' });
+    if (!r.ok) return null;
+    const j = await r.json();
+    if (j && Array.isArray(j.data) && j.data.length) return { id: 'direct', data: j.data };
+  } catch (e) {}
+  return null;
+}
+function normalize(item, longUrl) {
+  if (!item || !item.url || !/^https:\/\//i.test(item.url)) return null;
+  const region = /^[a-z]{2,8}$/i.test(item.region || '') ? String(item.region).toLowerCase() : null;
+  if (!region) return null;
+  const lat = item.coordinates && isFinite(item.coordinates.lat) ? Number(item.coordinates.lat) : null;
+  const lng = item.coordinates && isFinite(item.coordinates.lng) ? Number(item.coordinates.lng) : null;
+  const meta = REGION_META[region] || { label: region.toUpperCase(), city: '—', flag: '🌐', net: 'direct' };
+  return {
+    region,
+    name: String(item.name || item.domain || '').slice(0, 40),
+    urlShort: String(item.url),
+    urlLong: longUrl || String(item.url).replace(/\/dld\/[^/]+$/i, '/dld/1GB.bin'),
+    closest: !!item.closest,
+    lat, lng, meta,
+  };
+}
+/* Race every source in parallel; the first valid one wins. */
+async function discoverLiveOnly() {
+  const discover = (length) =>
+    Promise.all(proxyChain().map(b => tryProxy(b, length)).concat([tryDirect(length)]))
+      .then(rs => rs.find(Boolean) || null);
+  const [short, long] = await Promise.all([discover('short'), discover('long')]);
+  if (short && short.data.length >= 5) {
+    const list = short.data.map(s => {
+      const l = long ? long.data.find(x => x.region === s.region && x.name === s.name) : null;
+      const n = normalize(s, null);
+      if (n && l && l.url) n.urlLong = String(l.url);
+      return n;
+    }).filter(Boolean);
+    if (list.length >= 5) return { source: short.id, list };
+  }
+  return null;
+}
+function snapshotList() {
+  return SNAPSHOT.data.map(s => normalize({
+    region: s.region, name: s.name, url: s.url,
+    coordinates: { lat: s.lat, lng: s.lng }, closest: !!s.closest,
+  }, s.url_long || null)).filter(Boolean);
+}
+/* V3-8: prove the snapshot hosts are still alive (1-byte Range GET each). */
+async function probeEndpoints(list) {
+  const hosts = [...new Set(list.map(s => hostOf(s.urlShort)).filter(Boolean))];
+  let fails = 0;
+  await Promise.all(hosts.map(async h => {
+    try {
+      const r = await fetch(h + '/dld/100MB.bin', {
+        headers: { Range: 'bytes=0-0' }, cache: 'no-store', signal: AbortSignal.timeout(3000),
+      });
+      try { await r.body.cancel(); } catch (e) {}
+      if (!r.ok && r.status !== 206) fails++;
+    } catch (e) { fails++; }
+  }));
+  return { total: hosts.length, fails, ok: fails <= Math.ceil(hosts.length * 0.2) };
+}
+
+/* ────────────────────────── orchestration (pure; UI via hooks) ────────────────────────── */
+function buildRun(mode, servers, cfg) {
+  return {
+    id: Date.now(),
+    mode, cfg,
+    nodes: servers.map(s => ({
+      s, status: 'queued',
+      ping: null, pingMin: null, jitter: null, pingsAll: [],
+      ttfb: null, reps: [],
+      steady: null, avgFb: null, peak: null, p95: null, consistency: null,
+      verdict: null, streamable: null,
+      err: null, bytes: 0, marks: null, rank: 0,
+      repLive: 0, liveRep: -1, capLive: 0,
+    })),
+    startedAt: 0, finishedAt: 0,
+    totalBytes: 0,
+    aborted: false, finished: false, _done: false,
+  };
+}
+
+/* Ping every node, 4 origins at a time. */
+async function pingPhaseV3(run, hooks) {
+  const queue = run.nodes.slice();
+  const pump = async () => {
+    while (queue.length && !run.aborted) {
+      const node = queue.shift();
+      node.status = 'ping';
+      if (hooks.onNodeState) hooks.onNodeState(node);
+      try {
+        const { promise } = Engine.runWorker(
+          { url: node.s.urlShort, pingRounds: PING_ROUNDS, windowMs: 0, withPing: true },
+          () => {}
+        );
+        const d = await promise;
+        node.ping = d.ping; node.pingMin = d.pingMin; node.jitter = d.jitter; node.pingsAll = d.pingsAll || [];
+      } catch (e) { /* ping failed — node keeps testing, verdict stays ping-agnostic */ }
+      if (!run.aborted) node.status = 'queued';
+      if (hooks.onNodeState) hooks.onNodeState(node);
+    }
+  };
+  const pumps = [];
+  for (let i = 0; i < Math.min(PING_CONCURRENCY, queue.length); i++) pumps.push(pump());
+  await Promise.all(pumps);
+}
+
+function finishNode(node, run, hooks) {
+  const ok = node.reps.filter(r => r && r.ok);
+  if (ok.length) {
+    node.avgFb = median(ok.map(r => r.avgFbMbps).filter(v => v != null));
+    const st = ok.map(r => r.steadyMbps).filter(v => v != null);
+    node.steady = st.length ? median(st) : node.avgFb;
+    const pk = ok.map(r => r.peakMbps).filter(v => v != null);
+    node.peak = pk.length ? Math.max(...pk) : null;
+    node.p95 = median(ok.map(r => r.p95Mbps).filter(v => v != null));
+    node.consistency = st.length >= 2 && mean(st) > 0 ? Math.max(0, Math.min(1, 1 - sd(st) / mean(st))) : null;
+    if (ok[0].ttfb != null) node.ttfb = ok[0].ttfb;
+    node.status = 'done';
+    node.verdict = verdictFor(node.steady, node.ping);
+    node.streamable = node.steady * 0.85;
+    node.marks = ok[0].marks || null;
+  } else {
+    node.status = 'failed';
+    const last = node.reps.length ? node.reps[node.reps.length - 1] : null;
+    node.err = (last && last.err) || (node.ping == null ? 'no response (ping + download)' : 'download failed');
+  }
+  if (hooks.onNodeState) hooks.onNodeState(node);
+}
+
+/* Accurate / Express: one node at a time, one connection, reps on the 1 GB file. */
+async function runAccurate(run, hooks) {
+  run.startedAt = now();
+  const n = run.nodes.length;
+  if (hooks.onStatus) hooks.onStatus(`Pinging ${n} CDNs (4 at a time)…`);
+  await pingPhaseV3(run, hooks);
+
+  let list = run.nodes.slice().sort((a, b) => (a.ping == null ? 1e9 : a.ping) - (b.ping == null ? 1e9 : b.ping));
+  if (run.cfg.mode === 'express') {
+    const closest = run.nodes.find(x => x.s.closest);
+    const rest = list.filter(x => x !== closest);
+    list = [closest, ...rest].filter(Boolean).slice(0, 5);
+    for (const x of run.nodes) if (!list.includes(x)) { x.status = 'skipped'; x.err = 'not in Express scope'; if (hooks.onNodeState) hooks.onNodeState(x); }
+  }
+
+  let doneCount = 0;
+  for (let i = 0; i < list.length; i++) {
+    if (run.aborted) break;
+    const node = list[i];
+    const worstCase = run.cfg.reps * FILE_1GB * 1.02;
+    if (run.totalBytes + worstCase > BUDGET_BYTES) {
+      node.status = 'skipped'; node.err = 'data budget (12 GB)';
+      if (hooks.onNodeState) hooks.onNodeState(node);
+      continue;
+    }
+    for (let rep = 0; rep < run.cfg.reps; rep++) {
+      if (run.aborted) break;
+      if (rep > 0 && run.totalBytes + FILE_1GB * 1.02 > BUDGET_BYTES) { node.budgetReps = true; break; }
+      node.status = rep === 0 ? 'rep1' : 'rep2';
+      node.liveRep = rep;
+      node.bytes = 0; node.repLive = 0;
+      if (hooks.onNodeState) hooks.onNodeState(node);
+      const repRange = rep > 0 ? { start: Math.floor(FILE_1GB / 2), end: FILE_1GB - 1 } : null;
+      const { promise } = Engine.runWorker({
+        url: node.s.urlLong, windowMs: run.cfg.windowMs, graceMs: 8000,
+        range: repRange, withPing: false,
+      }, (d) => {
+        if (d.type === 'progress') { node.repLive = d.mbps; node.bytes = d.bytes; if (hooks.onProgress) hooks.onProgress(node, rep, d); }
+      });
+      let res;
+      try { res = await promise; }
+      catch (e) { res = { ok: false, status: 'error', err: String(e.message || e), bytes: node.bytes, ttfb: null, steadyMbps: null, avgFbMbps: null, peakMbps: null, p95Mbps: null, marks: [] }; }
+      node.reps.push(res);
+      run.totalBytes += res.bytes || 0;
+    }
+    finishNode(node, run, hooks);
+    doneCount++;
+    if (!run.aborted && hooks.onStatus) {
+      const elapsed = now() - run.startedAt;
+      const per = elapsed / doneCount;
+      const remain = (list.length - doneCount) * per / 1000;
+      hooks.onStatus(
+        `${node.s.meta.flag} ${node.s.meta.label}: ${node.status === 'done' ? fmtMbps(node.steady) + ' steady' : node.status} (${doneCount}/${list.length})` +
+        (remain > 0 ? ` · ETA ${fmtEta(remain)}` : '')
+      );
+    }
+  }
+}
+
+/* Capacity: all nodes at once, N REAL parallel Range connections per node. */
+async function runCapacity(run, hooks) {
+  run.startedAt = now();
+  const n = run.nodes.length;
+  if (hooks.onStatus) hooks.onStatus(`Pinging ${n} CDNs (4 at a time)…`);
+  await pingPhaseV3(run, hooks);
+
+  let remaining = run.nodes.length;
+  for (const node of run.nodes) {
+    if (run.aborted) break;
+    if (run.totalBytes + run.cfg.capBytes > BUDGET_BYTES) {
+      node.status = 'skipped'; node.err = 'data budget (12 GB)';
+      if (hooks.onNodeState) hooks.onNodeState(node);
+      remaining--;
+      continue;
+    }
+    node.status = 'race';
+    if (hooks.onNodeState) hooks.onNodeState(node);
+    const slice = Math.max(1024 * 1024, Math.floor(run.cfg.capBytes / run.cfg.streams));
+    const jobs = [];
+    for (let i = 0; i < run.cfg.streams; i++) {
+      const start = i * slice;
+      const end = Math.min(FILE_1GB - 1, start + slice - 1);
+      jobs.push(Engine.runWorker({
+        url: node.s.urlLong, windowMs: run.cfg.windowMs, graceMs: 8000,
+        range: { start, end }, maxBytes: slice, withPing: false,
+      }, (d) => {
+        if (d.type === 'progress') {
+          node._lastMb = node._lastMb || [];
+          node._lastMb[i] = d.mbps;
+          node.capLive = node._lastMb.reduce((a, b) => a + (b || 0), 0);
+          if (hooks.onCapProgress) hooks.onCapProgress(node, d);
+        }
+      }).promise);
+    }
+    const results = await Promise.allSettled(jobs);
+    const ok = results.map(r => r.value).filter(Boolean).filter(r => r.ok);
+    node.reps = ok;
+    node.bytes = ok.reduce((a, r) => a + r.bytes, 0);
+    run.totalBytes += node.bytes;
+    // sum of per-slice steady rates (each slice is an independent measurement)
+    const sliceMbps = ok.map(r => {
+      const flow = (r.elapsedMs || 0) - (r.firstByteMs || 0);
+      return flow > 500 ? r.bytes * 8 / 1e6 / (flow / 1000) : 0;
+    });
+    if (ok.length) {
+      node.steady = sliceMbps.reduce((a, b) => a + b, 0);
+      node.avgFb = node.steady;
+      node.status = 'done';
+    } else {
+      node.status = 'failed';
+      node.err = 'download failed';
+    }
+    if (hooks.onNodeState) hooks.onNodeState(node);
+    remaining--;
+    if (!run.aborted && hooks.onStatus) hooks.onStatus(`Capacity race — ${remaining} node${remaining === 1 ? '' : 's'} left…`);
+  }
+}
+
+/* Final ranking — only nodes with a valid single-connection (or capacity)
+ * measurement are ranked; everything else is reported, never ranked [V3-6]. */
+function summarizeRun(run) {
+  const ranked = run.nodes.filter(x => x.status === 'done' && x.steady != null && x.steady > 0)
+    .sort((a, b) => b.steady - a.steady);
+  ranked.forEach((x, i) => { x.rank = i + 1; });
+  const failed = run.nodes.filter(x => x.status !== 'done');
+  return { ranked, failed };
+}
+/* ================= UI SECTION ================= */
+// Everything from here on touches the DOM. Everything above this marker is pure (unit-tested in test-engine.mjs).
+
+const $ = (id) => document.getElementById(id);
+function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+function toast(msg, ms = 3400) {
   const t = $('toast'); t.textContent = msg; t.classList.add('show');
   clearTimeout(t._h); t._h = setTimeout(() => t.classList.remove('show'), ms);
 }
-if (!AbortSignal.timeout) { AbortSignal.timeout = ms => { const c = new AbortController(); setTimeout(() => c.abort(), ms); return c.signal; }; }
 
-/* ────────────────────────── State ────────────────────────── */
+/* ────────────────────────── state ────────────────────────── */
 let servers = [];
 let endpointsSource = null;
+let snapshotVerified = null;
 let run = null;
 let results = null;
 let compareRun = null;
-let history = loadHistory();
-let mapBuilt = false;
 let geo = null;
+let mapBuilt = false;
+let unitMode = 'mb';
+try { unitMode = localStorage.getItem('coreSpeedUnit') === 'mib' ? 'mib' : 'mb'; } catch (e) {}
 
-/* ────────────────────────── Theme ────────────────────────── */
+function loadHistory() {
+  try { const h = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]'); return Array.isArray(h) ? h : []; } catch (e) { return []; }
+}
+let history = loadHistory();
+
+/* ────────────────────────── theme ────────────────────────── */
 function applyTheme(t) {
   document.documentElement.setAttribute('data-theme', t);
   $('themeBtn').textContent = t === 'dark' ? '◐ Theme' : '◑ Theme';
 }
 (function initTheme() {
   let t = 'dark';
-  try { t = localStorage.getItem('cbTheme') || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'); } catch (e) {}
+  try { t = localStorage.getItem('cbTheme') || (window.matchMedia && window.matchMedia('(prefers-reduced-motion: no-preference)').matches ? (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark') : 'dark'); } catch (e) {}
   applyTheme(t);
 })();
 $('themeBtn').addEventListener('click', () => {
   const t = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-  applyTheme(t); try { localStorage.setItem('cbTheme', t); } catch (e) {}
+  applyTheme(t);
+  try { localStorage.setItem('cbTheme', t); } catch (e) {}
 });
 
-/* ────────────────────────── Endpoint discovery ────────────────────────── */
-async function trySource(src, length) {
-  const url = src === 'worker'
-    ? `${WORKER}/proxy/v1/api/speedtest?host=${encodeURIComponent(API_HOST)}&test_length=${length}`
-    : `${API_HOST}/v1/api/speedtest?test_length=${length}`;
-  try {
-    const r = await fetch(url, { signal: AbortSignal.timeout(8000), cache: 'no-store' });
-    if (!r.ok) return null;
-    const j = await r.json();
-    if (j && Array.isArray(j.data) && j.data.length) return { id: src, data: j.data };
-  } catch (e) { /* next source */ }
-  return null;
+/* ────────────────────────── status bar ────────────────────────── */
+function setStatus(kind, text) {
+  $('statusDot').className = 'dot' + (kind === 'running' ? ' running' : kind === 'done' ? ' done' : kind === 'err' ? ' err' : '');
+  $('statusText').textContent = text;
 }
-
-function normalize(item, longPath) {
-  if (!item || !item.url || !/^https:\/\//i.test(item.url)) return null;
-  const region = /^[a-z]{2,8}$/i.test(item.region || '') ? item.region.toLowerCase() : null;
-  if (!region) return null;
-  const lat = item.coordinates && isFinite(item.coordinates.lat) ? Number(item.coordinates.lat) : null;
-  const lng = item.coordinates && isFinite(item.coordinates.lng) ? Number(item.coordinates.lng) : null;
-  const meta = REGION_META[region] || { label: region.toUpperCase(), city: '—', flag: '🌐', net: 'direct' };
-  const short = String(item.url);
-  return {
-    region, name: String(item.name || item.domain || '').slice(0, 40),
-    urlShort: short,
-    urlLong: longPath ? short.replace(/\/dld\/[^/]+$/i, longPath) : short.replace(/\/dld\/[^/]+$/i, '/dld/1GB.bin'),
-    closest: !!item.closest, lat, lng, meta,
-  };
+function tickStatus() {
+  if (!run) return;
+  const t = now(), started = run.startedAt || t;
+  const elapsed = (t - started) / 1000;
+  $('stElapsed').textContent = elapsed < 60 ? elapsed.toFixed(0) + 's' : (elapsed / 60).toFixed(1) + 'm';
+  $('stData').textContent = fmtBytes(run.totalBytes);
+  $('stBudget').textContent = fmtBytes(Math.max(0, BUDGET_BYTES - run.totalBytes));
+  const done = run.nodes.filter(x => x.status === 'done' || x.status === 'failed' || x.status === 'skipped').length;
+  $('stDone').textContent = `${done}/${run.nodes.length}`;
 }
+setInterval(tickStatus, 1000);
 
-async function loadEndpoints() {
-  setStatus('loading', 'Loading CDN endpoints…');
-  // Parallel discovery: worker proxy and direct API are both put in flight at
-  // once, so a dead source costs one timeout instead of four chained ones.
-  // The worker is preferred, but a worker success returns immediately rather
-  // than waiting on the direct probe it raced — and because the direct probe
-  // was already started, falling back to it adds no latency either.
-  // trySource never rejects (it resolves null on failure), so the unawaited
-  // probe cannot surface as an unhandled rejection.
-  const discover = async (length) => {
-    const worker = trySource('worker', length);
-    const direct = trySource('direct', length);
-    return (await worker) || (await direct);
-  };
-  const [short, long] = await Promise.all([discover('short'), discover('long')]);
-  let list = null;
-  if (short) {
-    const longPath = long && long.data[0] && long.data[0].path ? long.data[0].path : null;
-    list = short.data.map(s => {
-      const l = long ? long.data.find(x => x.region === s.region && x.name === s.name) : null;
-      const n = normalize(s, longPath);
-      if (n && l && l.url) n.urlLong = String(l.url);
-      return n;
-    }).filter(Boolean);
-    endpointsSource = short.id;
-  }
-  if (!list || list.length < 5) {
-    list = SNAPSHOT.data.map(s => normalize({
-      region: s.region, name: s.name, url: s.url,
-      coordinates: { lat: s.lat, lng: s.lng }, closest: !!s.closest,
-    }, null)).filter(Boolean);
-    endpointsSource = 'snapshot';
-  }
-  servers = list;
+/* ────────────────────────── endpoint loading ────────────────────────── */
+function updateEndpointBadge() {
   const badge = $('endpointBadge');
   badge.hidden = false;
-  if (endpointsSource === 'snapshot') {
-    badge.className = 'endpoint-badge snapshot';
-    badge.textContent = `offline snapshot · ${SNAPSHOT.fetched}`;
-    toast('Live endpoint list unreachable — using the embedded snapshot. Redeploy the worker proxy for live updates.');
-  } else {
-    badge.className = 'endpoint-badge live';
-    badge.textContent = endpointsSource === 'worker' ? 'live · via worker' : 'live · direct API';
+  if (endpointsSource === 'worker') { badge.className = 'endpoint-badge live'; badge.textContent = 'live · via worker proxy'; }
+  else if (endpointsSource === 'direct') { badge.className = 'endpoint-badge live'; badge.textContent = 'live · direct API'; }
+  else if (snapshotVerified) { badge.className = 'endpoint-badge verified'; badge.textContent = `snapshot ${SNAPSHOT.fetched} · verified`; }
+  else { badge.className = 'endpoint-badge unverified'; badge.textContent = `snapshot ${SNAPSHOT.fetched} · unverified`; }
+}
+async function loadEndpoints() {
+  setStatus('loading', 'Loading CDN endpoints…');
+  let disc = await discoverLiveOnly();
+  if (!disc) {
+    disc = { source: 'snapshot', list: snapshotList() };
+    const probe = await probeEndpoints(disc.list);
+    snapshotVerified = probe.ok;
+    if (!probe.ok) {
+      toast('Snapshot hosts unreachable — retrying live endpoint list…', 4200);
+      const live = await discoverLiveOnly();
+      if (live) { disc = live; snapshotVerified = null; }
+      else { endpointsSource = 'snapshot'; servers = disc.list; updateEndpointBadge(); renderLiveTable(); updateDataNote(); $('goBtn').disabled = false; setStatus('ready', `${servers.length} CDN endpoints (unverified snapshot) — results may use retired hosts.`); return; }
+    }
   }
+  endpointsSource = disc.source;
+  servers = disc.list;
+  updateEndpointBadge();
   buildAnycastLegend();
   renderLiveTable();
+  updateDataNote();
   $('goBtn').disabled = false;
-  setStatus('ready', `${servers.length} CDN endpoints ready — Sequential mode gives playback-accurate results.`);
+  setStatus('ready', `${servers.length} CDN endpoints ready — Accurate mode is first-byte-anchored, worker-isolated, ${$('repsSel').value === '2' ? 'two-rep' : 'single-rep'}.`);
 }
 
-/* ────────────────────────── Scope ────────────────────────── */
-function selectedServers() {
-  const scope = $('scopeSel').value;
-  if (scope === 'all') return servers.slice();
-  const closest = servers.find(s => s.closest) || servers[0];
-  if (scope === 'closest') return closest ? [closest] : servers.slice(0, 1);
-  if (scope === 'top') {
-    const edge = servers.filter(s => s.meta && s.meta.net !== 'direct');
-    const geo = servers.filter(s => s.meta && s.meta.net === 'direct');
-    const sorted = geo.slice().sort((a, b) => haversine(closest, a) - haversine(closest, b));
-    return [...sorted.slice(0, 8), ...edge];
-  }
-  return servers.slice();
-}
+/* ────────────────────────── scope & preconnect ────────────────────────── */
 function haversine(a, b) {
   if (!a || !b || a.lat == null || b.lat == null) return Infinity;
   const R = 6371, dLa = (b.lat - a.lat) * Math.PI / 180, dLo = (b.lng - a.lng) * Math.PI / 180;
   const s = Math.sin(dLa / 2) ** 2 + Math.cos(a.lat * Math.PI / 180) * Math.cos(b.lat * Math.PI / 180) * Math.sin(dLo / 2) ** 2;
   return R * 2 * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s));
 }
-
-/* ────────────────────────── Status bar ────────────────────────── */
-function setStatus(kind, text) {
-  const dot = $('statusDot'), bar = $('statusBar');
-  dot.className = 'dot' + (kind === 'running' ? ' running' : kind === 'done' ? ' done' : kind === 'err' ? ' err' : '');
-  $('statusText').textContent = text;
+function selectedServers() {
+  const scope = $('scopeSel').value;
+  if (scope === 'all') return servers.slice();
+  const closest = servers.find(s => s.closest) || servers[0];
+  if (scope === 'closest') return closest ? [closest] : servers.slice(0, 1);
+  const edge = servers.filter(s => s.meta && s.meta.net !== 'direct');
+  const geoList = servers.filter(s => s.meta && s.meta.net === 'direct');
+  const sorted = geoList.slice().sort((a, b) => haversine(closest, a) - haversine(closest, b));
+  return [...sorted.slice(0, 8), ...edge];
+}
+function preconnect(list) {
+  const seen = new Set();
+  for (const s of list) {
+    if (seen.size >= 8) break;
+    const h = hostOf(s.urlShort);
+    if (!h || seen.has(h)) continue;
+    seen.add(h);
+    try {
+      const l = document.createElement('link');
+      l.rel = 'preconnect'; l.href = h;
+      document.head.appendChild(l);
+    } catch (e) {}
+  }
 }
 
-/* ────────────────────────── Test engine ────────────────────────── */
-const MODES = {
-  sequential: { label: 'Sequential · single connection', file: false, single: true },
-  burst:      { label: 'Burst race', file: false, single: false },
-  quick:      { label: 'Quick 100 MB', file: true, single: false },
-  full:       { label: 'Full 1 GB', file: true, single: false },
-};
-
-function buildRun() {
+/* ────────────────────────── start / stop ────────────────────────── */
+function buildConfig() {
   const mode = $('modeSel').value;
-  const selected = selectedServers();
-  run = {
+  return {
     mode,
-    streams: mode === 'sequential' ? 1 : Number($('streamsSel').value),
-    burstMs: Number($('durSel').value) * 1000,
-    capMs: mode === 'quick' ? 45000 : mode === 'full' ? 90000 : 0,
-    started: null,
-    current: null,
-    regions: selected.map(s => ({
-      s, status: 'queued', pings: [], ping: null, pingMin: null, jitter: null,
-      bytes: 0, lastBytes: 0, lastT: 0, ewma: 0, samples: [], instantSamples: [],
-      max: 0, startedT: 0, endT: 0, done: false, err: null, abort: null, seqOrder: -1,
-    })),
-    aggSamples: [], totalBytes: 0, lastTick: 0,
-    peak: 0, peakRegion: null, finished: false, partial: false,
-    tick: null, budgetHit: false, _done: false,
+    reps: mode === 'express' ? 1 : Number($('repsSel').value),
+    windowMs: Number($('windowSel').value) * 1000,
+    streams: Number($('streamsSel').value),
+    capBytes: Number($('capSel').value) * 1024 * 1024,
   };
-  results = null;
-  $('resultsCard').hidden = true;
-  $('thDelta').hidden = true;
-  compareRun = null; $('compareSel').value = '';
 }
-
 function startTest() {
   if (!servers.length) { toast('CDN endpoints are not ready yet.'); return; }
-  if (run) stopTest(true);
-  buildRun();
-  const m = MODES[run.mode];
-  setStatus('running', `Pinging ${run.regions.length} CDNs — then ${m.single ? 'testing each node one at a time with a single connection' : `downloading with ${run.streams} streams per node`}.`);
-  $('goBtn').classList.add('stop');
-  $('goBtn').querySelector('span').textContent = 'Stop Test';
-  $('goBtn').querySelector('svg').outerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>';
-  $('refreshBtn').disabled = true;
-  ['modeSel', 'durSel', 'streamsSel', 'scopeSel'].forEach(id => $(id).disabled = true);
-  $('liveBadge').hidden = false;
-  $('gaugeSubLbl').textContent = m.single ? 'current CDN · single connection' : 'aggregate across all CDNs';
-  $('liveSub').textContent = m.single ? "One node at a time — single connection, like TorBox's own test." : 'Every node downloading simultaneously — ranked in real time (contended).';
-  $('stElapsed').textContent = '0s'; $('stData').textContent = '0 MB';
-  $('stDone').textContent = `0/${run.regions.length}`; $('stPeak').textContent = '—';
+  stopTest(true);
+  const cfg = buildConfig();
+  const scope = selectedServers();
+  preconnect(scope);
+  run = buildRun(cfg.mode, scope, cfg);
+  results = null;
+  $('resultsCard').hidden = true;
+  compareRun = null; $('compareSel').value = '';
   resetGauge(); resetSpark();
-  renderLiveTable();
-  updateMap();
-  pingPhase();
-}
-
-function stopTest(fromUI) {
-  if (!run) return;
-  const rn = run;
-  rn.finished = true; rn.partial = true;
-  rn.regions.forEach(r => { if (r.abort) { try { r.abort.abort(); } catch (e) {} } });
-  clearInterval(rn.tick);
-  finishRunFor(rn, fromUI ? 'Stopped — partial results kept.' : null);
-}
-
-/* ── Phase 1: latency (all nodes, 5 HEADs, trimmed mean) ── */
-async function pingPhase() {
-  run.started = now();
-  await Promise.all(run.regions.map(async r => {
-    if (run.finished) return;
-    r.status = 'ping';
-    const url = run.mode === 'full' ? r.s.urlLong : r.s.urlShort;
-    const times = [];
-    for (let i = 0; i < PING_ROUNDS; i++) {
-      if (run.finished) break;
-      const t0 = now();
-      try {
-        const res = await fetch(url, { method: 'HEAD', cache: 'no-store', signal: AbortSignal.timeout(4000) });
-        if (!res.ok) throw new Error('http ' + res.status);
-        times.push(now() - t0);
-      } catch (e) { /* failed round */ }
-    }
-    if (times.length) {
-      r.pings = times;
-      r.pingMin = Math.min(...times);
-      const sorted = times.slice().sort((a, b) => a - b);
-      const trimmed = sorted.length >= PING_ROUNDS ? sorted.slice(1, -1) : sorted;
-      r.ping = mean(trimmed);
-      r.jitter = times.reduce((a, b) => a + Math.abs(b - mean(times)), 0) / times.length;
-    }
-    r.status = run.finished ? r.status : 'dl';
-    renderLiveTable();
-  }));
-  if (!run.finished) {
-    if (run.mode === 'sequential') sequentialPhase();
-    else downloadPhase();
-  }
-}
-
-/* ── Phase 2 (sequential): one node at a time, one connection ── */
-async function sequentialPhase() {
-  const rn = run;
-  rn.lastTick = now();
-  rn.tick = setInterval(tick, 250);   // drives gauge/spark/live stats during the sequential walk
-  const list = rn.regions.filter(r => r.status === 'dl');
-  let idx = 0;
-  for (const r of list) {
-    if (rn.finished) break;
-    r.seqOrder = idx++;
-    rn.current = r;
-    r.status = 'dl';
-    r.startedT = now();
-    setStatus('running', `Testing ${r.s.meta.flag} ${r.s.meta.label} — single connection (${idx}/${list.length}).`);
-    renderLiveTable(); updateMap();
-    await singleStreamTest(rn, r);
-    r.endT = now();
-    // Hitting the 10 s cap is a good sample and sets r.capped, not r.err — but a
-    // node that transferred some bytes and then genuinely failed is NOT done, or
-    // it would earn a playback verdict from a truncated sample.
-    r.done = r.bytes > 0 && !r.err;
-    r.status = r.done ? 'done' : 'err';
-    rn.current = null;
-    if (!rn.finished) {
-      const doneCount = rn.regions.filter(x => x.status === 'done' || x.status === 'err').length;
-      const avgPer = (now() - rn.started) / Math.max(1, doneCount);
-      const remaining = Math.max(0, (rn.regions.length - doneCount) * avgPer / 1000);
-      const next = list[idx];
-      setStatus('running', next
-        ? `Next: ${next.s.meta.flag} ${next.s.meta.label} — ${Math.round(remaining)}s remaining.`
-        : 'Finishing up…');
-      renderLiveTable(); updateMap();
-    }
-    await new Promise(res => setTimeout(res, 350));
-  }
-  rn.regions.forEach(r => { if (r.status === 'queued' || r.status === 'ping') { r.status = 'err'; r.err = 'skipped'; } });
-  if (!rn.finished) { rn.finished = true; finishRunFor(rn, null); }
-}
-
-async function singleStreamTest(rn, r) {
-  const url = r.s.urlShort;
-  r.abort = new AbortController();
-  const capTimer = setTimeout(() => { try { r.abort.abort(); } catch (e) {} }, SEQ_CAP_MS);
-  const sampler = setInterval(() => {
-    if (rn.finished || r.status !== 'dl') return;
-    const t = now();
-    if (r.lastT === 0) { r.lastT = t; r.lastBytes = r.bytes; return; }   // baseline: skip the buffered first interval
-    const dt = Math.max(0.05, (t - r.lastT) / 1000);
-    const inst = Math.max(0, (r.bytes - r.lastBytes) / dt * 8 / 1e6);
-    r.ewma = r.ewma ? r.ewma * 0.65 + inst * 0.35 : inst;
-    r.max = Math.max(r.max, inst);
-    r.samples.push({ t: t - r.startedT, v: r.ewma });
-    r.instantSamples.push(inst);
-    r.lastBytes = r.bytes; r.lastT = t;
-  }, 250);
-  try {
-    const res = await fetch(url, { cache: 'no-store', signal: r.abort.signal });
-    if (!res.ok || !res.body) throw new Error('http ' + (res.status || 'err'));
-    const reader = res.body.getReader();
-    while (true) {
-      if (r.abort.signal.aborted) break;
-      const { done, value } = await reader.read();
-      if (done) break;
-      r.bytes += value.byteLength;
-    }
-    r.completedFile = !r.abort.signal.aborted;
-  } catch (e) {
-    if (!rn.finished) {
-      if (e && e.name === 'AbortError') r.capped = true;   // hit the 10s cap — a successful measurement
-      else r.err = String(e.message || 'failed');
-    }
-  }
-  clearInterval(sampler); clearTimeout(capTimer);
-}
-
-/* ── Phase 2 (concurrent race): all nodes at once, N streams ── */
-function downloadPhase() {
-  const rn = run;
-  const fileMode = MODES[rn.mode].file;
-  rn.regions.forEach(r => { if (r.status === 'dl') startRegionDownload(r); });
-  rn.lastTick = now();
-  rn.regions.forEach(r => { r.lastT = 0; });
-  rn.tick = setInterval(tick, 250);
-  if (!fileMode) {
-    setTimeout(() => { if (rn && !rn.finished) { rn.finished = true; rn.partial = false; finishRunFor(rn, null); } }, rn.burstMs);
-  } else {
-    setTimeout(() => {
-      if (rn && !rn.finished) {
-        rn.regions.forEach(r => { if (r.status === 'dl') { r.status = 'done'; r.done = true; r.err = 'cap'; if (r.abort) { try { r.abort.abort(); } catch (e) {} } } });
-        rn.finished = true; finishRunFor(rn, null);
-      }
-    }, rn.capMs);
-  }
-}
-
-function startRegionDownload(r) {
-  const rn = run;
-  r.startedT = now();
-  r.abort = new AbortController();
-  const url = rn.mode === 'full' ? r.s.urlLong : r.s.urlShort;
-  const jobs = [];
-  for (let i = 0; i < rn.streams; i++) jobs.push(streamLoop(rn, r, url, r.abort.signal));
-  Promise.allSettled(jobs).then(() => {
-    r.endT = now();
-    if (rn.finished) return;
-    r.status = 'done'; r.done = true;
-    const doneCount = rn.regions.filter(x => x.status === 'done' || x.status === 'err').length;
-    if (doneCount >= rn.regions.length) { rn.finished = true; finishRunFor(rn, null); }
-  });
-}
-
-async function streamLoop(rn, r, url, signal) {
-  try {
-    const res = await fetch(url, { cache: 'no-store', signal });
-    if (!res.ok || !res.body) throw new Error('http ' + res.status);
-    const reader = res.body.getReader();
-    while (true) {
-      if (signal.aborted) return;
-      const { done, value } = await reader.read();
-      if (done) return;
-      r.bytes += value.byteLength;
-    }
-  } catch (e) {
-    if (!rn.finished) { r.status = 'err'; r.err = String(e && e.name === 'AbortError' ? 'aborted' : (e.message || 'failed')); }
-  }
-}
-
-/* ── Live tick (UI sampling) ── */
-function tick() {
-  const rn = run;
-  const t = now(), dt = Math.max(1, t - rn.lastTick);
-  rn.lastTick = t;
-  const sum = rn.regions.reduce((a, r) => a + r.bytes, 0);
-  rn.totalBytes = sum;
-  if (rn.totalBytes > DATA_BUDGET_BYTES && !rn.budgetHit) {
-    rn.budgetHit = true; rn.partial = true; rn.finished = true;
-    clearInterval(rn.tick);
-    rn.regions.forEach(x => { if (x.abort) { try { x.abort.abort(); } catch (e) {} } });
-    finishRunFor(rn, 'Hit the 12 GB data budget — stopping early.');
-    return;
-  }
-  let agg = 0, doneCount = 0;
-  if (rn.mode === 'sequential') {
-    const cur = rn.current;
-    if (cur && cur.status === 'dl') agg = cur.ewma;
-  } else {
-    rn.regions.forEach(r => {
-      if (r.status === 'dl') {
-        if (r.lastT === 0) { r.lastT = t; r.lastBytes = r.bytes; return; }   // baseline: skip the buffered first interval
-        const inst = Math.max(0, (r.bytes - r.lastBytes) / dt * 1000 * 8 / 1e6);
-        r.ewma = r.ewma ? r.ewma * 0.65 + inst * 0.35 : inst;
-        r.max = Math.max(r.max, inst);
-        if (t - r.lastT >= 400) {
-          r.samples.push({ t: t - rn.started, v: r.ewma });
-          r.instantSamples.push(inst);
-          r.lastT = t;
-        }
-        agg += inst;
-        r.lastBytes = r.bytes;
+  $('liveBadge').hidden = false;
+  $('gaugeSubLbl').textContent = cfg.mode === 'capacity' ? 'aggregate across all CDNs (N connections each)' : 'current CDN · single connection';
+  $('liveSub').textContent = cfg.mode === 'capacity'
+    ? `${cfg.streams} real parallel connections per node, ${cfg.windowMs / 1000} s window — pipe capacity, not a playback verdict.`
+    : `One node at a time · first-byte-anchored ${cfg.windowMs / 1000} s window${cfg.reps > 1 ? ' · 2 reps, median steady' : ''}.`;
+  $('stElapsed').textContent = '0s'; $('stData').textContent = '0 MB'; $('stBudget').textContent = fmtBytes(BUDGET_BYTES);
+  $('stDone').textContent = `0/${run.nodes.length}`; $('stPeak').textContent = '—'; $('stEta').textContent = '—';
+  renderLiveTable(); updateMap();
+  let warnedHidden = false;
+  const hooks = {
+    onStatus: (text) => setStatus('running', text),
+    onNodeState: (node) => { renderLiveTable(); updateMap(); },
+    onProgress: (node, rep, d) => { updateLiveGauge(run.cfg.mode === 'capacity' ? 0 : node.repLive); },
+    onCapProgress: (node, d) => { updateLiveGauge(capacityAggregate()); },
+  };
+  const go = cfg.mode === 'capacity' ? runCapacity(run, hooks) : runAccurate(run, hooks);
+  go.catch((e) => { toast('Run error: ' + (e && e.message ? e.message : 'unknown')); })
+    .finally(() => {
+      if (run && !run.finished) {
+        run.finished = true;
+        run.finishedAt = now();
+        finishRunFor(run, run.aborted ? 'Stopped — partial results kept.' : null);
       }
     });
-  }
-  rn.aggSamples.push({ t: t - rn.started, v: agg });
-  if (rn.aggSamples.length > SAMPLE_WINDOW) rn.aggSamples.shift();
-  if (agg > rn.peak) { rn.peak = agg; rn.peakRegion = topRegion(); }
-  const elapsed = (t - rn.started) / 1000;
-  $('stElapsed').textContent = elapsed < 60 ? elapsed.toFixed(0) + 's' : (elapsed / 60).toFixed(1) + 'm';
-  $('stData').textContent = fmtBytes(rn.totalBytes);
-  rn.regions.forEach(r => { if (r.status === 'done' || r.status === 'err') doneCount++; });
-  $('stDone').textContent = `${doneCount}/${rn.regions.length}`;
-  if (rn.mode === 'sequential') {
-    const cur = rn.current;
-    $('stPeak').textContent = fmtMbps(rn.peak);
-    $('sPeak').innerHTML = fmtMbps(rn.peak) + '<small> Mbps</small>';
-    if (cur && cur.status === 'dl') {
-      updateGauge(cur.ewma);
-      pushSpark(cur.ewma);
-      $('sparkNow').innerHTML = fmtMbps(cur.ewma) + ' <small>Mbps</small>';
-      $('gaugeFastest').textContent = `now · ${cur.s.meta.flag} ${cur.s.meta.label}`;
-      $('sBest').textContent = cur.s.meta.flag + ' ' + cur.s.meta.label;
+  document.addEventListener('visibilitychange', function vc() {
+    if (document.hidden && run && !run.finished && !warnedHidden) {
+      warnedHidden = true;
+      toast('Keep this page visible — backgrounded tabs can be throttled by the OS.');
     }
-  } else {
-    updateGauge(agg);
-    pushSpark(agg);
-    $('sparkNow').innerHTML = fmtMbps(agg) + ' <small>Mbps</small>';
-    $('sPeak').innerHTML = fmtMbps(rn.peak) + '<small> Mbps</small>';
-    const tr = topRegion();
-    if (tr) { $('gaugeFastest').textContent = `fastest now · ${tr.s.meta.flag} ${tr.s.meta.label}`; $('sBest').textContent = tr.s.meta.flag + ' ' + tr.s.meta.label; }
-  }
-  const pings = rn.regions.filter(r => r.ping != null).map(r => r.ping);
-  if (pings.length) {
-    $('sLatency').innerHTML = Math.min(...pings) + '<small> ms</small>';
-    $('sLatencyWorst').innerHTML = Math.max(...pings) + '<small> ms</small>';
-  }
-  renderLiveTable();
-  updateMap();
-  if (rn.mode !== 'sequential') buildAnycastLegend();
-}
-
-function topRegion() {
-  let best = null;
-  run.regions.forEach(r => { if (r.status === 'dl' && r.ewma > 0 && (!best || r.ewma > best.ewma)) best = r; });
-  return best;
-}
-
-/* ── Finish ── */
-function finishRun(note) {
-  if (run._done) return; run._done = true;
-  clearInterval(run.tick);
-  run.regions.forEach(r => { if (r.abort) { try { r.abort.abort(); } catch (e) {} } });
-  const t = now();
-  run.elapsed = (t - run.started) / 1000;
-  const isSingle = run.mode === 'sequential' || run.streams === 1;
-  run.regions.forEach(r => {
-    if (!r.endT && r.done) r.endT = t;
-    const dur = Math.max(0.05, r.done && r.endT ? (r.endT - (r.startedT || run.started)) / 1000 : run.elapsed);
-    r.sustained = r.bytes * 8 / 1e6 / dur;
-    const steady = r.instantSamples.filter((_, i) => r.samples[i] && r.samples[i].t > 2000);  // post slow-start
-    const insts = steady.length >= 3 ? steady : (r.instantSamples.length ? r.instantSamples : [r.sustained]);
-    const m = mean(insts);
-    const sd = Math.sqrt(insts.reduce((a, b) => a + (b - m) ** 2, 0) / insts.length);
-    r.stability = m > 0 ? Math.max(0, Math.min(1, 1 - sd / m)) : 0;
-    if (r.status === 'dl') { r.status = r.bytes > 0 ? 'done' : 'err'; r.done = r.bytes > 0; }
-    if ((r.status === 'queued' || r.status === 'ping') && run.partial) { r.status = 'err'; r.err = 'skipped'; }
-    if (r.bytes === 0 && !r.ping) { r.status = 'err'; r.err = r.err || 'no response'; }
-    if (run.partial && r.bytes === 0 && !r.err) { r.err = 'skipped'; }
-    // Playback verdicts only from single-connection data.
-    if (isSingle && r.sustained > 0) {
-      const base = r.sustained * 0.85;
-      let v = base >= 150 ? ['v4k', '4K Remux ready'] : base >= 60 ? ['v4k', '4K streaming'] :
-        base >= 25 ? ['vq', '1080p Remux / 4K'] : base >= 8 ? ['vf', '1080p'] : base >= 4 ? ['vf', '720p'] : ['vs', 'SD only'];
-      if (r.ping != null && r.ping > 400) v = ['vs', 'SD — very high latency'];
-      else if (r.ping != null && r.ping > 250) v = base >= 8 ? ['vf', '1080p max — high latency'] : ['vs', 'SD — high latency'];
-      r.verdict = v;
-      r.streamable = base;
-    } else {
-      r.verdict = null;
-      r.streamable = null;
-    }
+    if (!document.hidden) document.removeEventListener('visibilitychange', vc);
   });
-  const ranked = run.regions.filter(r => r.sustained > 0).sort((a, b) => b.sustained - a.sustained);
-  ranked.forEach((r, i) => { r.rank = i + 1; });
-  if (ranked.length) $('sBest').textContent = ranked[0].s.meta.flag + ' ' + ranked[0].s.meta.label;
-  run.totalBytes = run.regions.reduce((a, r) => a + r.bytes, 0);
+}
+function stopTest(fromUI) {
+  if (!run || run.finished) return;
+  run.aborted = true;
+  Engine.stopAll();
+  if (fromUI) setStatus('running', 'Stopping — collecting partial results…');
+}
+$('goBtn').addEventListener('click', () => { if (run && !run.finished) stopTest(true); else startTest(); });
+
+function capacityAggregate() {
+  if (!run) return 0;
+  let s = 0;
+  run.nodes.forEach(n => { s += n.capLive || 0; });
+  return s;
+}
+
+/* ────────────────────────── finish ────────────────────────── */
+function finishRunFor(runObj, note) {
+  if (runObj._done) return;
+  runObj._done = true;
+  runObj.finished = true;
+  if (!runObj.finishedAt) runObj.finishedAt = now();
+  const { ranked, failed } = summarizeRun(runObj);
   results = {
-    id: Date.now(), ts: new Date().toISOString(), mode: run.mode, streams: run.streams,
-    source: endpointsSource, dataBytes: run.totalBytes, elapsed: run.elapsed, partial: !!run.partial,
-    budgetHit: !!run.budgetHit, peak: run.peak, single: isSingle, regions: ranked,
+    id: runObj.id, ts: new Date().toISOString(),
+    mode: runObj.cfg.mode, cfg: runObj.cfg,
+    source: endpointsSource, dataBytes: runObj.totalBytes,
+    elapsed: (runObj.finishedAt - runObj.startedAt) / 1000,
+    partial: !!runObj.aborted, unit: unitMode,
+    ranked, failed,
   };
   saveToHistory(results);
   renderResults();
-  setStatus(results.regions.length ? 'done' : 'err', note || `Done in ${results.elapsed.toFixed(1)}s — ${results.regions.length} CDN${results.regions.length === 1 ? '' : 's'} measured, ${fmtBytes(results.dataBytes)} used.`);
-  $('goBtn').disabled = false; $('goBtn').classList.remove('stop');
-  $('goBtn').querySelector('span').textContent = 'Start Test';
-  $('goBtn').querySelector('svg').outerHTML = '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>';
-  $('refreshBtn').disabled = false;
-  ['modeSel', 'durSel', 'streamsSel', 'scopeSel'].forEach(id => $(id).disabled = false);
-  applyModeDisabled();
-  $('liveBadge').hidden = true;
-  $('liveSub').textContent = 'One node at a time in Sequential mode — ranked when finished.';
-  renderLiveTable();   // final states (done/err/skipped) — the throttled renderer skips mid-run frames
+  renderLiveTable();
   updateMap(true);
   renderHistory();
+  const best = ranked[0];
+  setStatus(ranked.length ? 'done' : 'err',
+    note || (ranked.length
+      ? `Done in ${results.elapsed.toFixed(0)}s — ${ranked.length} CDN${ranked.length === 1 ? '' : 's'} measured, ${fmtBytes(results.dataBytes)} used. Best: ${regionLabel(best.s)} at ${fmtMbps(best.steady)} steady.`
+      : 'No node produced a valid measurement — check network/DNS and retry.'));
+  $('goBtn').disabled = false;
+  $('goBtn').classList.remove('stop');
+  $('goBtn').querySelector('span').textContent = 'Start Test';
+  $('refreshBtn').disabled = false;
+  ['modeSel', 'repsSel', 'windowSel', 'streamsSel', 'capSel', 'scopeSel'].forEach(id => { $(id).disabled = false; });
+  applyModeDisabled();
+  $('liveBadge').hidden = true;
 }
 
-function finishRunFor(rn, note) {
-  const saved = run; run = rn; try { finishRun(note); } finally { run = saved; }
-}
-
-/* ────────────────────────── Live table ────────────────────────── */
+/* ────────────────────────── live table ────────────────────────── */
 function regionLabel(s) {
   const m = s.meta || REGION_META[s.region] || {};
-  return m.flag ? `${m.flag} ${m.label}` : m.label;
+  return m.flag ? `${m.flag} ${m.label}` : (m.label || s.region);
 }
 function regionCity(s) {
   const m = s.meta || {};
   const net = m.net && m.net !== 'direct' ? ' · ' + m.net : '';
   return (m.city || '—') + net;
 }
-
+function statusChip(node) {
+  switch (node.status) {
+    case 'queued': return '<span class="chip-mini">waiting</span>';
+    case 'ping': return '<span class="chip-mini run">ping</span>';
+    case 'rep1': return '<span class="chip-mini run">● rep 1</span>';
+    case 'rep2': return '<span class="chip-mini run">● rep 2</span>';
+    case 'race': return `<span class="chip-mini run">● ${run ? run.cfg.streams : ''}× race</span>`;
+    case 'done': return node.budgetReps ? '<span class="chip-mini ok">✓ 1 rep (budget)</span>' : (node.reps && node.reps.length === 2 && run && run.cfg.mode !== 'capacity' ? '<span class="chip-mini ok">✓ 2 reps</span>' : '<span class="chip-mini ok">✓ done</span>');
+    case 'skipped': return `<span class="chip-mini" title="${esc(node.err || '')}">⏭ skipped</span>`;
+    case 'failed': return `<span class="chip-mini bad" title="${esc(node.err || '')}">✕ ${esc((node.err || 'failed').slice(0, 14))}</span>`;
+    default: return '<span class="chip-mini">idle</span>';
+  }
+}
+function repLabel(node) {
+  if (run && run.cfg.mode === 'capacity') return node.status === 'done' ? `${node.reps.length}×` : (node.status === 'race' ? `${run.cfg.streams}×` : '—');
+  const doneReps = node.reps.length;
+  if (node.status === 'rep1') return 'R1…';
+  if (node.status === 'rep2') return 'R2…';
+  if (node.status === 'done') return node.budgetReps ? '1/2' : `${doneReps}/${run ? run.cfg.reps : doneReps}`;
+  return doneReps ? `${doneReps}` : '—';
+}
 let lastTableRender = 0;
 function renderLiveTable() {
   const t = now();
   const hasRun = run && !run.finished;
-  if (hasRun && t - lastTableRender < 150) return;
+  if (hasRun && t - lastTableRender < 250) return;
   lastTableRender = t;
   const body = $('liveBody');
   let list;
-  if (run && run.mode === 'sequential') {
-    list = run.regions.slice().sort((a, b) => {
-      const order = r => r.status === 'dl' ? -2 : (r.status === 'done' || r.status === 'err') ? r.seqOrder : 1e6;
+  if (run && run.cfg.mode !== 'capacity') {
+    list = run.nodes.slice().sort((a, b) => {
+      const order = (x) => x.status === 'rep1' || x.status === 'rep2' ? -2 : (x.status === 'done' || x.status === 'failed' || x.status === 'skipped') ? (x.rank || 99) : (x.ping == null ? 1e9 : x.ping);
       return order(a) - order(b);
     });
+  } else if (run) {
+    list = run.nodes.slice().sort((a, b) => (b.status === 'race' ? b.capLive : b.steady || 0) - (a.status === 'race' ? a.capLive : a.steady || 0));
   } else {
-    list = run ? run.regions.slice().sort((a, b) => {
-      const sa = a.status === 'dl' ? a.ewma : a.status === 'done' ? (a.sustained || 0) : -1;
-      const sb = b.status === 'dl' ? b.ewma : b.status === 'done' ? (b.sustained || 0) : -1;
-      return sb - sa;
-    }) : servers.map(s => ({ s, status: 'idle', ping: null, ewma: 0, max: 0 }));
+    list = servers.map(s => ({ s, status: 'idle', ping: null, ttfb: null, repLive: 0, capLive: 0, reps: [], err: null }));
   }
-  const maxEwma = Math.max(1, ...list.map(r => r.ewma || 0));
-  if (hasRun && run.mode !== 'sequential') buildAnycastLegend();
+  const maxV = Math.max(10, ...list.map(x => (x.status === 'done' ? (x.steady || 0) : (x.repLive || x.capLive || 0))));
   body.innerHTML = list.map((r, i) => {
     const st = r.status;
-    const chip = st === 'queued' ? '<span class="chip-mini">waiting</span>'
-      : st === 'ping' ? '<span class="chip-mini run">ping</span>'
-      : st === 'dl' ? '<span class="chip-mini run">● testing</span>'
-      : st === 'done' ? `<span class="chip-mini ok"${r.capped ? ' title="measured for 10 s, then capped — good sample"' : ''}>✓ done</span>`
-      : st === 'err' ? `<span class="chip-mini bad" title="${esc(r.err || '')}">✕ ${esc((r.err || 'failed').slice(0, 12))}</span>`
-      : '<span class="chip-mini">idle</span>';
-    const pingTxt = r.ping != null ? fmtMs(r.ping) : st === 'ping' ? '…' : '—';
-    const pct = st === 'dl' || st === 'done' ? Math.min(100, (r.ewma || r.sustained || 0) / maxEwma * 100) : 0;
-    const speedTxt = st === 'dl' ? fmtMbps(r.ewma) : st === 'done' && r.sustained ? fmtMbps(r.sustained) : '—';
-    const maxTxt = r.max > 0 ? fmtMbps(r.max) : '—';
-    const cls = ['row', st === 'err' ? 'row-err' : '', st === 'done' ? 'row-done' : '', i === 0 && (st === 'dl' || st === 'done') ? 'rank-1' : ''].join(' ').trim();
+    const live = st === 'done' ? (r.steady || 0) : (r.repLive || r.capLive || 0);
+    const pct = (st === 'done' || st === 'rep1' || st === 'rep2' || st === 'race') ? Math.min(100, live / maxV * 100) : 0;
+    const cls = ['row', st === 'failed' ? 'row-err' : '', st === 'done' ? 'row-done' : '', st === 'skipped' ? 'row-skip' : '', i === 0 && (st === 'done' || st === 'rep1' || st === 'rep2' || st === 'race') ? 'rank-1' : ''].join(' ').trim();
+    const speedTxt = st === 'done' ? fmtMbps(r.steady) : (live > 0 ? fmtMbps(live) : '—');
     return `<tr class="${cls}">
-      <td class="rank-num">${i + 1}</td>
+      <td class="rank-num">${r.rank || (i + 1)}</td>
       <td><div class="reg-name"><span class="n"><span class="fl">${esc(regionLabel(r.s))}</span>${r.s.closest ? '<span class="chip-mini run">closest</span>' : ''}${r.s.meta && r.s.meta.net && r.s.meta.net !== 'direct' ? `<span class="chip-mini">${esc(r.s.meta.net)}</span>` : ''}</span><span class="c">${esc(regionCity(r.s))}</span></div></td>
-      <td style="color:var(--th-tx2)">${pingTxt}</td>
-      <td class="speed-bar-cell"><div style="display:flex;align-items:center;gap:8px"><div class="speed-bar"><i style="width:${pct}%"></i></div><span class="speed-num">${speedTxt}<small> / ${maxTxt}</small></span></div></td>
-      <td>${chip}</td>
+      <td style="color:var(--th-tx2)">${r.ping != null ? Math.round(r.ping) + ' ms' : (st === 'ping' ? '…' : '—')}${r.jitter ? ` <small style="color:var(--th-tx4)">±${Math.round(r.jitter)}</small>` : ''}</td>
+      <td style="color:var(--th-tx3)">${r.ttfb != null ? Math.round(r.ttfb) + ' ms' : '—'}</td>
+      <td class="speed-bar-cell"><div style="display:flex;align-items:center;gap:8px"><div class="speed-bar"><i style="width:${pct.toFixed(1)}%"></i></div><span class="speed-num">${speedTxt}</span></div></td>
+      <td><span class="mini-reps">${repLabel(r)}</span></td>
+      <td class="cell-status">${statusChip(r)}</td>
     </tr>`;
   }).join('');
 }
 
-/* ────────────────────────── Gauge ────────────────────────── */
+/* ────────────────────────── gauge ────────────────────────── */
 const GAUGE = { cx: 120, cy: 96, R: 88, start: -120, sweep: 240 };
 function ptOnArc(p, r) {
   const a = (GAUGE.start + GAUGE.sweep * p) * Math.PI / 180;
@@ -1153,17 +1500,16 @@ function arcPath(r) {
 const LOG_MAX = Math.log10(10000), LOG_MIN = Math.log10(1);
 function logP(mbps) { return Math.max(0, Math.min(1, (Math.log10(Math.max(1, mbps)) - LOG_MIN) / (LOG_MAX - LOG_MIN))); }
 const TICK_VALUES = [1, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
-function tickLabel(v) { return v >= 1000 ? (v / 1000).toFixed(v % 1000 ? 1 : 0) + 'k' : String(v); }
-
 function buildGauge() {
-  $('zoneArc').setAttribute('d', arcPath(GAUGE.R));
   $('zoneTrack').setAttribute('d', arcPath(GAUGE.R));
+  $('zoneArc').setAttribute('d', arcPath(GAUGE.R));
   $('gaugeTicks').innerHTML = TICK_VALUES.map(v => {
     const p = logP(v);
     const [x0, y0] = ptOnArc(p, GAUGE.R - 8), [x1, y1] = ptOnArc(p, GAUGE.R + 1);
     const [lx, ly] = ptOnArc(p, GAUGE.R - 20);
+    const lbl = v >= 1000 ? (v / 1000).toFixed(v % 1000 ? 1 : 0) + 'k' : String(v);
     return `<line x1="${x0.toFixed(1)}" y1="${y0.toFixed(1)}" x2="${x1.toFixed(1)}" y2="${y1.toFixed(1)}" stroke="var(--th-tx4)" stroke-width="1.5"/>
-      <text x="${lx.toFixed(1)}" y="${(ly + 3).toFixed(1)}" text-anchor="middle" font-size="8.5" fill="var(--th-tx4)" font-weight="700">${tickLabel(v)}</text>`;
+      <text x="${lx.toFixed(1)}" y="${(ly + 3).toFixed(1)}" text-anchor="middle" font-size="8.5" fill="var(--th-tx4)" font-weight="700">${lbl}</text>`;
   }).join('');
   resetGauge();
 }
@@ -1182,27 +1528,60 @@ function setNeedle(p) {
 function updateGauge(mbps) {
   const p = logP(mbps);
   setNeedle(p);
-  const el = $('gaugeValue');
-  el.innerHTML = mbps >= 1000
+  $('gaugeValue').innerHTML = mbps >= 1000
     ? (mbps / 1000).toFixed(2) + '<span class="unit">Gbps</span>'
     : Math.round(mbps) + '<span class="unit">Mbps</span>';
 }
+let lastGaugeAt = 0;
+function updateLiveGauge(v) {
+  const t = now();
+  if (t - lastGaugeAt < 150) return;   // UI-only throttle; measurement is unaffected (worker)
+  lastGaugeAt = t;
+  v = isFinite(v) && v > 0 ? v : 0;
+  updateGauge(v);
+  pushSpark(v);
+  $('sparkNow').innerHTML = fmtMbps(v) + ' <small></small>';
+  if (run) {
+    const peaks = run.nodes.map(n => n.peak || 0).concat([v]).filter(x => x > 0);
+    const peak = peaks.length ? Math.max(...peaks) : 0;
+    if (peak > 0) { $('stPeak').textContent = fmtMbps(peak); $('sPeak').innerHTML = fmtMbps(peak) + '<small> Mbps</small>'; }
+    const pings = run.nodes.filter(x => x.ping != null).map(x => x.ping);
+    if (pings.length) {
+      $('sLatency').innerHTML = Math.round(Math.min(...pings)) + '<small> ms</small>';
+      $('sLatencyWorst').innerHTML = Math.round(Math.max(...pings)) + '<small> ms</small>';
+    }
+    let bestName = '—';
+    if (run.cfg.mode === 'capacity') {
+      const cur = run.nodes.filter(n => n.status === 'race' || n.status === 'done').sort((a, b) => ((b.status === 'race' ? b.capLive : b.steady) || 0) - ((a.status === 'race' ? a.capLive : a.steady) || 0))[0];
+      if (cur) bestName = `${regionLabel(cur.s)} (${run.cfg.mode === 'capacity' ? 'live/total' : 'steady'})`;
+    } else if (run.nodes.some(n => n.status === 'rep1' || n.status === 'rep2')) {
+      const cur = run.nodes.find(n => n.status === 'rep1' || n.status === 'rep2');
+      if (cur) bestName = `now · ${regionLabel(cur.s)}`;
+    } else {
+      const done = run.nodes.filter(n => n.status === 'done').sort((a, b) => b.steady - a.steady)[0];
+      if (done) bestName = `${regionLabel(done.s)} (best)`;
+    }
+    $('gaugeFastest').textContent = bestName;
+    $('sBest').textContent = bestName;
+  }
+}
 
-/* ────────────────────────── Sparkline ────────────────────────── */
+/* ────────────────────────── sparkline ────────────────────────── */
 let sparkSamples = [];
 function resetSpark() { sparkSamples = []; drawSpark(); }
 function pushSpark(v) {
-  sparkSamples.push({ t: now(), v });
-  const cutoff = now() - 60000;
+  const t = now();
+  sparkSamples.push({ t, v });
+  const cutoff = t - 60000;
   while (sparkSamples.length && sparkSamples[0].t < cutoff) sparkSamples.shift();
-  if (sparkSamples.length > SAMPLE_WINDOW) sparkSamples.shift();
+  if (sparkSamples.length > 240) sparkSamples.shift();
   drawSpark();
 }
 function drawSpark() {
   const cv = $('sparkCanvas');
   const dpr = window.devicePixelRatio || 1;
   const W = cv.clientWidth || 300, H = cv.clientHeight || 74;
-  if (cv.width !== W * dpr) { cv.width = W * dpr; cv.height = H * dpr; }
+  if (cv.width !== Math.round(W * dpr)) { cv.width = Math.round(W * dpr); cv.height = Math.round(H * dpr); }
   const ctx = cv.getContext('2d');
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, W, H);
@@ -1214,8 +1593,8 @@ function drawSpark() {
   let maxV = 10;
   sparkSamples.forEach(s => { if (s.v > maxV) maxV = s.v; });
   maxV = niceMax(maxV * 1.12);
-  const X = s => (s.t - t0) / Math.max(1, t1 - t0) * W;
-  const Y = s => H - 4 - (s.v / maxV) * (H - 8);
+  const X = (s) => (s.t - t0) / Math.max(1, t1 - t0) * W;
+  const Y = (s) => H - 4 - (s.v / maxV) * (H - 8);
   ctx.strokeStyle = 'rgba(128,128,128,.15)'; ctx.lineWidth = 1;
   [0.25, 0.5, 0.75].forEach(f => { ctx.beginPath(); ctx.moveTo(0, H - (H * f)); ctx.lineTo(W, H - (H * f)); ctx.stroke(); });
   ctx.beginPath();
@@ -1236,10 +1615,8 @@ function niceMax(v) {
   return m * base;
 }
 
-/* ────────────────────────── World map ────────────────────────── */
-function proj(lat, lng) {
-  return { x: (lng + 180) / 360 * 1000, y: (90 - lat) / 180 * 500 };
-}
+/* ────────────────────────── world map (rebuilds only on state change) ────────────────────────── */
+function proj(lat, lng) { return { x: (lng + 180) / 360 * 1000, y: (90 - lat) / 180 * 500 }; }
 function buildMap() {
   if (mapBuilt) return;
   const svg = $('mapSvg');
@@ -1247,40 +1624,39 @@ function buildMap() {
     <g id="mapNodes"></g><g id="mapYou"></g>`;
   mapBuilt = true;
 }
-function nodeColor(r) {
-  if (r.status === 'err') return '#f87171';
-  const v = r.sustained || r.ewma || 0;
+function nodeColor(v) {
+  if (v == null) return '#5b6b83';
   if (v >= 150) return '#34d399';
   if (v >= 60) return '#00d4ff';
   if (v >= 25) return '#5aa9ff';
   if (v >= 8) return '#a78bfa';
-  return '#5b6b83';
+  return '#8b949e';
 }
 function updateMap(final) {
   if (!servers.length) return;
   buildMap();
   const g = document.getElementById('mapNodes');
   if (!g) return;
-  const active = run ? run.regions : [];
-  const rowFor = s => active.find(r => r.s.region === s.region && r.s.name === s.name);
   g.innerHTML = '';
+  const active = run ? run.nodes : [];
   servers.forEach(s => {
     if (s.lat == null || s.lng == null) return;
-    if (s.meta && s.meta.net && s.meta.net !== 'direct') return;   // edge/anycast live in the legend, not the map
+    if (s.meta && s.meta.net && s.meta.net !== 'direct') return;
+    const r = active.find(x => x.s === s);
+    const failed = r && r.status === 'failed';
+    const value = failed ? null : (r ? (r.steady != null ? r.steady : (r.repLive || r.capLive || 0)) : null);
     const p = proj(s.lat, s.lng);
-    const r = rowFor(s);
-    const value = r ? (r.sustained || r.ewma || 0) : 0;
-    const rad = value > 0 ? 5 + 8 * Math.min(1, Math.log10(1 + value) / Math.log10(1 + 1000)) : 4.5;
-    const color = r ? nodeColor(r) : '#5b6b83';
-    const testing = r && (r.status === 'dl' || r.status === 'ping');
-    const won = results && results.regions.length && results.regions[0].s.region === s.region && results.regions[0].s.name === s.name;
-    g.insertAdjacentHTML('beforeend', `<circle cx="${p.x}" cy="${p.y}" r="${rad.toFixed(1)}" fill="${color}" opacity="${r ? .95 : .55}" class="map-node">
-        ${testing ? `<circle class="pulse" cx="${p.x}" cy="${p.y}" r="${rad.toFixed(1)}" fill="none" stroke="${color}" stroke-width="1.6"/>` : ''}
-        ${won ? `<circle cx="${p.x}" cy="${p.y}" r="${(rad + 5).toFixed(1)}" fill="none" stroke="#fbbf24" stroke-width="1.8" opacity=".9"/>` : ''}
+    const rad = value != null && value > 0 ? 5 + 8 * Math.min(1, Math.log10(1 + value) / Math.log10(1 + 1000)) : 4.5;
+    const color = failed ? '#f87171' : nodeColor(value);
+    const testing = r && (r.status === 'rep1' || r.status === 'rep2' || r.status === 'race' || r.status === 'ping');
+    const won = final && results && results.ranked.length && results.ranked[0].s === s;
+    g.insertAdjacentHTML('beforeend', `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${rad.toFixed(1)}" fill="${color}" opacity="${r ? .95 : .55}" class="map-node">
+        ${testing ? `<circle class="pulse" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${rad.toFixed(1)}" fill="none" stroke="${color}" stroke-width="1.6"/>` : ''}
+        ${won ? `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${(rad + 5).toFixed(1)}" fill="none" stroke="#fbbf24" stroke-width="1.8" opacity=".9"/>` : ''}
       </circle>
-      <title>${esc(s.meta.label)} · ${esc(regionCity(s))}${r ? ' — ' + fmtMbps(r.sustained || r.ewma) : ''}</title>`);
-    if (won || (results && results.regions.length > 0 && results.regions.slice(0, 3).some(x => x.s.region === s.region && x.s.name === s.name))) {
-      g.insertAdjacentHTML('beforeend', `<text class="map-label" x="${p.x}" y="${p.y - rad - 8}" text-anchor="middle">${esc(s.region.toUpperCase())}</text>`);
+      <title>${esc(regionLabel(s))} · ${esc(regionCity(s))}${r && r.steady != null ? ' — ' + fmtMbps(r.steady) + ' steady' : ''}</title>`);
+    if (won || (final && results && results.ranked.slice(0, 3).some(x => x.s === s))) {
+      g.insertAdjacentHTML('beforeend', `<text class="map-label" x="${p.x.toFixed(1)}" y="${(p.y - rad - 8).toFixed(1)}" text-anchor="middle">${esc(s.region.toUpperCase())}</text>`);
     }
   });
   drawYou();
@@ -1293,13 +1669,13 @@ function drawYou() {
   if (!geo || geo.lat == null) { badge.hidden = true; return; }
   badge.hidden = false;
   const p = proj(geo.lat, geo.lng);
-  you.innerHTML = `<circle cx="${p.x}" cy="${p.y}" r="5" fill="#fff" stroke="#00d4ff" stroke-width="2.5"/>
-    <circle cx="${p.x}" cy="${p.y}" r="11" fill="none" stroke="#00d4ff" stroke-width="1" opacity=".6"/>
-    <text class="map-you" x="${p.x}" y="${p.y - 13}" text-anchor="middle">YOU</text>`;
+  you.innerHTML = `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="5" fill="#fff" stroke="#00d4ff" stroke-width="2.5"/>
+    <circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="11" fill="none" stroke="#00d4ff" stroke-width="1" opacity=".6"/>
+    <text class="map-you" x="${p.x.toFixed(1)}" y="${(p.y - 13).toFixed(1)}" text-anchor="middle">YOU</text>`;
 }
 function locateYou() {
   fetch(GEO_API, { signal: AbortSignal.timeout(4000) })
-    .then(r => { if (r.ok) return r.json(); throw new Error(); })
+    .then(r => { if (!r.ok) throw new Error('geo'); return r.json(); })
     .then(j => {
       if (j && isFinite(j.latitude) && isFinite(j.longitude)) {
         geo = { lat: Number(j.latitude), lng: Number(j.longitude), label: j.city || 'you' };
@@ -1314,44 +1690,48 @@ function locateYou() {
 function buildAnycastLegend() {
   const el = $('anycastLegend');
   el.innerHTML = servers.filter(s => s.meta && s.meta.net !== 'direct').map(s => {
-    const r = run ? run.regions.find(x => x.s.region === s.region) : null;
-    const color = r ? nodeColor(r) : '#5b6b83';
-    const v = r ? (r.sustained || r.ewma || 0) : null;
-    return `<span class="ax"><i style="background:${color}"></i>${esc(s.meta.label)} · ${esc(s.meta.net)}${v ? ' · ' + fmtMbps(v) : ''}</span>`;
+    const r = run ? run.nodes.find(x => x.s === s) : null;
+    const color = r && r.steady != null ? nodeColor(r.steady) : '#5b6b83';
+    const v = r ? r.steady : null;
+    return `<span class="ax"><i style="background:${color}"></i>${esc(regionLabel(s))} · ${esc(s.meta.net)}${v != null ? ' · ' + fmtMbps(v) : ''}</span>`;
   }).join('');
 }
-
-/* ────────────────────────── Results ────────────────────────── */
+/* ────────────────────────── results ────────────────────────── */
 let sortKey = 'rank', sortDir = 1;
+function regionKey(r) { return r.s.region + '|' + r.s.name; }
 function renderResults() {
   if (!results) return;
   $('resultsCard').hidden = false;
-  const modeLbl = MODES[results.mode].label;
-  $('resultsSub').textContent = `${results.regions.length} CDNs measured · ${modeLbl} · ${results.single ? 'single connection' : results.streams + ' streams/node'} · ${fmtBytes(results.dataBytes)} used · ${results.elapsed.toFixed(1)}s${results.partial ? ' · partial run' : ''}`;
-  const best = results.regions[0];
+  const modeLbl = results.cfg.mode === 'accurate' ? 'Accurate · single connection' : results.cfg.mode === 'express' ? 'Express · single connection' : 'Capacity race · ' + results.cfg.streams + ' connections/node';
+  $('resultsSub').textContent =
+    `${results.ranked.length} CDNs measured · ${modeLbl} · ${results.cfg.windowMs / 1000} s window${results.cfg.mode !== 'capacity' ? ` · ${results.cfg.reps} rep${results.cfg.reps > 1 ? 's' : ''}` : ''} · ${fmtBytes(results.dataBytes)} used · ${results.elapsed.toFixed(0)}s` +
+    (results.partial ? ' · partial run (stopped)' : '');
+  const best = results.ranked[0];
   if (best) {
-    const closest = results.regions.find(r => r.s.closest);
-    const vs = closest && closest.region !== best.region ? ` · ${(best.sustained / Math.max(1e-9, closest.sustained)).toFixed(1)}× your closest CDN` : '';
-    const slowest = results.regions.length > 1 ? `▲ ${(best.sustained / Math.max(1e-9, results.regions[results.regions.length - 1].sustained)).toFixed(1)}× slowest` : '';
-    const pings = results.regions.map(r => r.ping).filter(p => p != null);
+    const closest = results.ranked.find(r => r.s.closest);
+    const vs = closest && closest.s !== best.s ? ` · ${(best.steady / Math.max(1e-9, closest.steady)).toFixed(1)}× your closest CDN` : '';
+    const pings = results.ranked.map(r => r.ping).filter(p => p != null);
     const minPing = pings.length ? Math.min(...pings) : null;
     const anomaly = best.ping != null && minPing != null && best.ping - minPing > 80
-      ? `<div class="s" style="color:var(--th-yellow);margin-top:4px">⚠ ${Math.round(best.ping - minPing)} ms farther than your nearest node — your ISP just routes here well. Single-connection playback adds that latency; trust the ping column too.</div>` : '';
-    const isSingle = results.single;
-    const verdict = best.verdict ? `<span class="v">${esc(best.verdict[1])}</span>` : `<span class="v" style="color:var(--th-yellow)">multi-stream — no playback verdict</span>`;
-    const verdictSub = best.streamable != null
+      ? `<div class="s" style="color:var(--yellow);margin-top:4px">⚠ ${Math.round(best.ping - minPing)} ms farther than your nearest node — your ISP just routes here well. Single-connection playback adds that latency; trust the ping column too.</div>` : '';
+    const isSingle = results.cfg.mode !== 'capacity';
+    const verdict = isSingle && best.verdict ? `<span class="v">${esc(best.verdict[1])}</span>` : `<span class="v" style="color:var(--yellow)">multi-connection — no playback verdict</span>`;
+    const verdictSub = isSingle && best.streamable != null
       ? `≈ up to ${Math.round(best.streamable)} Mbps of smooth single-stream playback from this node.`
-      : 'Run Sequential mode (default) for a playback-accurate verdict — a player uses one connection.';
+      : 'Capacity numbers are pipe capacity with N parallel connections — run Accurate mode for a playback verdict.';
     $('winnerBox').innerHTML = `
       <span class="trophy" aria-hidden="true">🏆</span>
       <div>
-        <div class="w-head">${isSingle ? 'Best CDN for playback' : 'Fastest in this multi-stream race'}</div>
-        <div class="w-name"><span>${esc(regionLabel(best.s))}</span><span style="font-size:.66rem;font-weight:700;color:var(--th-tx3)">${esc(regionCity(best.s))}</span></div>
+        <div class="w-head">${isSingle ? 'Best CDN for playback' : 'Fastest in this capacity race'}</div>
+        <div class="w-name"><span>${esc(regionLabel(best.s))}</span><span style="font-size:.66rem;font-weight:700;color:var(--th-tx3)">${esc(regionCity(best.s))} · ${esc(best.s.name)}</span></div>
         <div class="w-stats">
-          <span>${isSingle ? 'Single-stream' : results.streams + '-stream'} sustained <b>${fmtMbps(best.sustained)}</b> (${fmtMBps(best.sustained)})</span>
-          <span>Peak <b>${fmtMbps(best.max)}</b></span>
-          <span>Ping <b>${fmtMs(best.ping)}</b></span>
-          ${slowest ? `<span class="pos">${slowest}${vs}</span>` : ''}
+          <span>${isSingle ? 'Steady (median)' : results.cfg.streams + '-conn aggregate'} <b>${fmtMbps(best.steady)}</b> (${fmtUnit(best.steady, unitMode)})</span>
+          <span>Raw avg <b>${fmtMbps(best.avgFb)}</b></span>
+          <span>Peak <b>${fmtMbps(best.peak)}</b></span>
+          <span>p95 <b>${fmtMbps(best.p95)}</b></span>
+          <span>Ping <b>${fmtMs(best.ping)}</b>${best.jitter ? ` <small style="color:var(--th-tx4)">±${Math.round(best.jitter)}</small>` : ''}</span>
+          ${best.ttfb != null ? `<span>TTFB <b>${Math.round(best.ttfb)} ms</b></span>` : ''}
+          ${vs ? `<span class="pos">${vs}</span>` : ''}
         </div>
       </div>
       <div class="w-verdict">
@@ -1359,52 +1739,76 @@ function renderResults() {
         <span class="s">${verdictSub}</span>
         ${anomaly}
       </div>`;
+  } else {
+    $('winnerBox').innerHTML = `<span class="trophy" aria-hidden="true">🫥</span><div><div class="w-head">No valid measurements</div><div class="w-name">Every node failed or was skipped</div><div class="w-verdict"><span class="s">Check your connection, DNS, or ad-blocker (this page needs outbound HTTPS to *.tb-cdn.*), then retry.</span></div></div>`;
   }
   renderResultsTable();
   renderCompareOptions();
 }
-function regionKey(r) { return r.s.region + '|' + r.s.name; }
 function renderResultsTable() {
   const body = $('resultsBody');
-  const rows = results.regions.slice().sort((a, b) => {
-    const va = sortKey === 'rank' ? a.rank : sortKey === 'region' ? regionKey(a) : a[sortKey];
-    const vb = sortKey === 'rank' ? b.rank : sortKey === 'region' ? regionKey(b) : b[sortKey];
+  const rows = results.ranked.slice().sort((a, b) => {
+    const va = sortKey === 'rank' ? a.rank : sortKey === 'region' ? regionKey(a) : sortKey === 'delta' ? 0 : (a[sortKey] == null ? -1 : a[sortKey]);
+    const vb = sortKey === 'rank' ? b.rank : sortKey === 'region' ? regionKey(b) : sortKey === 'delta' ? 0 : (b[sortKey] == null ? -1 : b[sortKey]);
     if (typeof va === 'string') return va.localeCompare(vb) * sortDir;
     return (va - vb) * sortDir;
   });
   body.innerHTML = rows.map(r => {
-    const prev = compareRun && compareRun.results.find(x => x.region === r.s.region && x.name === r.s.name);
-    const delta = prev ? (r.sustained - prev.sustained) / Math.max(1e-9, prev.sustained) * 100 : null;
+    const prev = compareRun ? compareRun.ranked.find(x => x.s.region === r.s.region && x.s.name === r.s.name) : null;
+    const delta = prev ? (r.steady - prev.steady) / Math.max(1e-9, prev.steady) * 100 : null;
     const deltaHtml = prev
       ? `<span class="${delta >= 0 ? 'delta-pos' : 'delta-neg'}">${delta >= 0 ? '▲' : '▼'} ${Math.abs(delta).toFixed(0)}%</span>`
       : '<span style="color:var(--th-tx4)">—</span>';
-    const spark = miniSpark(r.samples);
-    const verdict = r.verdict ? `<span class="verdict ${r.verdict[0]}">${esc(r.verdict[1])}</span>` : `<span class="chip-mini" title="Multi-stream numbers don't reflect what a single-connection player gets. Run Sequential mode for a verdict.">— multi-stream</span>`;
+    const spark = miniSpark(r.marks);
+    const verdict = (results.cfg.mode !== 'capacity' && r.verdict)
+      ? `<span class="verdict ${r.verdict[0]}">${esc(r.verdict[1])}</span>`
+      : `<span class="chip-mini" title="Multi-connection numbers don't reflect a single-connection player. Run Accurate mode.">— capacity</span>`;
+    const repsTxt = results.cfg.mode === 'capacity'
+      ? `${r.reps.length}× ok`
+      : r.reps.map(x => x.steadyMbps != null ? Math.round(x.steadyMbps) : '✕').join(' / ');
+    const cons = r.consistency != null ? `<span class="stability-bar"><i style="width:${(r.consistency * 100).toFixed(0)}%"></i></span>${(r.consistency * 100).toFixed(0)}%` : '<span style="color:var(--th-tx4)">1 rep</span>';
     return `<tr class="${r.rank === 1 ? 'best-row' : ''}">
       <td class="rank-num">${r.rank}</td>
       <td><div class="reg-name"><span class="n"><span class="fl">${esc(regionLabel(r.s))}</span>${r.s.closest ? '<span class="chip-mini run">closest</span>' : ''}</span><span class="c">${esc(regionCity(r.s))} · ${esc(r.s.name)}</span></div></td>
-      <td>${fmtMs(r.ping)}${r.jitter ? ' <small style="color:var(--th-tx4)">±' + Math.round(r.jitter) + '</small>' : ''}</td>
-      <td><b>${fmtMbps(r.sustained)}</b> <small style="color:var(--th-tx4)">${fmtMBps(r.sustained)}</small></td>
-      <td>${fmtMbps(r.max)}</td>
-      <td><span class="stability-bar"><i style="width:${(r.stability * 100).toFixed(0)}%"></i></span>${(r.stability * 100).toFixed(0)}%</td>
+      <td>${fmtMs(r.ping)}${r.jitter ? ` <small style="color:var(--th-tx4)">±${Math.round(r.jitter)}</small>` : ''}</td>
+      <td>${r.ttfb != null ? Math.round(r.ttfb) + ' ms' : '—'}</td>
+      <td><b>${fmtMbps(r.steady)}</b> <small style="color:var(--th-tx4)">${fmtUnit(r.steady, unitMode)}</small></td>
+      <td>${fmtMbps(r.avgFb)}</td>
+      <td>${fmtMbps(r.peak)}</td>
+      <td>${fmtMbps(r.p95)}</td>
+      <td><span class="mini-reps">${repsTxt}</span></td>
+      <td>${cons}</td>
       <td ${compareRun ? '' : 'hidden'}>${deltaHtml}</td>
       <td>${verdict} ${spark}</td>
     </tr>`;
   }).join('');
   $('thDelta').hidden = !compareRun;
+  // not-ranked section
+  const fs = $('failedSec'), fl = $('failedList');
+  if (results.failed.length) {
+    fs.hidden = false;
+    fl.innerHTML = results.failed.map(r =>
+      `<div class="fail-row"><span class="fl">${esc(regionLabel(r.s))}</span><span>${esc(regionCity(r.s))} · ${esc(r.s.name)}</span><span class="chip-mini ${r.status === 'skipped' ? '' : 'bad'}">${r.status === 'skipped' ? '⏭ skipped' : '✕ failed'}</span><span class="c">${esc(r.err || '')}</span></div>`
+    ).join('');
+  } else fs.hidden = true;
 }
 function miniSpark(samples) {
   if (!samples || samples.length < 2) return '';
-  const down = samples.length > 40 ? samples.filter((_, i) => i % Math.ceil(samples.length / 40) === 0) : samples;
+  const down = samples.length > 40 ? downSample(samples, 40) : samples;
   const W = 58, H = 18;
-  const max = Math.max(...down.map(s => s.v)) || 1;
-  const pts = down.map((s, i) => `${(i / (down.length - 1) * W).toFixed(1)},${(H - 2 - (s.v / max) * (H - 4)).toFixed(1)}`).join(' ');
+  const max = Math.max(...down.map(s => s.b)) || 1;
+  const t0 = down[0].t;
+  const pts = down.map((s, i) => {
+    const x = down.length > 1 ? (s.t - t0) / Math.max(1, down[down.length - 1].t - t0) * W : 0;
+    return `${x.toFixed(1)},${(H - 2 - (s.b / max) * (H - 4)).toFixed(1)}`;
+  }).join(' ');
   return `<svg class="reg-spark" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" style="display:inline-block;vertical-align:middle;margin-left:6px" aria-hidden="true"><polyline points="${pts}" fill="none" stroke="#00d4ff" stroke-width="1.2"/></svg>`;
 }
 document.querySelectorAll('#resultsTable th[data-sort]').forEach(th => {
   th.addEventListener('click', () => {
     const key = th.dataset.sort;
-    if (sortKey === key) sortDir *= -1; else { sortKey = key; sortDir = key === 'region' ? 1 : key === 'rank' ? 1 : -1; }
+    if (sortKey === key) sortDir *= -1;
+    else { sortKey = key; sortDir = key === 'region' ? 1 : key === 'rank' ? 1 : -1; }
     renderResultsTable();
   });
 });
@@ -1412,42 +1816,36 @@ function renderCompareOptions() {
   const sel = $('compareSel');
   const prev = history.filter(h => h.id !== results.id).slice(0, 20);
   sel.innerHTML = '<option value="">— previous runs —</option>' + prev.map(h =>
-    `<option value="${h.id}">${new Date(h.ts).toLocaleString()} · ${esc(h.bestLabel || '')} · ${fmtMbps(h.bestAvg || 0)}</option>`).join('');
+    `<option value="${h.id}">${new Date(h.ts).toLocaleString()} · ${esc(h.bestLabel || '—')} · ${fmtMbps(h.bestSteady || 0)}</option>`).join('');
 }
 $('compareSel').addEventListener('change', () => {
   const id = $('compareSel').value;
-  compareRun = id ? history.find(h => String(h.id) === id) || null : null;
+  compareRun = id ? history.find(h => String(h.id) === String(id)) || null : null;
   renderResultsTable();
 });
 
-/* ────────────────────────── History ────────────────────────── */
-function loadHistory() {
-  try { return JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]'); } catch (e) { return []; }
-}
+/* ────────────────────────── history ────────────────────────── */
 function saveToHistory(res) {
   const entry = {
-    id: res.id, ts: res.ts, mode: res.mode, streams: res.streams, single: res.single,
-    source: res.source, dataBytes: res.dataBytes, elapsed: res.elapsed, partial: res.partial, peak: res.peak,
-    bestLabel: res.regions.length ? regionLabel(res.regions[0].s) : '—',
-    bestAvg: res.regions.length ? res.regions[0].sustained : 0,
-    bestPing: res.regions.length ? res.regions[0].ping : null,
-    results: res.regions.map(r => ({
+    id: res.id, ts: res.ts, mode: res.cfg.mode, cfg: res.cfg,
+    source: res.source, dataBytes: res.dataBytes, elapsed: res.elapsed, partial: !!res.partial,
+    bestLabel: res.ranked.length ? regionLabel(res.ranked[0].s) : '—',
+    bestSteady: res.ranked.length ? res.ranked[0].steady : 0,
+    bestPing: res.ranked.length ? res.ranked[0].ping : null,
+    ranked: res.ranked.map(r => ({
       region: r.s.region, name: r.s.name, label: regionLabel(r.s), city: regionCity(r.s),
-      closest: r.s.closest, ping: r.ping, jitter: r.jitter, sustained: r.sustained, max: r.max,
-      stability: r.stability, verdict: r.verdict ? r.verdict[1] : null, streamable: r.streamable, rank: r.rank,
-      samples: downSample(r.samples, 40),
+      closest: r.s.closest, ping: r.ping, pingMin: r.pingMin, jitter: r.jitter, ttfb: r.ttfb,
+      steady: r.steady, avgFb: r.avgFb, peak: r.peak, p95: r.p95, consistency: r.consistency,
+      verdict: r.verdict ? r.verdict[1] : null, rank: r.rank,
+      reps: (r.reps || []).map(x => ({ status: x.status, bytes: x.bytes, steady: x.steadyMbps, avgFb: x.avgFbMbps, firstByteMs: x.firstByteMs })),
+      marks: downSample(r.marks || [], 40),
     })),
+    failed: res.failed.map(r => ({ region: r.s.region, name: r.s.name, label: regionLabel(r.s), status: r.status, err: r.err })),
+    s: res.ranked.map(r => ({ region: r.s.region, name: r.s.name, closest: r.s.closest, lat: r.s.lat, lng: r.s.lng, meta: r.s.meta })),
   };
   history.unshift(entry);
   if (history.length > HISTORY_MAX) history.length = HISTORY_MAX;
   try { localStorage.setItem(HISTORY_KEY, JSON.stringify(history)); } catch (e) {}
-}
-function downSample(arr, n) {
-  if (!arr || arr.length <= n) return arr || [];
-  const step = arr.length / n;
-  const out = [];
-  for (let i = 0; i < n; i++) out.push(arr[Math.floor(i * step)]);
-  return out;
 }
 function renderHistory() {
   const el = $('historyList');
@@ -1456,10 +1854,10 @@ function renderHistory() {
     <div class="hist-item">
       <span class="hist-ts">${new Date(h.ts).toLocaleString()}</span>
       <span class="hist-best">
-        <span class="n">${esc(h.bestLabel)}${h.single ? ' <span class="chip-mini ok">single</span>' : ' <span class="chip-mini">multi-stream</span>'}</span>
-        <span class="s">${(MODES[h.mode] || {}).label || h.mode} · ${fmtBytes(h.dataBytes)}${h.partial ? ' · partial' : ''}</span>
+        <span class="n">${esc(h.bestLabel)}${h.mode !== 'capacity' ? ' <span class="chip-mini ok">single</span>' : ' <span class="chip-mini">capacity</span>'}</span>
+        <span class="s">${h.mode} · ${fmtBytes(h.dataBytes)}${h.partial ? ' · partial' : ''}</span>
       </span>
-      <span class="hist-num">${fmtMbps(h.bestAvg)}<small>best sustained</small></span>
+      <span class="hist-num">${fmtMbps(h.bestSteady)}<small>best steady</small></span>
       <span class="hist-num">${fmtMs(h.bestPing)}<small>ping</small></span>
       <span class="hist-actions">
         <button class="btn-ghost" data-hist-load="${h.id}" type="button">Load</button>
@@ -1468,26 +1866,29 @@ function renderHistory() {
     </div>`).join('');
   el.querySelectorAll('[data-hist-load]').forEach(b => b.addEventListener('click', () => loadFromHistory(Number(b.dataset.histLoad))));
   el.querySelectorAll('[data-hist-del]').forEach(b => b.addEventListener('click', () => {
-    history = history.filter(x => String(x.id) !== b.dataset.histDel);
-    try { localStorage.setItem(HISTORY_KEY, JSON.stringify(history)); } catch (e) {}
-    renderHistory(); renderCompareOptions();
+    history = history.filter(x => String(x.id) !== String(b.dataset.histDel));
+    try { localStorage.removeItem(HISTORY_KEY); localStorage.setItem(HISTORY_KEY, JSON.stringify(history)); } catch (e) {}
+    renderHistory();
   }));
 }
 function loadFromHistory(id) {
   const h = history.find(x => String(x.id) === String(id));
   if (!h) return;
+  const sMap = {}; (h.s || []).forEach(s => { sMap[s.region + '|' + s.name] = s; });
+  const restore = (r) => {
+    const meta = REGION_META[r.region] || { label: r.region.toUpperCase(), city: '—', flag: '🌐', net: 'direct' };
+    const saved = sMap[r.region + '|' + r.name];
+    return {
+      s: { region: r.region, name: r.name, closest: r.closest, lat: saved ? saved.lat : null, lng: saved ? saved.lng : null, meta },
+      ping: r.ping, pingMin: r.pingMin, jitter: r.jitter, ttfb: r.ttfb,
+      steady: r.steady, avgFb: r.avgFb, peak: r.peak, p95: r.p95, consistency: r.consistency,
+      verdict: r.verdict ? ['vq', r.verdict] : null, rank: r.rank, marks: r.marks || [], reps: (r.reps || []).map(x => ({ ok: x.steady != null, steadyMbps: x.steady, avgFbMbps: x.avgFb, status: x.status, bytes: x.bytes })),
+    };
+  };
   results = {
-    id: h.id + '-view', ts: h.ts, mode: h.mode, streams: h.streams, single: !!h.single,
-    source: h.source, dataBytes: h.dataBytes, elapsed: h.elapsed, partial: h.partial, peak: h.peak,
-    regions: h.results.map(r => {
-      const meta = REGION_META[r.region] || { label: r.region.toUpperCase(), city: '—', flag: '🌐', net: 'direct' };
-      return {
-        s: { region: r.region, name: r.name, closest: r.closest, meta },
-        ping: r.ping, jitter: r.jitter, sustained: r.sustained, max: r.max,
-        stability: r.stability, verdict: r.verdict ? ['vq', r.verdict] : null, streamable: r.streamable,
-        rank: r.rank, samples: r.samples || [],
-      };
-    }).sort((a, b) => a.rank - b.rank),
+    id: h.id + '-view', ts: h.ts, mode: h.mode, cfg: h.cfg, source: h.source,
+    dataBytes: h.dataBytes, elapsed: h.elapsed, partial: h.partial, unit: unitMode,
+    ranked: h.ranked.map(restore), failed: (h.failed || []).map(restore),
   };
   compareRun = null; $('compareSel').value = '';
   renderResults();
@@ -1499,31 +1900,41 @@ function loadFromHistory(id) {
 $('clearHistBtn').addEventListener('click', () => {
   history = [];
   try { localStorage.removeItem(HISTORY_KEY); } catch (e) {}
-  renderHistory(); renderCompareOptions();
+  renderHistory();
   toast('History cleared.');
 });
 
-/* ────────────────────────── Exports ────────────────────────── */
+/* ────────────────────────── exports ────────────────────────── */
 function markdownReport() {
   if (!results) return '';
-  const L = ['# CoreSpeed — TorBox CDN results', '',
+  const L = ['# CoreSpeed v3 — TorBox CDN results', '',
     `- **Date:** ${new Date(results.ts).toLocaleString()}`,
-    `- **Mode:** ${MODES[results.mode].label} · ${results.single ? 'single connection' : results.streams + ' streams/node'}`,
-    `- **Data used:** ${fmtBytes(results.dataBytes)} · **Elapsed:** ${results.elapsed.toFixed(1)}s`,
-    `- **Endpoints:** ${results.source === 'snapshot' ? 'offline snapshot' : 'live (' + results.source + ')'}`,
-    '',
-    '| # | Region | Ping | Sustained | Peak | Stability | Streaming |',
-    '|---:|---|---|---:|---:|---:|---|'];
-  results.regions.forEach(r => {
-    L.push(`| ${r.rank} | ${regionLabel(r.s)} (${regionCity(r.s)}) | ${fmtMs(r.ping)} | ${fmtMbps(r.sustained)} | ${fmtMbps(r.max)} | ${(r.stability * 100).toFixed(0)}% | ${r.verdict ? r.verdict[1] : '— (multi-stream)'} |`);
+    `- **Mode:** ${results.cfg.mode} · ${results.cfg.mode === 'capacity' ? results.cfg.streams + ' connections/node' : results.cfg.reps + ' rep(s), ' + results.cfg.windowMs / 1000 + ' s window, first-byte anchored'}`,
+    `- **Data used:** ${fmtBytes(results.dataBytes)} · **Elapsed:** ${results.elapsed.toFixed(0)}s${results.partial ? ' · partial (stopped)' : ''}`,
+    `- **Endpoints:** ${results.source}`, '',
+    '| # | Region | Ping ±j | TTFB | Steady (median) | Raw avg | Peak | p95 | Consistency | Streaming |',
+    '|---:|---|---:|---:|---:|---:|---:|---:|---:|---|'];
+  results.ranked.forEach(r => {
+    L.push(`| ${r.rank} | ${regionLabel(r.s)} (${regionCity(r.s)}) | ${fmtMs(r.ping)}${r.jitter ? ' ±' + Math.round(r.jitter) : ''} | ${r.ttfb != null ? Math.round(r.ttfb) + ' ms' : '—'} | ${fmtMbps(r.steady)} | ${fmtMbps(r.avgFb)} | ${fmtMbps(r.peak)} | ${fmtMbps(r.p95)} | ${r.consistency != null ? (r.consistency * 100).toFixed(0) + '%' : '1 rep'} | ${results.cfg.mode !== 'capacity' && r.verdict ? r.verdict[1] : '— (capacity)'} |`);
   });
-  L.push('', '_Measured with CoreSpeed — brevitya.github.io/Core-Builds/tools/speedtest/_');
+  if (results.failed.length) {
+    L.push('', '## Not ranked', '');
+    results.failed.forEach(r => L.push(`- ${regionLabel(r.s)} — ${r.status}${r.err ? ' (' + r.err + ')' : ''}`));
+  }
+  L.push('', '_Measured with CoreSpeed v3 — brevitya.github.io/Core-Builds/tools/speedtest/ · decimal units_');
   return L.join('\n');
 }
 function csvReport() {
   if (!results) return '';
-  const rows = [['rank', 'region', 'name', 'city', 'ping_ms', 'jitter_ms', 'sustained_mbps', 'peak_mbps', 'stability_pct', 'streams', 'verdict']];
-  results.regions.forEach(r => rows.push([r.rank, r.s.region, r.s.name, regionCity(r.s), r.ping == null ? '' : r.ping.toFixed(0), r.jitter == null ? '' : r.jitter.toFixed(0), r.sustained.toFixed(1), r.max.toFixed(1), (r.stability * 100).toFixed(0), results.streams, r.verdict ? r.verdict[1] : '']));
+  const rows = [['rank', 'region', 'name', 'city', 'ping_ms', 'jitter_ms', 'ttfb_ms', 'steady_mbps', 'raw_avg_mbps', 'peak_mbps', 'p95_mbps', 'reps_ok', 'consistency_pct', 'mode', 'window_s', 'verdict']];
+  results.ranked.forEach(r => rows.push([
+    r.rank, r.s.region, r.s.name, regionCity(r.s),
+    r.ping == null ? '' : r.ping.toFixed(1), r.jitter == null ? '' : r.jitter.toFixed(1), r.ttfb == null ? '' : r.ttfb.toFixed(0),
+    (r.steady || 0).toFixed(1), (r.avgFb || 0).toFixed(1), (r.peak || 0).toFixed(1), (r.p95 || 0).toFixed(1),
+    (r.reps || []).filter(x => x && x.ok).length, r.consistency == null ? '' : (r.consistency * 100).toFixed(0),
+    results.cfg.mode, results.cfg.windowMs / 1000,
+    results.cfg.mode !== 'capacity' && r.verdict ? r.verdict[1] : '',
+  ]));
   return rows.map(r => r.map(c => /[",\n]/.test(String(c)) ? '"' + String(c).replace(/"/g, '""') + '"' : c).join(',')).join('\n');
 }
 function download(name, content, type) {
@@ -1538,89 +1949,126 @@ $('copyMdBtn').addEventListener('click', async () => {
   try { await navigator.clipboard.writeText(markdownReport()); toast('Report copied to clipboard.'); }
   catch (e) { toast('Clipboard blocked — use JSON export instead.'); }
 });
-$('csvBtn').addEventListener('click', () => { if (results) download('corespeed-results.csv', csvReport(), 'text/csv'); });
-$('jsonBtn').addEventListener('click', () => { if (results) download('corespeed-results.json', JSON.stringify(results, null, 2), 'application/json'); });
+$('csvBtn').addEventListener('click', () => { if (results) download('corespeed-v3-results.csv', csvReport(), 'text/csv'); });
+$('jsonBtn').addEventListener('click', () => {
+  if (!results) return;
+  const slim = {
+    id: results.id, ts: results.ts, mode: results.cfg.mode, cfg: results.cfg, source: results.source,
+    dataBytes: results.dataBytes, elapsed: results.elapsed, partial: results.partial,
+    ranked: results.ranked.map(r => ({
+      rank: r.rank, region: r.s.region, name: r.s.name, label: regionLabel(r.s), city: regionCity(r.s),
+      closest: r.s.closest, ping: r.ping, pingMin: r.pingMin, jitter: r.jitter, ttfb: r.ttfb,
+      steadyMbps: r.steady, rawAvgMbps: r.avgFb, peakMbps: r.peak, p95Mbps: r.p95,
+      consistency: r.consistency, verdict: r.verdict ? r.verdict[1] : null,
+      reps: (r.reps || []).map(x => ({ status: x.status, bytes: x.bytes, steadyMbps: x.steadyMbps, rawAvgMbps: x.avgFbMbps, firstByteMs: x.firstByteMs, peakMbps: x.peakMbps, p95Mbps: x.p95Mbps })),
+      marks: r.marks,
+    })),
+    failed: results.failed.map(r => ({ region: r.s.region, name: r.s.name, status: r.status, err: r.err })),
+  };
+  download('corespeed-v3-results.json', JSON.stringify(slim, null, 2), 'application/json');
+});
 
-/* ────────────────────────── Diagnostics (for supporter reports) ────────────────────────── */
+/* ────────────────────────── diagnostics ────────────────────────── */
 $('diagBtn').addEventListener('click', async () => {
   toast('Collecting diagnostics — includes DNS lookups…', 4000);
   try {
     const dnsCache = {};
-    const dnsOf = async host => {
+    const dnsOf = async (host) => {
       if (dnsCache[host] !== undefined) return dnsCache[host];
       try {
-        const r = await fetch(`https://dns.google/resolve?name=${encodeURIComponent(host)}&type=A`, { signal: AbortSignal.timeout(3500) });
+        const r = await fetch(`${DNS_API}?name=${encodeURIComponent(host)}&type=A`, { signal: AbortSignal.timeout(3500) });
         const j = await r.json();
         dnsCache[host] = (j.Answer || []).filter(a => a.type === 1).map(a => a.data);
       } catch (e) { dnsCache[host] = null; }
       return dnsCache[host];
     };
     const who = await fetch(GEO_API, { signal: AbortSignal.timeout(4000) }).then(r => r.json()).catch(() => null);
-    const regionRows = run ? run.regions : results ? results.regions : null;
+    const regionRows = run ? run.nodes : results ? results.ranked.concat(results.failed) : null;
     const perServer = await Promise.all(servers.map(async s => {
-      const r = regionRows ? regionRows.find(x => x.s.region === s.region && x.s.name === s.name) : null;
+      const r = regionRows ? regionRows.find(x => x.s === s) : null;
+      const host = (hostOf(s.urlShort) || '').replace(/^https:\/\//, '');
       return {
         region: s.region, name: s.name, closest: s.closest,
-        host: s.urlShort.replace(/^https:\/\//, '').split('/')[0],
-        net: s.meta.net, coords: { lat: s.lat, lng: s.lng },
-        dns: await dnsOf(s.urlShort.replace(/^https:\/\//, '').split('/')[0]),
+        host, net: s.meta.net, coords: { lat: s.lat, lng: s.lng },
+        dns: await dnsOf(host),
         pingMs: r && r.ping != null ? Math.round(r.ping) : null,
         pingMinMs: r && r.pingMin != null ? Math.round(r.pingMin) : null,
         jitterMs: r && r.jitter != null ? Math.round(r.jitter) : null,
-        pingsAll: r && r.pings ? r.pings.map(Math.round) : [],
-        sustainedMbps: r && r.sustained != null ? +r.sustained.toFixed(1) : null,
-        maxMbps: r && r.max != null ? +r.max.toFixed(1) : null,
-        bytes: r ? r.bytes : 0, status: r ? r.status : null, err: r ? r.err : null,
-        sampleCount: r ? r.samples.length : 0,
+        pingsAllMs: r ? r.pingsAll : [],
+        ttfbMs: r && r.ttfb != null ? Math.round(r.ttfb) : null,
+        steadyMbps: r && r.steady != null ? +r.steady.toFixed(1) : null,
+        rawAvgMbps: r && r.avgFb != null ? +r.avgFb.toFixed(1) : null,
+        peakMbps: r && r.peak != null ? +r.peak.toFixed(1) : null,
+        p95Mbps: r && r.p95 != null ? +r.p95.toFixed(1) : null,
+        bytes: r ? r.bytes : 0,
+        status: r ? r.status : null,
+        err: r ? (r.err || null) : null,
+        reps: r && r.reps ? r.reps.map(x => ({ status: x.status, bytes: x.bytes, steadyMbps: x.steadyMbps ? +x.steadyMbps.toFixed(1) : null, avgFbMbps: x.avgFbMbps ? +x.avgFbMbps.toFixed(1) : null, firstByteMs: x.firstByteMs, err: x.err || null })) : [],
       };
     }));
     const payload = {
-      tool: 'corespeed', v: 2, ts: new Date().toISOString(),
+      tool: 'corespeed', engine: ENGINE_VERSION, ts: new Date().toISOString(),
       ua: navigator.userAgent, url: location.href,
-      endpointsSource, mode: run ? run.mode : results ? results.mode : null,
-      streams: run ? run.streams : results ? results.streams : null,
+      endpointsSource, snapshotVerified,
+      cfg: run ? run.cfg : results ? results.cfg : null,
       you: who ? { ip: who.ip, country: who.country, city: who.city, isp: who.connection ? who.connection.isp : null, asn: who.connection ? who.connection.asn : null } : null,
       servers: perServer,
     };
-    download('corespeed-diagnostics.json', JSON.stringify(payload, null, 2), 'application/json');
+    download('corespeed-v3-diagnostics.json', JSON.stringify(payload, null, 2), 'application/json');
     toast('Diagnostics downloaded — send the JSON file to the Core Builds crew.');
   } catch (e) {
     toast('Diagnostics failed: ' + (e && e.message ? e.message : 'unknown error'));
   }
 });
 
-/* ────────────────────────── Controls wiring ────────────────────────── */
-$('goBtn').addEventListener('click', () => { if (run && !run.finished) stopTest(true); else startTest(); });
-$('refreshBtn').addEventListener('click', loadEndpoints);
-let lastStreams = '4';
+/* ────────────────────────── controls wiring ────────────────────────── */
 function applyModeDisabled() {
   const mode = $('modeSel').value;
-  $('durSel').disabled = mode !== 'burst';
-  $('streamsSel').disabled = mode === 'sequential';
-  if (mode === 'sequential') {
-    if ($('streamsSel').value !== '1') lastStreams = $('streamsSel').value;
-    $('streamsSel').value = '1';
-  } else if ($('streamsSel').value === '1' && lastStreams !== '1') {
-    $('streamsSel').value = lastStreams;
+  $('ctlReps').hidden = mode === 'capacity';
+  $('ctlWindow').hidden = false;
+  $('ctlStreams').hidden = mode !== 'capacity';
+  $('ctlCap').hidden = mode !== 'capacity';
+  $('scopeSel').disabled = mode === 'express';
+}
+function updateDataNote() {
+  const mode = $('modeSel').value;
+  const n = selectedServers().length;
+  const reps = $('repsSel').value, win = $('windowSel').value;
+  if (mode === 'accurate') {
+    const worstGB = ((n * Number(reps) * FILE_1GB) / (1024 ** 3)).toFixed(0);
+    $('dataNote').textContent = `One node at a time, one connection, on the 1 GB file. Each node: ${reps} × ${win}s window measured from the first byte; ranked by the MEDIAN of steady-state speeds (first 2 s of slow-start excluded). Byte counting runs in a Web Worker, so UI load can't distort it. Worst case ≈ ${worstGB} GB; fast lines hit the 12 GB budget sooner — remaining nodes are marked skipped, never truncated.`;
+  } else if (mode === 'express') {
+    $('dataNote').textContent = `Closest node + the 4 best pings, one ${win}s first-byte-anchored rep each — about 90–120 s for a playback check. Single connection, same methodology as Accurate mode.`;
+  } else {
+    const cap = Number($('capSel').value), streams = $('streamsSel').value;
+    $('dataNote').textContent = `Every scoped node downloads at once with ${streams} REAL parallel connections each (Range-split in workers), ${win}s window, ≤${cap} MB per node. Shows pipe capacity with concurrent connections — it is not a single-connection playback verdict. ${n} nodes × ${cap} MB ≈ ${((n * cap) / 1024).toFixed(1)} GB worst case.`;
   }
 }
-$('modeSel').addEventListener('change', () => {
-  applyModeDisabled();
-  const m = $('modeSel').value;
-  $('dataNote').textContent = m === 'sequential'
-    ? 'Sequential tests ONE node at a time with ONE connection — the same approach as TorBox\'s own speedtest and the number that matters for playback. ~2–3 min for all 17 nodes; use the scope selector to shorten it.'
-    : m === 'full'
-    ? 'Full tests can move several GB on a fast line. Every node is capped at 1 GB (or 90 s), there is a 12 GB global budget, and Stop aborts everything instantly.'
-    : 'Multi-stream race: every node downloads at once, so numbers are contested and latency-masked. Great for fun and pipe capacity — use Sequential mode for playback-accurate ranking.';
+['modeSel', 'repsSel', 'windowSel', 'streamsSel', 'capSel', 'scopeSel'].forEach(id => {
+  $(id).addEventListener('change', () => { applyModeDisabled(); updateDataNote(); });
 });
-applyModeDisabled();
+$('unitToggle').addEventListener('click', (e) => {
+  const btn = e.target.closest('[data-unit]');
+  if (!btn) return;
+  unitMode = btn.dataset.unit;
+  try { localStorage.setItem('coreSpeedUnit', unitMode); } catch (err) {}
+  [...$('unitToggle').children].forEach(c => c.classList.toggle('on', c.dataset.unit === unitMode));
+  if (results) renderResults();
+});
+function applyUnitToggle() {
+  [...$('unitToggle').children].forEach(c => c.classList.toggle('on', c.dataset.unit === unitMode));
+}
+$('refreshBtn').addEventListener('click', () => { loadEndpoints(); });
 
-/* ────────────────────────── Init ────────────────────────── */
+/* ────────────────────────── init ────────────────────────── */
 buildGauge();
 buildMap();
+applyModeDisabled();
+applyUnitToggle();
 renderHistory();
 renderCompareOptions();
 renderLiveTable();
+updateDataNote();
 loadEndpoints();
 locateYou();
 window.addEventListener('resize', drawSpark);

--- a/tools/speedtest/test-engine.mjs
+++ b/tools/speedtest/test-engine.mjs
@@ -1,0 +1,201 @@
+/* CoreSpeed v3 — engine test harness
+ * 1) Unit-tests the pure logic (extracted from the shipped index.html, section A).
+ * 2) Runs the ACTUAL shipped WORKER_SRC against the live TorBox CDN from Node
+ *    (worker emulated with a `self` shim + Node's real fetch).
+ */
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
+const script = html.match(/<script>([\s\S]*)<\/script>/)[1];
+const sectionA = script.split('/* ================= UI SECTION ================= */')[0];
+
+/* ---------- section A in a sandbox ---------- */
+const ctxA = {
+  performance, fetch, setTimeout, clearTimeout, URL, URLSearchParams,
+  AbortController, console,
+  location: { search: '', href: 'http://test/' },
+  navigator: { userAgent: 'node-test' },
+};
+vm.createContext(ctxA);
+// top-level const/let live in the context's lexical scope, not on the sandbox
+// object — append a `var` export list (var does attach to the global) so we
+// can reach the bindings from here.
+vm.runInContext(
+  sectionA +
+  '\n;var __exports = { WORKER_SRC, median, mean, sd, downSample, fmtMbps, fmtUnit, fmtMs, fmtBytes, fmtEta, hostOf, verdictFor, proxyChain, normalize, snapshotList, buildRun, summarizeRun, BUDGET_BYTES, FILE_1GB, SNAPSHOT };',
+  ctxA, { filename: 'sectionA.js' }
+);
+const A = ctxA.__exports;
+
+let pass = 0, fail = 0;
+function t(name, cond, extra = '') {
+  if (cond) { pass++; console.log('  PASS  ' + name); }
+  else { fail++; console.log('  FAIL  ' + name + (extra ? '  → ' + extra : '')); }
+}
+
+console.log('\n== unit: pure helpers ==');
+t('median empty → null', A.median([]) === null);
+t('median single', A.median([5]) === 5);
+t('median odd', A.median([1, 3, 2]) === 2);
+t('median even', A.median([4, 1, 3, 2]) === 2.5);
+t('verdict 4K remux', A.verdictFor(200, 50)[1] === '4K Remux ready');
+t('verdict 4K stream', A.verdictFor(90, 50)[1] === '4K streaming');
+t('verdict 1080p remux', A.verdictFor(30, 100)[1] === '1080p Remux / 4K');
+t('verdict high-latency cap', A.verdictFor(30, 300)[1] === '1080p max — high latency');
+t('verdict very-high-latency cap', A.verdictFor(100, 500)[1] === 'SD — very high latency');
+t('verdict SD', A.verdictFor(2, 100)[1] === 'SD only');
+t('verdict null', A.verdictFor(null, 100) === null);
+t('fmtUnit decimal', A.fmtUnit(80, 'mb') === '10.0 MB/s');
+t('fmtUnit binary', A.fmtUnit(80, 'mib') === '9.5 MiB/s');
+t('fmtMbps Gbps', A.fmtMbps(2500) === '2.50 Gbps');
+t('fmtMbps round', A.fmtMbps(120) === '120 Mbps');
+t('fmtMbps 1dp', A.fmtMbps(12.34) === '12.3 Mbps');
+t('fmtMs null', A.fmtMs(null) === '—');
+
+console.log('\n== unit: snapshot + normalize ==');
+const list = A.snapshotList();
+t('snapshot has 17 nodes', list.length === 17, `got ${list.length}`);
+t('snapshot has exactly one closest', list.filter(s => s.closest).length === 1);
+t('snapshot urls are https', list.every(s => s.urlShort.startsWith('https://') && s.urlLong.startsWith('https://')));
+t('snapshot 1GB paths', list.every(s => s.urlLong.includes('/dld/1GB.bin')));
+t('snapshot regions known', list.every(s => s.meta && s.meta.label));
+const norm = A.normalize({ region: 'wnam', name: 'store-011', url: 'https://store-011.wnam.tb-cdn.io/dld/100MB.bin', closest: true, coordinates: { lat: 34, lng: -118 } });
+t('normalize keeps fields', norm && norm.region === 'wnam' && norm.closest === true && norm.urlLong.includes('1GB.bin'));
+t('normalize rejects non-https', A.normalize({ region: 'wnam', url: 'http://x' }) === null);
+
+console.log('\n== unit: summarizeRun (never ranks failed) ==');
+const fakeRun = A.buildRun('accurate', [
+  { region: 'a', name: 'a', urlShort: 'https://a/x', urlLong: 'https://a/1GB.bin', closest: false, lat: 0, lng: 0, meta: { label: 'A', city: 'A', flag: '🌐', net: 'direct' } },
+  { region: 'b', name: 'b', urlShort: 'https://b/x', urlLong: 'https://b/1GB.bin', closest: true, lat: 0, lng: 0, meta: { label: 'B', city: 'B', flag: '🌐', net: 'direct' } },
+  { region: 'c', name: 'c', urlShort: 'https://c/x', urlLong: 'https://c/1GB.bin', closest: false, lat: 0, lng: 0, meta: { label: 'C', city: 'C', flag: '🌐', net: 'direct' } },
+  { region: 'd', name: 'd', urlShort: 'https://d/x', urlLong: 'https://d/1GB.bin', closest: false, lat: 0, lng: 0, meta: { label: 'D', city: 'D', flag: '🌐', net: 'direct' } },
+], { mode: 'accurate', reps: 2, windowMs: 15000, streams: 1, capBytes: 500 * 1024 * 1024 });
+fakeRun.nodes[0].status = 'done'; fakeRun.nodes[0].steady = 100;
+fakeRun.nodes[1].status = 'done'; fakeRun.nodes[1].steady = 220;
+fakeRun.nodes[2].status = 'failed'; fakeRun.nodes[2].err = 'timeout'; fakeRun.nodes[2].steady = null;
+fakeRun.nodes[3].status = 'skipped'; fakeRun.nodes[3].err = 'data budget (12 GB)';
+const sum = A.summarizeRun(fakeRun);
+t('ranked only valid', sum.ranked.length === 2);
+t('rank order by steady', sum.ranked[0].s.region === 'b' && sum.ranked[0].rank === 1 && sum.ranked[1].rank === 2);
+t('failed section', sum.failed.length === 2);
+
+/* ---------- live worker tests ---------- */
+function makeWorkerEnv() {
+  const messages = [];
+  const listeners = {};
+  const self = {
+    postMessage: (m) => messages.push(m),
+    addEventListener: (n, fn) => { listeners[n] = fn; },
+    removeEventListener: () => {},
+    onmessage: null,
+  };
+  const ctx = { self, performance, fetch, setTimeout, clearTimeout, AbortController, URL, console };
+  vm.createContext(ctx);
+  vm.runInContext(A.WORKER_SRC, ctx, { filename: 'worker-src.js' });
+  return {
+    messages,
+    send: (data) => self.onmessage({ data }),
+    stop: () => { if (listeners.message) listeners.message({ data: 'stop' }); },
+  };
+}
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+async function until(messages, type, timeoutMs = 60000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    const m = messages.find(x => x.type === type);
+    if (m) return m;
+    await wait(100);
+  }
+  return null;
+}
+
+if (process.argv.includes('--unit')) {
+  console.log(`\n${pass} passed, ${fail} failed (unit only — no network; drop --unit for live CDN tests)`);
+  process.exit(fail ? 1 : 0);
+}
+
+/* Live tests are vantage-point independent: probe a 2 MB sample first,
+ * then scale byte/speed assertions from the measured baseline. */
+const LIVE_URL = process.env.LIVE_URL || 'https://store-011.wnam.tb-cdn.io/dld/1GB.bin';
+const baselineMBps = await (async () => {
+  const end = 2 * 1024 * 1024 - 1;
+  const t0 = performance.now();
+  const r = await fetch(LIVE_URL, { headers: { Range: 'bytes=0-' + end }, cache: 'no-store' });
+  const buf = Buffer.from(await r.arrayBuffer());
+  const dt = (performance.now() - t0) / 1000;
+  return buf.byteLength / dt / 1e6;
+})();
+const baselineMbps = baselineMBps * 8;
+console.log(`\n== live: baseline ${baselineMBps.toFixed(1)} MB/s (${baselineMbps.toFixed(0)} Mbps) @ ${LIVE_URL} ==`);
+const WINDOW_S = 6;
+const SLICE_BYTES = Math.min(125 * 1024 * 1024, Math.max(8 * 1024 * 1024, Math.round(baselineMBps * 10) * 1024 * 1024));
+
+console.log('\n== live: ping + 6 s windowed 1 GB transfer ==');
+{
+  const env = makeWorkerEnv();
+  const p = env.send({ url: LIVE_URL, withPing: true, pingRounds: 5, windowMs: WINDOW_S * 1000, graceMs: 8000 });
+  const ping = await until(env.messages, 'ping');
+  t('ping message sent', !!ping);
+  t('ping 5 rounds', ping && ping.pingsAll.length === 5, `got ${ping && ping.pingsAll.length}`);
+  t('ping trimmed mean sane', ping && ping.ping > 5 && ping.ping < 5000, `ping=${ping && ping.ping}`);
+  t('ping min ≤ mean', ping && ping.pingMin <= ping.ping + 0.01);
+  t('jitter present', ping && ping.jitter >= 0);
+  const done = await until(env.messages, 'done', 60000);
+  t('done message sent', !!done);
+  if (done) {
+    t('transfer ok (capped or complete)', done.ok === true && (done.status === 'capped' || done.status === 'complete'), `status=${done.status} err=${done.err}`);
+    t('bytes > 1 MB in window', done.bytes > 1e6, `bytes=${(done.bytes / 1e6).toFixed(1)}MB`);
+    // Cloudflare-fronted nodes ramp per-connection, so the 2 MB baseline probe
+    // does NOT predict the sustained rate — assert line-rate-independent
+    // invariants instead.
+    t('steady absolute sanity (5–10 Gbps)', done.steadyMbps > 5 && done.steadyMbps < 10000, `steady=${done.steadyMbps && done.steadyMbps.toFixed(1)}Mbps`);
+    t('avgFb ≤ steady×1.25 (ramp included)', done.avgFbMbps > 0 && done.avgFbMbps <= done.steadyMbps * 1.25 + 5, `avgFb=${done.avgFbMbps && done.avgFbMbps.toFixed(1)}Mbps`);
+    t('peak ≥ steady (window mean cannot exceed max interval)', done.peakMbps >= done.steadyMbps - 1, `peak=${done.peakMbps && done.peakMbps.toFixed(1)}Mbps`);
+    t('ttfb measured', done.ttfb != null && done.ttfb > 0, `ttfb=${done.ttfb}`);
+    t('firstByteMs measured', done.firstByteMs > 0, `fb=${done.firstByteMs}`);
+    t('peak ≥ p95 ≥ 0', done.peakMbps >= (done.p95Mbps || 0) && done.peakMbps > 0);
+    t('marks for sparkline', Array.isArray(done.marks) && done.marks.length >= 5, `marks=${done.marks.length}`);
+    t('elapsed ≈ 6 s window', done.elapsedMs > WINDOW_S * 1000 - 200 && done.elapsedMs < WINDOW_S * 1000 + 6000, `elapsed=${done.elapsedMs}`);
+  }
+  console.log(`  info: bytes=${done && (done.bytes / 1e6).toFixed(0)}MB steady=${done && done.steadyMbps && done.steadyMbps.toFixed(1)}Mbps avgFb=${done && done.avgFbMbps && done.avgFbMbps.toFixed(1)}Mbps ping=${ping && ping.ping && ping.ping.toFixed(0)}ms ttfb=${done && done.ttfb && done.ttfb.toFixed(0)}ms`);
+}
+
+console.log(`\n== live: Range slice (${(SLICE_BYTES / 1048576).toFixed(0)} MB, capacity-style) ==`);
+{
+  const env = makeWorkerEnv();
+  const p = env.send({ url: LIVE_URL, withPing: false, windowMs: 30000, graceMs: 8000, range: { start: 0, end: SLICE_BYTES - 1 }, maxBytes: SLICE_BYTES });
+  const done = await until(env.messages, 'done', 90000);
+  t('slice done ok', !!done && done.ok === true, `status=${done && done.status} err=${done && done.err}`);
+  t('slice bytes exact (±1 KB)', done && Math.abs(done.bytes - SLICE_BYTES) < 1024, `bytes=${done && done.bytes}`);
+  // A multi-second slice crosses the 800 ms mid-fallback threshold, so we
+  // expect a steady estimate (or, if it finishes very fast, a sane avgFb).
+  const sliceRate = done ? (done.steadyMbps != null ? done.steadyMbps : done.avgFbMbps) : null;
+  t('slice steady/avgFb sane (5–10 Gbps)', sliceRate != null && sliceRate > 5 && sliceRate < 10000,
+    `steady=${done && done.steadyMbps} avgFb=${done && done.avgFbMbps}`);
+}
+
+console.log('\n== live: ping-only mode (no transfer) ==');
+{
+  const env = makeWorkerEnv();
+  const p = env.send({ url: LIVE_URL, withPing: true, pingRounds: 5, windowMs: 0 });
+  const done = await until(env.messages, 'done', 30000);
+  t('ping-only done', !!done && done.status === 'ping-only', `status=${done && done.status}`);
+  t('ping-only has ping', done && done.ping != null && done.ping > 0, `ping=${done && done.ping}`);
+  t('ping-only no bytes', done && done.bytes === 0);
+}
+
+console.log('\n== live: stop message aborts a running transfer ==');
+{
+  const env = makeWorkerEnv();
+  const p = env.send({ url: LIVE_URL, withPing: false, windowMs: 30000, graceMs: 8000 });
+  await until(env.messages, 'progress', 30000);
+  const before = env.messages.length;
+  env.stop();
+  const done = await until(env.messages, 'done', 15000);
+  t('stop → done with aborted status', !!done && (done.status === 'aborted' || done.status === 'timeout'), `status=${done && done.status}`);
+  t('stop → not ok', !!done && done.ok === false);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tools/speedtest/test-engine.mjs
+++ b/tools/speedtest/test-engine.mjs
@@ -7,7 +7,9 @@ import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
 const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
-const script = html.match(/<script>([\s\S]*)<\/script>/i)[1];
+const scriptMatch = html.match(/<script\b[^>]*>([\s\S]*)<\/script>/i);
+if (!scriptMatch) { console.error('FAIL: no <script> block found in index.html'); process.exit(1); }
+const script = scriptMatch[1];
 const sectionA = script.split('/* ================= UI SECTION ================= */')[0];
 
 /* ---------- section A in a sandbox ---------- */

--- a/tools/speedtest/test-engine.mjs
+++ b/tools/speedtest/test-engine.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
 const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
-const scriptMatch = html.match(/<script\b[^>]*>([\s\S]*)<\/script>/i);
+const scriptMatch = html.match(/<script>([\s\S]*)<\/script>/i);
 if (!scriptMatch) { console.error('FAIL: no <script> block found in index.html'); process.exit(1); }
 const script = scriptMatch[1];
 const sectionA = script.split('/* ================= UI SECTION ================= */')[0];

--- a/tools/speedtest/test-engine.mjs
+++ b/tools/speedtest/test-engine.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
 const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
-const script = html.match(/<script>([\s\S]*)<\/script>/)[1];
+const script = html.match(/<script>([\s\S]*)<\/script>/i)[1];
 const sectionA = script.split('/* ================= UI SECTION ================= */')[0];
 
 /* ---------- section A in a sandbox ---------- */


### PR DESCRIPTION
Replaces the speed test engine with v3. Measurement moves entirely into a Web Worker (the UI can no longer distort or cap the read loop), windows are first-byte-anchored on the 1 GB file (slow-start noise eliminated), nodes are measured twice and ranked by **median steady-state**, failed/skipped nodes are never ranked, the endpoint snapshot is probed on load, and the capacity race uses real N-connection Range splits.

Adds the tool's **first test surface**: 27 offline unit tests, a 51-assertion live CDN protocol test that runs the shipped worker verbatim, a syntax gate, and a nightly live CI job.

## Verification — receipts

| Gate | Expected | Got |
|---|---|---|
| `check-syntax.mjs` | "OK: inline script compiles" | ✅ 106,066 chars |
| `test-engine.mjs --unit` | 27 passed, 0 failed | ✅ **27 / 0** |
| `test-engine.mjs` (live CDN) | 51 passed, 0 failed | ✅ **51 / 0** |

The live run transferred 241 MB against a real node: `steady=387.2Mbps avgFb=320.3Mbps ping=115ms ttfb=107ms`.

## Two things I checked beyond the brief

**The snapshot was genuinely stale, and v3 fixes it.** The README claims TorBox renamed two nodes; that checked out. `store-039`→`store-011` (wnam) and `nexus-083`→`nexus-244` (latm) — the old pair is gone from v3's snapshot, the new pair is in. I confirmed against the **live** endpoint list through the deployed worker proxy: `200`, 17 nodes, both new names present. Our shipped v2 snapshot was pointing at two nodes that no longer exist.

**The proxy lane still works untouched.** `cloudflare-worker/` is not modified, per the brief. v3's request shape hits `GET /proxy/v1/api/speedtest`, which is exactly what `HOST_SCOPES` permits — verified live rather than assumed.

## One note rescued from the v2 README

The v3 README drops this, and it survives nowhere else in the tree (`cloudflare-worker/README.md` documents only manual `wrangler deploy`):

> `deploy-worker.yml` reports success even when it **skips** the deploy because the Cloudflare secrets are unset — a green tick does not prove the worker shipped.

That bit me twice this week on #707 and #709, where I had to confirm the "Deploy to Cloudflare Workers" step actually ran. It's worker operations rather than speedtest documentation, so rather than lose it — or touch `cloudflare-worker/`, which the brief puts off-limits — it moves into the CLAUDE.md section this PR already appends.

## Scope

Per the brief: **no version bump**, and no `configurator/`, `cli/`, `packages/core/` or `versions.json` changes — confirmed 0 files touched in those lanes, `versions.json` still `2.98.0`. The configurator build/test/validate suite was deliberately not run; this change touches none of it. The three `reference/` docs are background and are **not** committed.

## Post-merge checklist (from the brief)

1. Endpoint badge should read `live · via worker proxy` — it only says `snapshot …` if the proxy is down
2. Controls show Accurate / Express / Capacity race, reps, window, connections, per-CDN data, scope, MB/s–MiB/s toggle
3. Run Express on desktop (~2 min) and confirm gauge, sparkline, live table and all four exports
4. **Run one test on a Fire Stick or Android TV** — worker isolation on weak devices is the whole point of v3, and I cannot verify that from here
5. Confirm the `speedtest-engine` unit job ran green; the live job is nightly or manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_