### PR TITLE
fix(worker): version the public /api/stats cache key so deploys stop serving the old dump

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -103,7 +103,7 @@ jobs:
           for i in $(seq 1 12); do
             v=$(curl -sf "${{ needs.deploy.outputs.base_url }}/healthz" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).version' 2>/dev/null || true)
             echo "attempt $i: version=$v"
-            [ "$v" = "2026-09-08" ] && exit 0
+            [ "$v" = "2026-09-11" ] && exit 0
             sleep 5
           done
           echo "::warning::healthz never reported the expected version — smoke will run in strict mode and fail if the deploy is stale"

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -65,10 +65,10 @@ internals (which bindings exist, breaker state) are operator data:
 
 ```bash
 curl -s https://<worker>.workers.dev/healthz
-# {"ok":true,"version":"2026-09-08"}
+# {"ok":true,"version":"2026-09-11"}
 
 curl -s https://<worker>.workers.dev/healthz -H "Authorization: Bearer $ADMIN_TOKEN"
-# {"ok":true,"version":"2026-09-08","bindings":{"STATS":true,"TEMPLATES":true,
+# {"ok":true,"version":"2026-09-11","bindings":{"STATS":true,"TEMPLATES":true,
 #  "PASTES":true,"RATELIMIT":false,"RL_PROXY":true,"DISCORD_WEBHOOK_URL":true,
 #  "ADMIN_TOKEN":true},"ready":true,"breakers_open":0}
 ```

