### PR TITLE
fix(worker): skip operator counter-class smoke when STATS KV is unbound

### DIFF
--- a/cloudflare-worker/smoke.mjs
+++ b/cloudflare-worker/smoke.mjs
@@ -104,10 +104,17 @@ async function main() {
       const sr = await fetch(`${BASE}/api/stats`, { ...auth, signal: AbortSignal.timeout(TIMEOUT_MS) });
       const d = await sr.json().catch(() => null);
       check('operator stats → 200', sr.status === 200, `http ${sr.status}`);
+      // Staging (and any env without STATS KV) cannot invent counter classes.
+      // Deploy #49 failed 28/29 here after a staging dispatch. Same skip as #741.
+      const hasStatsKv = !!h?.bindings?.STATS;
       const required = ['proxy_cache_hits', 'visits_rate_limited', 'visits_write_err', 'proxy_err_timeout', 'proxy_err_network', 'proxy_err_oversize', 'proxy_err_status',
         'proxy_err_redirect', 'proxy_err_breaker', 'contact_messages', 'counter_write_err', 'rate_limited', 'by_rate_limit'];
-      const missing = d ? required.filter((k) => !(k in d)) : required;
-      check('operator stats exposes every counter class', missing.length === 0, missing.length ? `missing: ${missing.join(', ')}` : 'all present');
+      if (!hasStatsKv) {
+        check('operator stats exposes every counter class', true, 'skipped: STATS KV not bound');
+      } else {
+        const missing = d ? required.filter((k) => !(k in d)) : required;
+        check('operator stats exposes every counter class', missing.length === 0, missing.length ? `missing: ${missing.join(', ')}` : 'all present');
+      }
       if (d && Number(d.proxy_calls) > 100) {
         const ratio = Number(d.proxy_errors) / Number(d.proxy_calls);
         check('lifetime proxy error ratio < 35%', ratio < 0.35, `${(ratio * 100).toFixed(1)}%`);


### PR DESCRIPTION
## Description

Deploy [#49](https://github.com/brevityA/Core-Builds/actions/runs/34602009724) went 28/29 because **Run workflow** defaults to **staging**. Staging has `ADMIN_TOKEN` and PASTES, but `bindings.STATS=false`. Smoke then required `proxy_cache_hits`, `visits_rate_limited`, … which only exist on the production STATS KV.

Same skip as #741, for the operator path:

- `bindings.STATS === false` → PASS `skipped: STATS KV not bound`
- production (`STATS: true`) still requires every counter class (#50 already 30/30)

Production was never broken. Do not roll it back.

## Type of Change
- [x] Bug fix (template error, broken ESE/PSE, wrong setting)
- [ ] Template improvement (optimisation, new feature)
- [ ] New template
- [ ] Documentation update
- [x] Workflow / infrastructure

## Template Checklist

N/A — smoke only.

## Testing

- Production path unchanged when STATS is bound
- After merge, a staging dispatch should no longer fail that one check

[skip docs-gate]
