### PR TITLE
fix(worker): skip counter class check when STATS binding absent

### DIFF
--- a/cloudflare-worker/smoke.mjs
+++ b/cloudflare-worker/smoke.mjs
@@ -75,10 +75,12 @@ async function main() {
       try { d = JSON.parse(r.text); } catch { d = null; }
       const hasCounters = !!d && Object.keys(d).length > 2;
       check('stats has visits counter', !hasCounters || Number.isFinite(Number(d.visits)), hasCounters ? `visits=${d?.visits}` : 'no STATS binding (staging?)');
-      const required = ['proxy_cache_hits', 'visits_rate_limited', 'visits_write_err', 'proxy_err_timeout', 'proxy_err_network', 'proxy_err_oversize', 'proxy_err_status',
-        'proxy_err_redirect', 'proxy_err_breaker', 'contact_messages', 'counter_write_err', 'rate_limited', 'by_rate_limit'];
-      const missing = d ? required.filter((k) => !(k in d)) : required;
-      check('stats exposes every counter class', missing.length === 0 || !STRICT, missing.length ? `missing: ${missing.join(', ')} (deployed worker older than 2026-09-03?)` : 'all present');
+      if (hasCounters) {
+        const required = ['proxy_cache_hits', 'visits_rate_limited', 'visits_write_err', 'proxy_err_timeout', 'proxy_err_network', 'proxy_err_oversize', 'proxy_err_status',
+          'proxy_err_redirect', 'proxy_err_breaker', 'contact_messages', 'counter_write_err', 'rate_limited', 'by_rate_limit'];
+        const missing = d ? required.filter((k) => !(k in d)) : required;
+        check('stats exposes every counter class', missing.length === 0 || !STRICT, missing.length ? `missing: ${missing.join(', ')} (deployed worker older than 2026-09-03?)` : 'all present');
+      }
       if (d && Number(d.proxy_calls) > 100) {
         const ratio = Number(d.proxy_errors) / Number(d.proxy_calls);
         check('lifetime proxy error ratio < 35%', ratio < 0.35, `${(ratio * 100).toFixed(1)}%`);


### PR DESCRIPTION
## Description

The post-deploy smoke test (`cloudflare-worker/smoke.mjs`) fails with `--strict` on staging environments that lack the STATS KV binding. Test 12 ("stats exposes every counter class") checks for 13 required counter keys, but when the worker has no STATS binding, the stats endpoint returns minimal data — causing a hard failure even though it's a binding configuration issue, not a code problem.

The fix wraps the counter class check inside the existing `hasCounters` guard, so it only validates counter completeness when the STATS binding is actually present. This matches the existing soft-pass behavior of test 11 ("stats has visits counter"), which already handles the no-binding case gracefully.

**Before:** Deploy CORS Proxy Worker #44 fails 24/25 on staging (no STATS KV).
**After:** Counter class check skipped when no STATS binding; production (with binding) still validates all 13 counter classes.

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)
- [x] Workflow / infrastructure

## Template Checklist

N/A — no template JSON modified.

## Testing

- Ran `node cloudflare-worker/smoke.mjs --strict` against production worker → 26/26 pass
- Confirmed counter class check still fires when STATS binding exists
- Confirmed the check is skipped (not soft-failed) when `hasCounters` is false

## Related Issues

Fixes Deploy CORS Proxy Worker #44 smoke failure.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjJY6oPCVWp1mTNgbELjrR)_