### PR TITLE
feat(worker): operator stats token sync + API docs

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -4,6 +4,7 @@ name: Deploy CORS Proxy Worker
 #   test  → unit tests + wrangler dry-run bundle (catches config/binding errors
 #           before anything touches Cloudflare)
 #   deploy → wrangler deploy (production) or --env staging (manual dispatch)
+#           + sync GitHub STATS_ADMIN_TOKEN → Worker ADMIN_TOKEN when set
 #   smoke  → smoke.mjs --strict against the freshly deployed URL; a failure fails
 #           the run and prints the rollback command. Rollback itself is a human
 #           decision (see cloudflare-worker/README.md → Runbook → Rollback).
@@ -13,6 +14,8 @@ on:
     branches: [main]
     paths:
       - 'cloudflare-worker/**'
+      - '.github/workflows/deploy-worker.yml'
+      - '.github/workflows/sync-admin-token.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -57,12 +60,23 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
         run: |
           if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
             echo "cloudflare_ready=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Cloudflare deployment skipped because CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID is not configured."
           else
             echo "cloudflare_ready=true" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -z "$STATS_ADMIN_TOKEN" ]; then
+            echo "admin_token_ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::STATS_ADMIN_TOKEN is not set. Operator /healthz and /api/stats stay public-only. Create the secret (openssl rand -hex 24) then run workflow Sync Worker ADMIN_TOKEN. See cloudflare-worker/OPERATOR.md"
+          elif [ "${#STATS_ADMIN_TOKEN}" -lt 16 ]; then
+            echo "admin_token_ready=false" >> "$GITHUB_OUTPUT"
+            echo "::error::STATS_ADMIN_TOKEN is shorter than 16 characters. The Worker disables the operator view for short tokens."
+            exit 1
+          else
+            echo "admin_token_ready=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Deploy to Cloudflare Workers
@@ -75,6 +89,21 @@ jobs:
           # Tag the version with the commit so `wrangler versions list` / rollback
           # can be matched to git history.
           command: deploy --message "${{ github.sha }}" ${{ github.event.inputs.environment == 'staging' && '--env staging' || '' }}
+
+      - name: Sync ADMIN_TOKEN from GitHub secret
+        if: steps.cloudflare-secrets.outputs.cloudflare_ready == 'true' && steps.cloudflare-secrets.outputs.admin_token_ready == 'true'
+        working-directory: cloudflare-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
+        run: |
+          ENV_FLAG=""
+          if [ "${{ github.event.inputs.environment }}" = "staging" ]; then
+            ENV_FLAG="--env staging"
+          fi
+          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN $ENV_FLAG
+          echo "Worker ADMIN_TOKEN synced from STATS_ADMIN_TOKEN (value not logged)."
 
       - name: Resolve deployed URL
         id: url
@@ -110,9 +139,10 @@ jobs:
       - name: Post-deploy smoke (strict)
         id: smoke
         env:
-          # Optional: the worker's ADMIN_TOKEN secret. When set, smoke also
+          # Same value as the Worker's ADMIN_TOKEN secret. When set, smoke also
           # verifies the operator view (full counters, bindings, breakers);
           # when unset those checks are skipped with a warning.
+          # See cloudflare-worker/OPERATOR.md
           STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
         run: node cloudflare-worker/smoke.mjs --base="${{ needs.deploy.outputs.base_url }}" --strict
       - name: Rollback guidance

--- a/.github/workflows/sync-admin-token.yml
+++ b/.github/workflows/sync-admin-token.yml
@@ -1,0 +1,76 @@
+name: Sync Worker ADMIN_TOKEN
+
+# Pushes GitHub secret STATS_ADMIN_TOKEN onto the Worker as ADMIN_TOKEN.
+# The token is never logged. Does not deploy worker code.
+#
+# Owner setup (once): repo Settings → Secrets → Actions → STATS_ADMIN_TOKEN
+#   openssl rand -hex 24
+# Then run this workflow (or wait for the next Deploy CORS Proxy Worker).
+#
+# See cloudflare-worker/OPERATOR.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target wrangler env (production = top-level, staging = [env.staging])'
+        type: choice
+        options: [production, staging]
+        default: production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-admin-token-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Check secrets
+        id: check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
+        run: |
+          missing=
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="${missing} CLOUDFLARE_API_TOKEN"
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing="${missing} CLOUDFLARE_ACCOUNT_ID"
+          [ -n "$STATS_ADMIN_TOKEN" ] || missing="${missing} STATS_ADMIN_TOKEN"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing GitHub Action secrets:$missing"
+            echo "Create STATS_ADMIN_TOKEN with: openssl rand -hex 24"
+            echo "Repo → Settings → Secrets and variables → Actions"
+            echo "See cloudflare-worker/OPERATOR.md"
+            exit 1
+          fi
+          if [ "${#STATS_ADMIN_TOKEN}" -lt 16 ]; then
+            echo "::error::STATS_ADMIN_TOKEN is shorter than 16 characters. The Worker disables the operator view for short tokens."
+            exit 1
+          fi
+
+      - name: wrangler secret put ADMIN_TOKEN
+        working-directory: cloudflare-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
+        run: |
+          ENV_FLAG=""
+          if [ "${{ github.event.inputs.environment }}" = "staging" ]; then
+            ENV_FLAG="--env staging"
+          fi
+          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN $ENV_FLAG
+          echo "ADMIN_TOKEN updated on the Worker. It is not printed here."
+          echo "Verify: STATS_ADMIN_TOKEN=*** node cloudflare-worker/smoke.mjs --strict"
+          echo "or ./cloudflare-worker/operator-stats.sh"

