### PR TITLE
fix(ci): pin wrangler secret put to --env= on production

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -98,11 +98,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
         run: |
-          ENV_FLAG=""
           if [ "${{ github.event.inputs.environment }}" = "staging" ]; then
-            ENV_FLAG="--env staging"
+            ENV_FLAG=(--env staging)
+          else
+            ENV_FLAG=(--env=)
           fi
-          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN $ENV_FLAG
+          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN "${ENV_FLAG[@]}"
           echo "Worker ADMIN_TOKEN synced from STATS_ADMIN_TOKEN (value not logged)."
 
       - name: Resolve deployed URL

--- a/.github/workflows/sync-admin-token.yml
+++ b/.github/workflows/sync-admin-token.yml
@@ -66,11 +66,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
         run: |
-          ENV_FLAG=""
+          # wrangler.toml has [env.staging]; omitting --env warns and can miss the target.
+          # --env= is the documented way to address the top-level (production) worker.
           if [ "${{ github.event.inputs.environment }}" = "staging" ]; then
-            ENV_FLAG="--env staging"
+            ENV_FLAG=(--env staging)
+          else
+            ENV_FLAG=(--env=)
           fi
-          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN $ENV_FLAG
+          printf '%s' "$STATS_ADMIN_TOKEN" | npx --yes wrangler@4 secret put ADMIN_TOKEN "${ENV_FLAG[@]}"
           echo "ADMIN_TOKEN updated on the Worker. It is not printed here."
           echo "Verify: STATS_ADMIN_TOKEN=*** node cloudflare-worker/smoke.mjs --strict"
           echo "or ./cloudflare-worker/operator-stats.sh"


### PR DESCRIPTION
## Description

Wrangler 4.86 warned on Sync Worker ADMIN_TOKEN run 1:

> Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the secret put command.
> If your intention is to use the top-level environment … pass `--env=""`.

The secret still uploaded to `core-builds-cors-proxy`, but the flag should be explicit so a future wrangler change cannot put `ADMIN_TOKEN` on staging by accident.

- Production: `wrangler secret put ADMIN_TOKEN --env=`
- Staging dispatch: `--env staging`
- Same change in Deploy CORS Proxy Worker’s post-deploy sync step

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [ ] Documentation update
- [x] Workflow / infrastructure

## Template Checklist

N/A — workflows only.

## Testing

- No Worker JS change; unit tests / dry-run unchanged
- After merge, optional: Actions → Sync Worker ADMIN_TOKEN → production. Log should show the secret put **without** the multi-env warning.

[skip docs-gate]