--- a/cloudflare-worker/smoke.mjs
+++ b/cloudflare-worker/smoke.mjs
@@ -41,10 +41,10 @@ async function get(url) {
 
 const enc = (s) => encodeURIComponent(s);
 
-// --strict: fail (not warn) when the deployed worker predates 2026-09-08
+// --strict: fail (not warn) when the deployed worker predates 2026-09-11
 // (used by the deploy workflow's post-deploy gate).
 const STRICT = args.includes('--strict');
-const EXPECTED_VERSION = '2026-09-08';
+const EXPECTED_VERSION = '2026-09-11';
 
 async function main() {
   console.log(`Core Builds worker smoke — ${BASE}\n`);
@@ -76,7 +76,18 @@ async function main() {
     if (r.status === 200) {
       let d;
       try { d = JSON.parse(r.text); } catch { d = null; }
-      const pubKeys = d ? Object.keys(d).sort().join(',') : '';
+      let pubKeys = d ? Object.keys(d).sort().join(',') : '';
+      // Deploy #46 failed here: colo Cache API still held the pre-hardening
+      // 27-key dump for up to 60s. The worker now versions that cache key;
+      // retry briefly so a leftover edge entry cannot fail --strict.
+      if (STRICT && pubKeys && pubKeys !== 'generates,visits') {
+        for (let i = 0; i < 6 && pubKeys !== 'generates,visits'; i++) {
+          await new Promise((ok) => setTimeout(ok, 2000));
+          const retry = await get(`${BASE}/api/stats`);
+          try { d = JSON.parse(retry.text); } catch { d = null; }
+          pubKeys = d ? Object.keys(d).sort().join(',') : '';
+        }
+      }
       check('public stats exposes only visits + generates', !STRICT || (d && pubKeys === 'generates,visits'), `keys=${pubKeys || '(no STATS binding?)'}`);
       check('visits counter is numeric', !!d && Number.isFinite(Number(d.visits)), `visits=${d?.visits}`);
     }

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -18,7 +18,7 @@
 // lane, probe cache, CORS narrowing), 2026-09-03 (INFRA-AUDIT.md: redirect refusal,
 // layered rate limiting, DO paste store, circuit breaker, observability fixes).
 
-const WORKER_VERSION = '2026-09-08';
+const WORKER_VERSION = '2026-09-11';
 
 // ── Hardening constants ─────────────────────────────────────────────────────
 const PROXY_MAX_SIZE = 2 * 1024 * 1024;     // 2 MB proxy request body cap (configs are a few KB)
@@ -482,6 +482,26 @@ function cleanDimension(v) {
 const STATS_DAILY_WINDOW_DAYS = 120;
 const STATS_CACHE_TTL = 60;
 
+// Public /api/stats Cache API key. Incoming `?bust=` is ignored (the key is
+// constructed, not taken from the request URL) so clients cannot force a
+// rebuild. The version query is INTERNAL to the cache key — it is never on
+// the public URL. Deploy #46 failed 23/24 because the 2026-09-08 hardening
+// still read caches.default at `/api/stats`, which held the pre-hardening
+// 27-key dump for the remaining 60 s TTL. Versioning the key makes a payload
+// shape change a cache miss instead of a leak.
+function publicStatsCacheKey(origin) {
+  return new URL(`/api/stats?v=${WORKER_VERSION}`, origin);
+}
+
+function isPublicStatsBody(text) {
+  try {
+    const d = JSON.parse(text);
+    const keys = Object.keys(d);
+    return keys.length === 2 && 'visits' in d && 'generates' in d
+      && Number.isFinite(Number(d.visits)) && Number.isFinite(Number(d.generates));
+  } catch { return false; }
+}
+
 // ── Structured, secret-free logging (INFRA-AUDIT O6) ────────────────────────
 // The ONLY console sink in this worker. Fields are a fixed, reviewed set: event
 // name, error class, hostname label, HTTP status. Never a URL, path, body, IP,
@@ -729,14 +749,15 @@ export default {
         // The public surface is exactly what the configurator splash renders:
         // { visits, generates }. No totals beyond those, no breakdowns, no
         // per-host data, no daily series, no error counters — operator data
-        // lives behind ADMIN_TOKEN only. Served from the colo Cache API (60 s,
-        // keyed on the path only so ?cache-busting cannot force a rebuild).
+        // lives behind ADMIN_TOKEN only. Served from the colo Cache API (60 s).
+        // Cache key is versioned (see publicStatsCacheKey); a hit whose body
+        // is not the public shape is treated as a miss and rebuilt.
         if (!env.STATS) return respond(200, { visits: 0, generates: 0 });
-        const statsKey = new URL('/api/stats', url.origin);
+        const statsKey = publicStatsCacheKey(url.origin);
         const cached = await statusProbeCacheGet(statsKey);
         if (cached) {
           const body = await cached.text().catch(() => null);
-          if (body !== null) {
+          if (body !== null && isPublicStatsBody(body)) {
             return new Response(body, { status: 200, headers: { 'Content-Type': 'application/json', ...SECURE_DOC_HEADERS, ...cors, 'Cache-Control': `public, max-age=${STATS_CACHE_TTL}` } });
           }
         }
@@ -748,7 +769,7 @@ export default {
       }
       // Operator view (Authorization: Bearer ADMIN_TOKEN). Full counters and
       // breakdowns. NEVER cached (no-store, no Cache API) — the public cache
-      // key is the path, and a cached full dump must never leak to a plain
+      // key is versioned, and a cached full dump must never leak to a plain
       // public request.
       if (!env.STATS) return respond(200, {});
       // Every counter the worker writes must appear here or it is write-only.

--- a/cloudflare-worker/worker.test.js
+++ b/cloudflare-worker/worker.test.js
@@ -1139,7 +1139,7 @@ test('O5: /healthz public shows only ok+version; operator view shows bindings; n
   assert.ok(!('bindings' in notReadyBody), '503 body stays minimal on the public surface');
 });
 
-test('R5: public /api/stats is cached on the path key; the operator view is never cached', async () => {
+test('R5: public /api/stats is cached on a versioned path key; the operator view is never cached', async () => {
   let kvLists = 0; let kvGets = 0; let putKey = null;
   const env = withAdmin({ STATS: { get: async () => { kvGets++; return '1'; }, list: async () => { kvLists++; return { keys: [], list_complete: true }; } } });
   let stored = null;
@@ -1147,7 +1147,7 @@ test('R5: public /api/stats is cached on the path key; the operator view is neve
   try {
     await worker.fetch(new Request('https://w.example/api/stats?bust=1'), env, ctxSync);
     await settle();
-    assert.equal(putKey, 'https://w.example/api/stats', 'public stats cached on the path key only');
+    assert.equal(putKey, `https://w.example/api/stats?v=${WORKER_VERSION}`, 'public stats cached on a versioned path key; query busting is ignored');
     assert.equal(kvLists, 0, 'the public build never enumerates KV prefixes');
     kvGets = 0;
     await worker.fetch(new Request('https://w.example/api/stats?bust=2'), env, ctxSync);
@@ -1159,6 +1159,52 @@ test('R5: public /api/stats is cached on the path key; the operator view is neve
     assert.equal(adminRes.headers.get('cache-control'), 'no-store');
     assert.equal(putKey, null, 'operator stats must never be written to the shared public cache');
     assert.equal(kvLists, 7, 'operator build enumerates all seven breakdown prefixes');
+  } finally { delete globalThis.caches; }
+});
+
+test('R5b: a stale unversioned /api/stats cache hit (pre-hardening dump) is ignored', async () => {
+  // Deploy #46: caches.default still held the 27-key public dump at /api/stats
+  // after the 2026-09-08 hardening shipped. Serving it leaked by_host and
+  // failed smoke --strict. The versioned key must miss, and the unversioned
+  // entry must not be returned.
+  const store = { visits: '7', generates: '3', proxy_calls: '9000' };
+  const env = { STATS: { get: async (k) => store[k] ?? null, list: async () => ({ keys: [], list_complete: true }) } };
+  const stale = new Response(JSON.stringify({
+    visits: 1, generates: 2, by_host: { 'aio.deuspi.xyz': 9 }, version: '2026-09-03',
+  }), { headers: { 'Content-Type': 'application/json' } });
+  let putKey = null;
+  globalThis.caches = {
+    default: {
+      match: async (req) => {
+        const u = new URL(req.url);
+        if (u.pathname === '/api/stats' && u.search === '') return stale.clone();
+        return undefined;
+      },
+      put: async (req) => { putKey = req.url; },
+    },
+  };
+  try {
+    const res = await worker.fetch(new Request('https://w.example/api/stats'), env, ctxSync);
+    assert.deepEqual(await res.json(), { visits: 7, generates: 3 }, 'stale full dump must not be served');
+    assert.equal(putKey, `https://w.example/api/stats?v=${WORKER_VERSION}`);
+  } finally { delete globalThis.caches; }
+});
+
+test('R5c: a wrong-shape body at the versioned stats cache key is rebuilt', async () => {
+  const store = { visits: '7', generates: '3' };
+  const env = { STATS: { get: async (k) => store[k] ?? null, list: async () => ({ keys: [], list_complete: true }) } };
+  const poisoned = new Response(JSON.stringify({ visits: 1, generates: 2, by_host: { custom: 1 } }), { headers: { 'Content-Type': 'application/json' } });
+  let rebuilt = false;
+  globalThis.caches = {
+    default: {
+      match: async (req) => (req.url.includes(`v=${WORKER_VERSION}`) ? poisoned.clone() : undefined),
+      put: async () => { rebuilt = true; },
+    },
+  };
+  try {
+    const res = await worker.fetch(new Request('https://w.example/api/stats'), env, ctxSync);
+    assert.deepEqual(await res.json(), { visits: 7, generates: 3 }, 'poisoned cache entry must not leak extra keys');
+    assert.equal(rebuilt, true, 'wrong-shape hit is treated as a miss and rewritten');
   } finally { delete globalThis.caches; }
 });
 


### PR DESCRIPTION
## Description

Fixes Deploy CORS Proxy Worker [#46](https://github.com/brevityA/Core-Builds/actions/runs/34588975009) (23/24). Tests and Wrangler deploy succeeded; `/healthz` flipped to `2026-09-08` immediately (`no-store`). Smoke `--strict` then hit `caches.default` at the **unversioned** `/api/stats` key and got the pre-hardening 27-key dump (`by_host`, `daily`, `version`, …) still in the 60s TTL.

The worker was never down — production is already on the #740 payload (`{visits, generates}`). The next payload-shape change would fail the same way without this.

- Public stats Cache API key is now `/api/stats?v=$WORKER_VERSION` (internal; incoming `?bust=` still ignored)
- A cache hit whose body is not exactly `{visits, generates}` is treated as a miss and rebuilt
- Smoke retries the public-stats shape briefly so a leftover edge entry cannot fail `--strict`
- Deploy wait-loop expects `2026-09-11`
- R5b/R5c cover the leftover-dump and poisoned-key cases

`WORKER_VERSION` bumped to `2026-09-11` so this deploy is distinguishable from #740.

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)
- [x] Workflow / infrastructure

## Template Checklist

N/A — no template JSON is added or modified.

## Testing

- `node --test cloudflare-worker/worker.test.js` → **83/83 pass** (81 previous + R5b leftover unversioned dump + R5c poisoned versioned key)

## Related Issues

Fixes the red run on Deploy CORS Proxy Worker #46 after #740.