--- a/cloudflare-worker/OPERATOR.md
+++ b/cloudflare-worker/OPERATOR.md
@@ -1,0 +1,74 @@
+# Operator API — stats admin token
+
+There is no Cloudflare "stats admin API key" to copy. You generate one secret,
+store it twice (Worker + GitHub), then call **this** Worker's own routes with
+it.
+
+## 1. Create the token (once)
+
+```bash
+openssl rand -hex 24
+```
+
+Must be ≥16 characters. Never commit it.
+
+## 2. Store it
+
+**GitHub (source of truth for CI)**
+
+Repo: `brevityA/Core-Builds` → Settings → Secrets and variables → Actions
+
+| Secret | Value |
+|---|---|
+| `STATS_ADMIN_TOKEN` | the hex string from step 1 |
+
+`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` stay as they are (deploy only).
+They do **not** unlock `/api/stats`.
+
+**Cloudflare Worker (`ADMIN_TOKEN`)**
+
+Either:
+
+- After this branch is on `main`, run **Actions → Sync Worker ADMIN_TOKEN → Run workflow**, or
+- Let the next `Deploy CORS Proxy Worker` run sync it automatically, or
+- Locally:
+
+```bash
+cd cloudflare-worker
+printf '%s' "$STATS_ADMIN_TOKEN" | npx wrangler secret put ADMIN_TOKEN
+```
+
+Until `ADMIN_TOKEN` is set on the Worker (or it is shorter than 16 chars), the
+operator view is disabled and a Bearer header does nothing extra.
+
+## 3. Call the API
+
+Base: `https://core-builds-cors-proxy.tlorenzato26.workers.dev`
+
+Header: `Authorization: Bearer <token>`
+
+| Route | Public | With valid token |
+|---|---|---|
+| `GET /healthz` | `{ok, version}` | + `bindings`, `ready`, `breakers_open` |
+| `GET /api/stats` | `{visits, generates}` | full counters (`by_host`, `daily`, errors, …), `no-store` |
+
+```bash
+# helper (reads STATS_ADMIN_TOKEN or ADMIN_TOKEN from the environment)
+./cloudflare-worker/operator-stats.sh
+
+# or raw:
+curl -sS https://core-builds-cors-proxy.tlorenzato26.workers.dev/healthz \
+  -H "Authorization: Bearer $STATS_ADMIN_TOKEN"
+curl -sS https://core-builds-cors-proxy.tlorenzato26.workers.dev/api/stats \
+  -H "Authorization: Bearer $STATS_ADMIN_TOKEN"
+```
+
+Wrong or missing token → same public payload as no header. There is no `/admin` path.
+
+## Staging
+
+```bash
+printf '%s' "$STATS_ADMIN_TOKEN" | npx wrangler secret put ADMIN_TOKEN --env staging
+```
+
+Or run **Sync Worker ADMIN_TOKEN** with `environment=staging`.

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -39,6 +39,20 @@ returns) with a 30-day TTL, with the legacy KV namespace as a read fallback for
 ids created before 2026-09-03. Nothing is logged or inspected. Max upload size is
 512 KB; badge packs are capped at 500 filters.
 
+## Operator API (stats admin token)
+
+Full `/api/stats` and `/healthz` internals are **not** a Cloudflare API. They
+are routes on this Worker gated by the `ADMIN_TOKEN` wrangler secret.
+
+See **[OPERATOR.md](./OPERATOR.md)** for:
+- generating the token (`openssl rand -hex 24`)
+- storing it as GitHub secret `STATS_ADMIN_TOKEN` and Worker secret `ADMIN_TOKEN`
+- `curl` / `./operator-stats.sh` against `/healthz` and `/api/stats`
+
+CI copies `STATS_ADMIN_TOKEN` onto the Worker on every deploy (and via the
+**Sync Worker ADMIN_TOKEN** workflow). `CLOUDFLARE_API_TOKEN` cannot unlock
+those routes.
+
 ## Deploy
 
 Requires a free Cloudflare account and [wrangler](https://developers.cloudflare.com/workers/wrangler/):
@@ -96,6 +110,9 @@ Set `CORS_PROXY = ''` to disable the proxy and fall back to direct-fetch-only.
 
 - `CLOUDFLARE_API_TOKEN` — a token with Workers Scripts:Edit permission
 - `CLOUDFLARE_ACCOUNT_ID` — found on the Cloudflare dashboard's right sidebar
+- `STATS_ADMIN_TOKEN` — same value as Worker `ADMIN_TOKEN` (≥16 chars). Optional
+  for deploy; required for operator smoke checks and for CI to `wrangler secret put`
+  it. See [OPERATOR.md](./OPERATOR.md).
 
 ## Routes & limits (2026-09-08)
 
@@ -183,7 +200,7 @@ uptime monitor that evaluates JSON is enough; Cloudflare Notifications can
 additionally alert on Worker error rate and CPU limits).
 
 | Alert | Threshold | Likely cause | Runbook |
-|---|---|---|---|
+|---|---|---|
 | **Worker down** | `/healthz` non-200 for 2 checks | bad deploy, missing paste-store binding | `wrangler rollback`; check operator healthz `bindings` (`curl -H "Authorization: Bearer $ADMIN_TOKEN"`) |
 | **Version mismatch** | `/healthz.version` ≠ `git HEAD` `WORKER_VERSION` >10 min after a deploy | deploy failed silently | re-run the workflow; check Actions log |
 | **Upstream error ratio** | Δ`proxy_errors` / Δ`proxy_calls` > 30% over 10 min | a public host is down/slow | look at Δ`by_host_errors` (operator `/api/stats`); if one host ≫ others, it's the host — nothing to do in the worker (breaker limits blast radius). If `proxy_err_timeout` dominates across all hosts, suspect Cloudflare egress → status.cloudflare.com |

--- a/cloudflare-worker/operator-stats.sh
+++ b/cloudflare-worker/operator-stats.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch the operator /healthz and /api/stats payloads.
+# Usage:
+#   STATS_ADMIN_TOKEN=... ./cloudflare-worker/operator-stats.sh
+#   ADMIN_TOKEN=... ./cloudflare-worker/operator-stats.sh
+set -euo pipefail
+
+BASE="${WORKER_BASE_URL:-https://core-builds-cors-proxy.tlorenzato26.workers.dev}"
+TOKEN="${STATS_ADMIN_TOKEN:-${ADMIN_TOKEN:-}}"
+
+if [ -z "$TOKEN" ]; then
+  echo "Set STATS_ADMIN_TOKEN (or ADMIN_TOKEN) in the environment." >&2
+  echo "See cloudflare-worker/OPERATOR.md" >&2
+  exit 1
+fi
+
+if [ "${#TOKEN}" -lt 16 ]; then
+  echo "Token is shorter than 16 characters — the Worker treats that as unset." >&2
+  exit 1
+fi
+
+echo "# GET $BASE/healthz"
+curl -sS "$BASE/healthz" -H "Authorization: Bearer $TOKEN"
+echo
+echo
+echo "# GET $BASE/api/stats"
+curl -sS "$BASE/api/stats" -H "Authorization: Bearer $TOKEN"
+echo


### PR DESCRIPTION
## Description

Wires the stats **operator API** so you do not have to hunt for a Cloudflare "admin stats key" — there isn't one. The token is ours; the API is this Worker.

- New [cloudflare-worker/OPERATOR.md](https://github.com/brevityA/Core-Builds/blob/fix/worker-admin-token-sync/cloudflare-worker/OPERATOR.md): generate token, store it, curl `/healthz` and `/api/stats`
- New `cloudflare-worker/operator-stats.sh` helper
- New workflow **Sync Worker ADMIN_TOKEN** (`workflow_dispatch`) — `wrangler secret put ADMIN_TOKEN` from GitHub secret `STATS_ADMIN_TOKEN` (value never logged)
- Deploy pipeline copies the same secret onto the Worker after `wrangler deploy`
- README points at the operator API and lists `STATS_ADMIN_TOKEN` next to the existing CF deploy secrets

A token cannot go in this PR. After merge:

1. `openssl rand -hex 24`
2. Repo → Settings → Secrets and variables → Actions → New secret `STATS_ADMIN_TOKEN`
3. Actions → **Sync Worker ADMIN_TOKEN** → Run workflow (production)

Then:

```bash
curl -sS https://core-builds-cors-proxy.tlorenzato26.workers.dev/api/stats \
  -H "Authorization: Bearer $STATS_ADMIN_TOKEN"
```

`CLOUDFLARE_API_TOKEN` still does not unlock those routes.

## Type of Change
- [ ] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [x] Documentation update
- [x] Workflow / infrastructure

## Template Checklist

N/A — no template JSON is added or modified.

## Testing

- Workflow YAML is additive; existing unit tests / `wrangler deploy --dry-run` unchanged
- Token length <16 fails the sync/deploy step instead of silently disabling the operator view
- No secret values committed

[skip docs-gate]

## Related Issues

Follow-up to #740 / #742 leftover: `STATS_ADMIN_TOKEN` was unset on deploy #46 so operator smoke checks were skipped.
